### PR TITLE
Add --yes option to some profile and node commands and ensure warewulfd is reloaded

### DIFF
--- a/internal/app/wwctl/node/delete/main.go
+++ b/internal/app/wwctl/node/delete/main.go
@@ -31,19 +31,22 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if count > 0 {
-		q := fmt.Sprintf("Are you sure you want to delete %d nodes(s)", count)
-
-		prompt := promptui.Prompt{
-			Label:     q,
-			IsConfirm: true,
-		}
-
-		result, _ := prompt.Run()
-
-		if result == "y" || result == "yes" {
+		if SetYes == true {
 			nodeDB.Persist()
-		}
+		} else {
+			q := fmt.Sprintf("Are you sure you want to delete %d nodes(s)", count)
 
+			prompt := promptui.Prompt{
+				Label:     q,
+				IsConfirm: true,
+			}
+
+			result, _ := prompt.Run()
+
+			if result == "y" || result == "yes" {
+				nodeDB.Persist()
+			}
+		}
 	} else {
 		fmt.Printf("No nodes found\n")
 	}

--- a/internal/app/wwctl/node/delete/root.go
+++ b/internal/app/wwctl/node/delete/root.go
@@ -11,6 +11,7 @@ var (
 		RunE:    CobraRunE,
 		Aliases: []string{"rm", "del"},
 	}
+	SetYes            bool
 	SetForce      string
 	SetGroup      string
 	SetController string
@@ -20,6 +21,7 @@ func init() {
 	baseCmd.PersistentFlags().StringVarP(&SetForce, "force", "f", "", "Force node delete")
 	baseCmd.PersistentFlags().StringVarP(&SetGroup, "group", "g", "default", "Set group to delete nodes from")
 	baseCmd.PersistentFlags().StringVarP(&SetController, "controller", "c", "default", "Controller to add nodes to")
+	baseCmd.PersistentFlags().BoolVarP(&SetYes, "yes", "y", false, "Set 'yes' to all questions asked")
 
 }
 

--- a/internal/app/wwctl/node/set/main.go
+++ b/internal/app/wwctl/node/set/main.go
@@ -296,6 +296,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	if len(nodes) > 0 {
 		if SetYes == true {
 			nodeDB.Persist()
+			warewulfd.DaemonReload()
 		} else {
 			q := fmt.Sprintf("Are you sure you want to modify %d nodes(s)", len(nodes))
 

--- a/internal/app/wwctl/profile/delete/main.go
+++ b/internal/app/wwctl/profile/delete/main.go
@@ -48,19 +48,22 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if count > 0 {
-		q := fmt.Sprintf("Are you sure you want to delete %d profile(s) (%d groups, %d nodes)", count, numGroups, numNodes)
-
-		prompt := promptui.Prompt{
-			Label:     q,
-			IsConfirm: true,
-		}
-
-		result, _ := prompt.Run()
-
-		if result == "y" || result == "yes" {
+		if SetYes == true {
 			nodeDB.Persist()
-		}
+		} else {
+			q := fmt.Sprintf("Are you sure you want to delete %d profile(s) (%d groups, %d nodes)", count, numGroups, numNodes)
 
+			prompt := promptui.Prompt{
+				Label:     q,
+				IsConfirm: true,
+			}
+
+			result, _ := prompt.Run()
+
+			if result == "y" || result == "yes" {
+				nodeDB.Persist()
+			}
+		}
 	} else {
 		wwlog.Printf(wwlog.INFO, "No groups found\n")
 	}

--- a/internal/app/wwctl/profile/delete/root.go
+++ b/internal/app/wwctl/profile/delete/root.go
@@ -10,7 +10,12 @@ var (
 		RunE:  CobraRunE,
 		Args:  cobra.MinimumNArgs(1),
 	}
+	SetYes            bool
 )
+
+func init() {
+baseCmd.PersistentFlags().BoolVarP(&SetYes, "yes", "y", false, "Set 'yes' to all questions asked")
+}
 
 // GetRootCommand returns the root cobra.Command for the application.
 func GetCommand() *cobra.Command {

--- a/internal/app/wwctl/profile/set/main.go
+++ b/internal/app/wwctl/profile/set/main.go
@@ -257,20 +257,23 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(profiles) > 0 {
-		q := fmt.Sprintf("Are you sure you want to modify %d profile(s)", len(profiles))
-
-		prompt := promptui.Prompt{
-			Label:     q,
-			IsConfirm: true,
-		}
-
-		result, _ := prompt.Run()
-
-		if result == "y" || result == "yes" {
+		if SetYes == true {
 			nodeDB.Persist()
-			warewulfd.DaemonReload()
-		}
+		} else {
+			q := fmt.Sprintf("Are you sure you want to modify %d profile(s)", len(profiles))
 
+			prompt := promptui.Prompt{
+				Label:     q,
+				IsConfirm: true,
+			}
+
+			result, _ := prompt.Run()
+
+			if result == "y" || result == "yes" {
+				nodeDB.Persist()
+				warewulfd.DaemonReload()
+			}
+		}
 	} else {
 		fmt.Printf("No profiles found\n")
 	}

--- a/internal/app/wwctl/profile/set/main.go
+++ b/internal/app/wwctl/profile/set/main.go
@@ -259,6 +259,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	if len(profiles) > 0 {
 		if SetYes == true {
 			nodeDB.Persist()
+			warewulfd.DaemonReload()
 		} else {
 			q := fmt.Sprintf("Are you sure you want to modify %d profile(s)", len(profiles))
 

--- a/internal/app/wwctl/profile/set/root.go
+++ b/internal/app/wwctl/profile/set/root.go
@@ -11,6 +11,7 @@ var (
 		RunE:  CobraRunE,
 	}
 	SetAll            bool
+	SetYes            bool
 	SetForce          bool
 	SetComment        string
 	SetContainer      string
@@ -64,6 +65,7 @@ func init() {
 
 	baseCmd.PersistentFlags().BoolVarP(&SetAll, "all", "a", false, "Set all profiles")
 	baseCmd.PersistentFlags().BoolVarP(&SetForce, "force", "f", false, "Force configuration (even on error)")
+	baseCmd.PersistentFlags().BoolVarP(&SetYes, "yes", "y", false, "Set 'yes' to all questions asked")
 }
 
 // GetRootCommand returns the root cobra.Command for the application.


### PR DESCRIPTION
Adds `if SetYes == true` logic to `wwctl profile set...`, `wwctl profile delete...` and `wwctl node delete...` commands and ensures `warewulfd` is reloaded after `wwctl {node,profile} set...` commands to resolve issues reported in #56.

There are other `wwctl` commands which call `nodeDB.Persist()` and do not include `warewulfd.DaemonReload()`. Not sure if those should also be modified so I didn't touch them.