### PR TITLE
GroupName --> ClusterName

### DIFF
--- a/internal/app/wwctl/overlay/edit/main.go
+++ b/internal/app/wwctl/overlay/edit/main.go
@@ -66,7 +66,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(w, "# of macros and logic which can be used within this file:\n")
 		fmt.Fprintf(w, "#\n")
 		fmt.Fprintf(w, "# Node FQDN = {{.Id}}\n")
-		fmt.Fprintf(w, "# Node Group = {{.GroupName}}\n")
+		fmt.Fprintf(w, "# Node Cluster = {{.ClusterName}}\n")
 		fmt.Fprintf(w, "# Network Config = {{.NetDevs.eth0.Ipaddr}}, {{.NetDevs.eth0.Hwaddr}}, etc.\n")
 		fmt.Fprintf(w, "#\n")
 		fmt.Fprintf(w, "# Goto the documentation pages for more information: http://www.hpcng.org/...\n")

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -21,7 +21,7 @@ import (
 type TemplateStruct struct {
 	Id           string
 	Hostname     string
-	GroupName    string
+	ClusterName    string
 	Container    string
 	Init         string
 	Root         string
@@ -139,6 +139,7 @@ func buildOverlay(nodeList []node.NodeInfo, overlayType string) error {
 
 		t.Id = n.Id.Get()
 		t.Hostname = n.Id.Get()
+		t.ClusterName = n.ClusterName.Get()
 		t.Container = n.ContainerName.Get()
 		t.Init = n.Init.Get()
 		t.Root = n.Root.Get()


### PR DESCRIPTION
changed `GroupName` to `ClusterName`.
Now `wwctl node set -c <clustername>` can be used on overlays. 