### PR TITLE
custom Parameters

### DIFF
--- a/internal/app/wwctl/node/list/main.go
+++ b/internal/app/wwctl/node/list/main.go
@@ -58,6 +58,10 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 				fmt.Printf("%-20s %-18s %-12s %s\n", node.Id.Get(), name+":TYPE", netdev.Type.Source(), netdev.Type.Print())
 				fmt.Printf("%-20s %-18s %-12s %t\n", node.Id.Get(), name+":DEFAULT", netdev.Default.Source(), netdev.Default.PrintB())
 			}
+
+			for name, param := range node.Params {
+				fmt.Printf("%-20s %-18s %-12s %s\n", node.Id.Get(), name+":VALUE", param.Value.Source(), param.Value.Print())
+			}
 		}
 
 	} else if ShowNet {

--- a/internal/app/wwctl/node/list/main.go
+++ b/internal/app/wwctl/node/list/main.go
@@ -59,8 +59,8 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 				fmt.Printf("%-20s %-18s %-12s %t\n", node.Id.Get(), name+":DEFAULT", netdev.Default.Source(), netdev.Default.PrintB())
 			}
 
-			for name, key := range node.Keys {
-				fmt.Printf("%-20s %-18s %-12s %s\n", node.Id.Get(), name, key.Source(), key.Print())
+			for keyname, key := range node.Keys {
+				fmt.Printf("%-20s %-18s %-12s %s\n", node.Id.Get(), "Keys."+keyname, key.Source(), key.Print())
 			}
 		}
 

--- a/internal/app/wwctl/node/list/main.go
+++ b/internal/app/wwctl/node/list/main.go
@@ -59,8 +59,8 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 				fmt.Printf("%-20s %-18s %-12s %t\n", node.Id.Get(), name+":DEFAULT", netdev.Default.Source(), netdev.Default.PrintB())
 			}
 
-			for name, param := range node.Params {
-				fmt.Printf("%-20s %-18s %-12s %s\n", node.Id.Get(), name, param.Source(), param.Print())
+			for name, key := range node.Keys {
+				fmt.Printf("%-20s %-18s %-12s %s\n", node.Id.Get(), name, key.Source(), key.Print())
 			}
 		}
 

--- a/internal/app/wwctl/node/list/main.go
+++ b/internal/app/wwctl/node/list/main.go
@@ -60,7 +60,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 			}
 
 			for name, param := range node.Params {
-				fmt.Printf("%-20s %-18s %-12s %s\n", node.Id.Get(), name+":VALUE", param.Value.Source(), param.Value.Print())
+				fmt.Printf("%-20s %-18s %-12s %s\n", node.Id.Get(), name, param.Source(), param.Print())
 			}
 		}
 

--- a/internal/app/wwctl/node/set/main.go
+++ b/internal/app/wwctl/node/set/main.go
@@ -332,11 +332,27 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 			}
 
 			if _, ok := n.Params[SetParam]; !ok {
-				var nd node.ParamEntry
+				wwlog.Printf(wwlog.VERBOSE, "Node: %s:%s, Setting Value %s\n", n.Id.Get(), SetParam, SetValue)
+				var nd node.Entry
 				n.Params[SetParam] = &nd
 			}
 			wwlog.Printf(wwlog.VERBOSE, "Node: %s:%s, Setting Value %s\n", n.Id.Get(), SetParam, SetValue)
-			n.Params[SetParam].Value.Set(SetValue)
+			n.Params[SetParam].Set(SetValue)
+		}
+
+		if SetParamDel == true {
+			if SetParam == "" {
+				wwlog.Printf(wwlog.ERROR, "You must include the '--param' option\n")
+				os.Exit(1)
+			}
+
+			if _, ok := n.Params[SetParam]; !ok {
+				wwlog.Printf(wwlog.ERROR, "Custom parameter doesn't exist: %s\n", SetParam)
+				os.Exit(1)
+			}
+
+			wwlog.Printf(wwlog.VERBOSE, "Node: %s, Deleting custom parameter: %s\n", n.Id.Get(), SetNetDev)
+			delete(n.Params, SetParam)
 		}
 
 		err := nodeDB.NodeUpdate(n)

--- a/internal/app/wwctl/node/set/main.go
+++ b/internal/app/wwctl/node/set/main.go
@@ -325,6 +325,20 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 			n.NetDevs[SetNetDev].Default.SetB(true)
 		}
 
+		if SetValue != "" {
+			if SetParam == "" {
+				wwlog.Printf(wwlog.ERROR, "You must include the '--param' option\n")
+				os.Exit(1)
+			}
+
+			if _, ok := n.Params[SetParam]; !ok {
+				var nd node.ParamEntry
+				n.Params[SetParam] = &nd
+			}
+			wwlog.Printf(wwlog.VERBOSE, "Node: %s:%s, Setting Value %s\n", n.Id.Get(), SetParam, SetValue)
+			n.Params[SetParam].Value.Set(SetValue)
+		}
+
 		err := nodeDB.NodeUpdate(n)
 		if err != nil {
 			wwlog.Printf(wwlog.ERROR, "%s\n", err)

--- a/internal/app/wwctl/node/set/main.go
+++ b/internal/app/wwctl/node/set/main.go
@@ -326,33 +326,32 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		}
 
 		if SetValue != "" {
-			if SetParam == "" {
-				wwlog.Printf(wwlog.ERROR, "You must include the '--param' option\n")
+			if SetKey == "" {
+				wwlog.Printf(wwlog.ERROR, "You must include the '--key/-k' option\n")
 				os.Exit(1)
 			}
 
-			if _, ok := n.Params[SetParam]; !ok {
-				wwlog.Printf(wwlog.VERBOSE, "Node: %s:%s, Setting Value %s\n", n.Id.Get(), SetParam, SetValue)
+			if _, ok := n.Keys[SetKey]; !ok {
 				var nd node.Entry
-				n.Params[SetParam] = &nd
+				n.Keys[SetKey] = &nd
 			}
-			wwlog.Printf(wwlog.VERBOSE, "Node: %s:%s, Setting Value %s\n", n.Id.Get(), SetParam, SetValue)
-			n.Params[SetParam].Set(SetValue)
+			wwlog.Printf(wwlog.VERBOSE, "Node: %s:%s, Setting Value %s\n", n.Id.Get(), SetKey, SetValue)
+			n.Keys[SetKey].Set(SetValue)
 		}
 
-		if SetParamDel == true {
-			if SetParam == "" {
-				wwlog.Printf(wwlog.ERROR, "You must include the '--param' option\n")
+		if SetKeyDel == true {
+			if SetKey == "" {
+				wwlog.Printf(wwlog.ERROR, "You must include the '--key/-k' option\n")
 				os.Exit(1)
 			}
 
-			if _, ok := n.Params[SetParam]; !ok {
-				wwlog.Printf(wwlog.ERROR, "Custom parameter doesn't exist: %s\n", SetParam)
+			if _, ok := n.Keys[SetKey]; !ok {
+				wwlog.Printf(wwlog.ERROR, "Custom parameter doesn't exist: %s\n", SetKey)
 				os.Exit(1)
 			}
 
 			wwlog.Printf(wwlog.VERBOSE, "Node: %s, Deleting custom parameter: %s\n", n.Id.Get(), SetNetDev)
-			delete(n.Params, SetParam)
+			delete(n.Keys, SetKey)
 		}
 
 		err := nodeDB.NodeUpdate(n)

--- a/internal/app/wwctl/node/set/root.go
+++ b/internal/app/wwctl/node/set/root.go
@@ -41,9 +41,9 @@ var (
 	SetDiscoverable   bool
 	SetUndiscoverable bool
 	SetRoot           string
-	SetParam          string
+	SetKey            string
 	SetValue          string
-	SetParamDel       bool
+	SetKeyDel         bool
 )
 
 func init() {
@@ -77,9 +77,10 @@ func init() {
 	baseCmd.PersistentFlags().BoolVar(&SetNetDevDel, "netdel", false, "Delete the node's network device")
 	baseCmd.PersistentFlags().BoolVar(&SetNetDevDefault, "netdefault", false, "Set this network to be default")
 
-	baseCmd.PersistentFlags().StringVarP(&SetParam, "param", "p", "", "Define custom parameter")
-	baseCmd.PersistentFlags().StringVarP(&SetValue, "value", "", "", "Set custom parameter value")
-	baseCmd.PersistentFlags().BoolVar(&SetParamDel, "paramdel", false, "Delete custom parameter")
+	baseCmd.PersistentFlags().StringVarP(&SetKey, "key", "k", "", "Define custom key")
+	baseCmd.PersistentFlags().BoolVar(&SetKeyDel, "keydel", false, "Delete custom key")
+
+	baseCmd.PersistentFlags().StringVarP(&SetValue, "value", "", "", "Set value")
 
 	baseCmd.PersistentFlags().BoolVarP(&SetNodeAll, "all", "a", false, "Set all nodes")
 

--- a/internal/app/wwctl/node/set/root.go
+++ b/internal/app/wwctl/node/set/root.go
@@ -41,6 +41,8 @@ var (
 	SetDiscoverable   bool
 	SetUndiscoverable bool
 	SetRoot           string
+	SetParam          string
+	SetValue          string
 )
 
 func init() {
@@ -73,6 +75,9 @@ func init() {
 	baseCmd.PersistentFlags().StringVarP(&SetType, "type", "T", "", "Set the node's network device type")
 	baseCmd.PersistentFlags().BoolVar(&SetNetDevDel, "netdel", false, "Delete the node's network device")
 	baseCmd.PersistentFlags().BoolVar(&SetNetDevDefault, "netdefault", false, "Set this network to be default")
+
+	baseCmd.PersistentFlags().StringVarP(&SetParam, "param", "p", "", "Define custom parameter")
+	baseCmd.PersistentFlags().StringVarP(&SetValue, "value", "", "", "Set custom parameter value")
 
 	baseCmd.PersistentFlags().BoolVarP(&SetNodeAll, "all", "a", false, "Set all nodes")
 

--- a/internal/app/wwctl/node/set/root.go
+++ b/internal/app/wwctl/node/set/root.go
@@ -43,6 +43,7 @@ var (
 	SetRoot           string
 	SetParam          string
 	SetValue          string
+	SetParamDel       bool
 )
 
 func init() {
@@ -78,6 +79,7 @@ func init() {
 
 	baseCmd.PersistentFlags().StringVarP(&SetParam, "param", "p", "", "Define custom parameter")
 	baseCmd.PersistentFlags().StringVarP(&SetValue, "value", "", "", "Set custom parameter value")
+	baseCmd.PersistentFlags().BoolVar(&SetParamDel, "paramdel", false, "Delete custom parameter")
 
 	baseCmd.PersistentFlags().BoolVarP(&SetNodeAll, "all", "a", false, "Set all nodes")
 

--- a/internal/app/wwctl/profile/list/main.go
+++ b/internal/app/wwctl/profile/list/main.go
@@ -55,8 +55,8 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 				fmt.Printf("%-20s %-18s %t\n", profile.Id.Get(), name+":DEFAULT", netdev.Default.PrintB())
 			}
 
-			for name, key := range profile.Keys {
-				fmt.Printf("%-20s %-18s %s\n", profile.Id.Get(), name, key.Print())
+			for keyname, key := range profile.Keys {
+				fmt.Printf("%-20s %-18s %s\n", profile.Id.Get(), "Keys."+keyname, key.Print())
 			}
 		}
 	} else {

--- a/internal/app/wwctl/profile/list/main.go
+++ b/internal/app/wwctl/profile/list/main.go
@@ -54,6 +54,10 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 				fmt.Printf("%-20s %-18s %s\n", profile.Id.Get(), name+":TYPE", netdev.Hwaddr.Print())
 				fmt.Printf("%-20s %-18s %t\n", profile.Id.Get(), name+":DEFAULT", netdev.Default.PrintB())
 			}
+
+			for name, param := range profile.Params {
+				fmt.Printf("%-20s %-18s %s\n", profile.Id.Get(), name, param.Print())
+			}
 		}
 	} else {
 		fmt.Printf("%-20s %s\n", "PROFILE NAME", "COMMENT/DESCRIPTION")

--- a/internal/app/wwctl/profile/list/main.go
+++ b/internal/app/wwctl/profile/list/main.go
@@ -55,8 +55,8 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 				fmt.Printf("%-20s %-18s %t\n", profile.Id.Get(), name+":DEFAULT", netdev.Default.PrintB())
 			}
 
-			for name, param := range profile.Params {
-				fmt.Printf("%-20s %-18s %s\n", profile.Id.Get(), name, param.Print())
+			for name, key := range profile.Keys {
+				fmt.Printf("%-20s %-18s %s\n", profile.Id.Get(), name, key.Print())
 			}
 		}
 	} else {

--- a/internal/app/wwctl/profile/set/main.go
+++ b/internal/app/wwctl/profile/set/main.go
@@ -242,32 +242,32 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		}
 
 		if SetValue != "" {
-			if SetParam == "" {
-				wwlog.Printf(wwlog.ERROR, "You must include the '--param' option\n")
+			if SetKey == "" {
+				wwlog.Printf(wwlog.ERROR, "You must include the '--key/-k' option\n")
 				os.Exit(1)
 			}
 
-			if _, ok := p.Params[SetParam]; !ok {
+			if _, ok := p.Keys[SetKey]; !ok {
 				var nd node.Entry
-				p.Params[SetParam] = &nd
+				p.Keys[SetKey] = &nd
 			}
-			wwlog.Printf(wwlog.VERBOSE, "Profile: %s:%s, Setting Value %s\n", p.Id.Get(), SetParam, SetValue)
-			p.Params[SetParam].Set(SetValue)
+			wwlog.Printf(wwlog.VERBOSE, "Profile: %s:%s, Setting Value %s\n", p.Id.Get(), SetKey, SetValue)
+			p.Keys[SetKey].Set(SetValue)
 		}
 
-		if SetParamDel == true {
-			if SetParam == "" {
-				wwlog.Printf(wwlog.ERROR, "You must include the '--param' option\n")
+		if SetKeyDel == true {
+			if SetKey == "" {
+				wwlog.Printf(wwlog.ERROR, "You must include the '--key/-k' option\n")
 				os.Exit(1)
 			}
 
-			if _, ok := p.Params[SetParam]; !ok {
-				wwlog.Printf(wwlog.ERROR, "Custom parameter doesn't exist: %s\n", SetParam)
+			if _, ok := p.Keys[SetKey]; !ok {
+				wwlog.Printf(wwlog.ERROR, "Custom key doesn't exist: %s\n", SetKey)
 				os.Exit(1)
 			}
 
-			wwlog.Printf(wwlog.VERBOSE, "Profile: %s, Deleting custom parameter: %s\n", p.Id.Get(), SetNetDev)
-			delete(p.Params, SetParam)
+			wwlog.Printf(wwlog.VERBOSE, "Profile: %s, Deleting custom key: %s\n", p.Id.Get(), SetNetDev)
+			delete(p.Keys, SetKey)
 		}
 
 		err := nodeDB.ProfileUpdate(p)

--- a/internal/app/wwctl/profile/set/main.go
+++ b/internal/app/wwctl/profile/set/main.go
@@ -233,12 +233,41 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 				p.NetDevs[SetNetDev] = &nd
 			}
 
-			wwlog.Printf(wwlog.VERBOSE, "Node: %s:%s, Setting device as default\n", p.Id.Get(), SetNetDev)
+			wwlog.Printf(wwlog.VERBOSE, "Profile: %s:%s, Setting device as default\n", p.Id.Get(), SetNetDev)
 			for _, dev := range p.NetDevs {
 				// First clear all other devices that might be configured as default
 				dev.Default.SetB(false)
 			}
 			p.NetDevs[SetNetDev].Default.SetB(true)
+		}
+
+		if SetValue != "" {
+			if SetParam == "" {
+				wwlog.Printf(wwlog.ERROR, "You must include the '--param' option\n")
+				os.Exit(1)
+			}
+
+			if _, ok := p.Params[SetParam]; !ok {
+				var nd node.Entry
+				p.Params[SetParam] = &nd
+			}
+			wwlog.Printf(wwlog.VERBOSE, "Profile: %s:%s, Setting Value %s\n", p.Id.Get(), SetParam, SetValue)
+			p.Params[SetParam].Set(SetValue)
+		}
+
+		if SetParamDel == true {
+			if SetParam == "" {
+				wwlog.Printf(wwlog.ERROR, "You must include the '--param' option\n")
+				os.Exit(1)
+			}
+
+			if _, ok := p.Params[SetParam]; !ok {
+				wwlog.Printf(wwlog.ERROR, "Custom parameter doesn't exist: %s\n", SetParam)
+				os.Exit(1)
+			}
+
+			wwlog.Printf(wwlog.VERBOSE, "Profile: %s, Deleting custom parameter: %s\n", p.Id.Get(), SetNetDev)
+			delete(p.Params, SetParam)
 		}
 
 		err := nodeDB.ProfileUpdate(p)

--- a/internal/app/wwctl/profile/set/root.go
+++ b/internal/app/wwctl/profile/set/root.go
@@ -35,6 +35,9 @@ var (
 	SetNetDevDefault  bool
 	SetInit           string
 	SetRoot           string
+	SetParam          string
+	SetValue          string
+	SetParamDel       bool
 )
 
 func init() {
@@ -62,6 +65,10 @@ func init() {
 	baseCmd.PersistentFlags().StringVarP(&SetType, "type", "T", "", "Set the node's network device type")
 	baseCmd.PersistentFlags().BoolVar(&SetNetDevDel, "netdel", false, "Delete the node's network device")
 	baseCmd.PersistentFlags().BoolVar(&SetNetDevDefault, "netdefault", false, "Set this network to be default")
+
+	baseCmd.PersistentFlags().StringVarP(&SetParam, "param", "p", "", "Define custom parameter")
+	baseCmd.PersistentFlags().StringVarP(&SetValue, "value", "", "", "Set custom parameter value")
+	baseCmd.PersistentFlags().BoolVar(&SetParamDel, "paramdel", false, "Delete custom parameter")
 
 	baseCmd.PersistentFlags().BoolVarP(&SetAll, "all", "a", false, "Set all profiles")
 	baseCmd.PersistentFlags().BoolVarP(&SetForce, "force", "f", false, "Force configuration (even on error)")

--- a/internal/app/wwctl/profile/set/root.go
+++ b/internal/app/wwctl/profile/set/root.go
@@ -35,9 +35,9 @@ var (
 	SetNetDevDefault  bool
 	SetInit           string
 	SetRoot           string
-	SetParam          string
+	SetKey            string
 	SetValue          string
-	SetParamDel       bool
+	SetKeyDel         bool
 )
 
 func init() {
@@ -66,9 +66,10 @@ func init() {
 	baseCmd.PersistentFlags().BoolVar(&SetNetDevDel, "netdel", false, "Delete the node's network device")
 	baseCmd.PersistentFlags().BoolVar(&SetNetDevDefault, "netdefault", false, "Set this network to be default")
 
-	baseCmd.PersistentFlags().StringVarP(&SetParam, "param", "p", "", "Define custom parameter")
-	baseCmd.PersistentFlags().StringVarP(&SetValue, "value", "", "", "Set custom parameter value")
-	baseCmd.PersistentFlags().BoolVar(&SetParamDel, "paramdel", false, "Delete custom parameter")
+	baseCmd.PersistentFlags().StringVarP(&SetKey, "key", "k", "", "Define custom key")
+	baseCmd.PersistentFlags().BoolVar(&SetKeyDel, "keydel", false, "Delete custom key")
+
+	baseCmd.PersistentFlags().StringVarP(&SetValue, "value", "", "", "Set value")
 
 	baseCmd.PersistentFlags().BoolVarP(&SetAll, "all", "a", false, "Set all profiles")
 	baseCmd.PersistentFlags().BoolVarP(&SetForce, "force", "f", false, "Force configuration (even on error)")

--- a/internal/pkg/node/constructors.go
+++ b/internal/pkg/node/constructors.go
@@ -43,7 +43,7 @@ func (config *nodeYaml) FindAllNodes() ([]NodeInfo, error) {
 
 		wwlog.Printf(wwlog.DEBUG, "In node loop: %s\n", nodename)
 		n.NetDevs = make(map[string]*NetDevEntry)
-		n.Params = make(map[string]*Entry)
+		n.Keys = make(map[string]*Entry)
 		n.SystemOverlay.SetDefault("default")
 		n.RuntimeOverlay.SetDefault("default")
 		n.Ipxe.SetDefault("default")
@@ -95,12 +95,12 @@ func (config *nodeYaml) FindAllNodes() ([]NodeInfo, error) {
 			n.NetDevs[devname].Default.SetB(netdev.Default)
 		}
 
-		for paramname, param := range node.Params {
-			if _, ok := n.Params[paramname]; !ok {
-				var param Entry
-				n.Params[paramname] = &param
+		for keyname, key := range node.Keys {
+			if _, ok := n.Keys[keyname]; !ok {
+				var key Entry
+				n.Keys[keyname] = &key
 			}
-			n.Params[paramname].Set(param)
+			n.Keys[keyname].Set(key)
 		}
 
 		for _, p := range n.Profiles {
@@ -144,12 +144,12 @@ func (config *nodeYaml) FindAllNodes() ([]NodeInfo, error) {
 				n.NetDevs[devname].Default.SetAltB(netdev.Default, p)
 			}
 
-			for paramname, param := range config.NodeProfiles[p].Params {
-				if _, ok := n.Params[paramname]; !ok {
-					var param Entry
-					n.Params[paramname] = &param
+			for keyname, key := range config.NodeProfiles[p].Keys {
+				if _, ok := n.Keys[keyname]; !ok {
+					var key Entry
+					n.Keys[keyname] = &key
 				}
-				n.Params[paramname].SetAlt(param, p)
+				n.Keys[keyname].SetAlt(key, p)
 			}
 		}
 
@@ -177,7 +177,7 @@ func (config *nodeYaml) FindAllProfiles() ([]NodeInfo, error) {
 	for name, profile := range config.NodeProfiles {
 		var p NodeInfo
 		p.NetDevs = make(map[string]*NetDevEntry)
-		p.Params = make(map[string]*Entry)
+		p.Keys = make(map[string]*Entry)
 
 		p.Id.Set(name)
 		p.Comment.Set(profile.Comment)
@@ -212,12 +212,12 @@ func (config *nodeYaml) FindAllProfiles() ([]NodeInfo, error) {
 			p.NetDevs[devname].Default.SetB(netdev.Default)
 		}
 
-		for paramname, param := range profile.Params {
-			if _, ok := p.Params[paramname]; !ok {
-				var param Entry
-				p.Params[paramname] = &param
+		for keyname, key := range profile.Keys {
+			if _, ok := p.Keys[keyname]; !ok {
+				var key Entry
+				p.Keys[keyname] = &key
 			}
-			p.Params[paramname].Set(param)
+			p.Keys[keyname].Set(key)
 		}
 
 		// TODO: Validate or die on all inputs

--- a/internal/pkg/node/constructors.go
+++ b/internal/pkg/node/constructors.go
@@ -43,6 +43,7 @@ func (config *nodeYaml) FindAllNodes() ([]NodeInfo, error) {
 
 		wwlog.Printf(wwlog.DEBUG, "In node loop: %s\n", nodename)
 		n.NetDevs = make(map[string]*NetDevEntry)
+		n.Params = make(map[string]*ParamEntry)
 		n.SystemOverlay.SetDefault("default")
 		n.RuntimeOverlay.SetDefault("default")
 		n.Ipxe.SetDefault("default")
@@ -92,6 +93,14 @@ func (config *nodeYaml) FindAllNodes() ([]NodeInfo, error) {
 			n.NetDevs[devname].Gateway.Set(netdev.Gateway)
 			n.NetDevs[devname].Type.Set(netdev.Type)
 			n.NetDevs[devname].Default.SetB(netdev.Default)
+		}
+
+		for paramname, param := range node.Params {
+			if _, ok := n.Params[paramname]; !ok {
+				var param ParamEntry
+				n.Params[paramname] = &param
+			}
+			n.Params[paramname].Value.Set(param.Value)
 		}
 
 		for _, p := range n.Profiles {

--- a/internal/pkg/node/constructors.go
+++ b/internal/pkg/node/constructors.go
@@ -43,7 +43,7 @@ func (config *nodeYaml) FindAllNodes() ([]NodeInfo, error) {
 
 		wwlog.Printf(wwlog.DEBUG, "In node loop: %s\n", nodename)
 		n.NetDevs = make(map[string]*NetDevEntry)
-		n.Params = make(map[string]*ParamEntry)
+		n.Params = make(map[string]*Entry)
 		n.SystemOverlay.SetDefault("default")
 		n.RuntimeOverlay.SetDefault("default")
 		n.Ipxe.SetDefault("default")
@@ -97,10 +97,10 @@ func (config *nodeYaml) FindAllNodes() ([]NodeInfo, error) {
 
 		for paramname, param := range node.Params {
 			if _, ok := n.Params[paramname]; !ok {
-				var param ParamEntry
+				var param Entry
 				n.Params[paramname] = &param
 			}
-			n.Params[paramname].Value.Set(param.Value)
+			n.Params[paramname].Set(param)
 		}
 
 		for _, p := range n.Profiles {
@@ -143,6 +143,14 @@ func (config *nodeYaml) FindAllNodes() ([]NodeInfo, error) {
 				n.NetDevs[devname].Type.SetAlt(netdev.Type, p)
 				n.NetDevs[devname].Default.SetAltB(netdev.Default, p)
 			}
+
+			for paramname, param := range config.NodeProfiles[p].Params {
+				if _, ok := n.Params[paramname]; !ok {
+					var param Entry
+					n.Params[paramname] = &param
+				}
+				n.Params[paramname].SetAlt(param, p)
+			}
 		}
 
 		ret = append(ret, n)
@@ -169,6 +177,7 @@ func (config *nodeYaml) FindAllProfiles() ([]NodeInfo, error) {
 	for name, profile := range config.NodeProfiles {
 		var p NodeInfo
 		p.NetDevs = make(map[string]*NetDevEntry)
+		p.Params = make(map[string]*Entry)
 
 		p.Id.Set(name)
 		p.Comment.Set(profile.Comment)
@@ -201,6 +210,14 @@ func (config *nodeYaml) FindAllProfiles() ([]NodeInfo, error) {
 			p.NetDevs[devname].Gateway.Set(netdev.Gateway)
 			p.NetDevs[devname].Type.Set(netdev.Type)
 			p.NetDevs[devname].Default.SetB(netdev.Default)
+		}
+
+		for paramname, param := range profile.Params {
+			if _, ok := p.Params[paramname]; !ok {
+				var param Entry
+				p.Params[paramname] = &param
+			}
+			p.Params[paramname].Set(param)
 		}
 
 		// TODO: Validate or die on all inputs

--- a/internal/pkg/node/datastructure.go
+++ b/internal/pkg/node/datastructure.go
@@ -36,7 +36,7 @@ type NodeConf struct {
 	Discoverable   bool                `yaml:"discoverable,omitempty"`
 	Profiles       []string            `yaml:"profiles,omitempty"`
 	NetDevs        map[string]*NetDevs `yaml:"network devices,omitempty"`
-	Params         map[string]string   `yaml:"parameters,omitempty"`
+	Keys           map[string]string   `yaml:"keys,omitempty"`
 }
 
 type NetDevs struct {
@@ -83,7 +83,7 @@ type NodeInfo struct {
 	Profiles       []string
 	GroupProfiles  []string
 	NetDevs        map[string]*NetDevEntry
-	Params         map[string]*Entry
+	Keys           map[string]*Entry
 }
 
 type NetDevEntry struct {

--- a/internal/pkg/node/datastructure.go
+++ b/internal/pkg/node/datastructure.go
@@ -36,6 +36,7 @@ type NodeConf struct {
 	Discoverable   bool                `yaml:"discoverable,omitempty"`
 	Profiles       []string            `yaml:"profiles,omitempty"`
 	NetDevs        map[string]*NetDevs `yaml:"network devices,omitempty"`
+	Params         map[string]*Params   `yaml:"parameters,omitempty"`
 }
 
 type NetDevs struct {
@@ -45,6 +46,10 @@ type NetDevs struct {
 	Ipaddr  string
 	Netmask string
 	Gateway string `yaml:"gateway,omitempty"`
+}
+
+type Params struct {
+	Value   string `yaml:"value,omitempty"`
 }
 
 /******
@@ -82,6 +87,7 @@ type NodeInfo struct {
 	Profiles       []string
 	GroupProfiles  []string
 	NetDevs        map[string]*NetDevEntry
+	Params         map[string]*ParamEntry
 }
 
 type NetDevEntry struct {
@@ -91,6 +97,10 @@ type NetDevEntry struct {
 	Ipaddr  Entry
 	Netmask Entry
 	Gateway Entry `yaml:"gateway,omitempty"`
+}
+
+type ParamEntry struct {
+	Value   Entry `yaml:"value,omitempty"`
 }
 
 func init() {

--- a/internal/pkg/node/datastructure.go
+++ b/internal/pkg/node/datastructure.go
@@ -36,7 +36,7 @@ type NodeConf struct {
 	Discoverable   bool                `yaml:"discoverable,omitempty"`
 	Profiles       []string            `yaml:"profiles,omitempty"`
 	NetDevs        map[string]*NetDevs `yaml:"network devices,omitempty"`
-	Params         map[string]*Params   `yaml:"parameters,omitempty"`
+	Params         map[string]string   `yaml:"parameters,omitempty"`
 }
 
 type NetDevs struct {
@@ -46,10 +46,6 @@ type NetDevs struct {
 	Ipaddr  string
 	Netmask string
 	Gateway string `yaml:"gateway,omitempty"`
-}
-
-type Params struct {
-	Value   string `yaml:"value,omitempty"`
 }
 
 /******
@@ -87,7 +83,7 @@ type NodeInfo struct {
 	Profiles       []string
 	GroupProfiles  []string
 	NetDevs        map[string]*NetDevEntry
-	Params         map[string]*ParamEntry
+	Params         map[string]*Entry
 }
 
 type NetDevEntry struct {
@@ -97,10 +93,6 @@ type NetDevEntry struct {
 	Ipaddr  Entry
 	Netmask Entry
 	Gateway Entry `yaml:"gateway,omitempty"`
-}
-
-type ParamEntry struct {
-	Value   Entry `yaml:"value,omitempty"`
 }
 
 func init() {

--- a/internal/pkg/node/modifiers.go
+++ b/internal/pkg/node/modifiers.go
@@ -27,7 +27,6 @@ func (config *nodeYaml) AddNode(nodeID string) (NodeInfo, error) {
 	config.Nodes[nodeID] = &node
 	config.Nodes[nodeID].Profiles = []string{"default"}
 	config.Nodes[nodeID].NetDevs = make(map[string]*NetDevs)
-	// config.Nodes[nodeID].Params = make(map[string]*Params)
 
 	n.Id.Set(nodeID)
 	n.Profiles = []string{"default"}
@@ -76,7 +75,7 @@ func (config *nodeYaml) NodeUpdate(node NodeInfo) error {
 	config.Nodes[nodeID].Profiles = node.Profiles
 	config.Nodes[nodeID].NetDevs = make(map[string]*NetDevs)
 
-	config.Nodes[nodeID].Params = make(map[string]*Params)
+	config.Nodes[nodeID].Params = make(map[string]string)
 
 	for devname, netdev := range node.NetDevs {
 		var newdev NetDevs
@@ -91,9 +90,7 @@ func (config *nodeYaml) NodeUpdate(node NodeInfo) error {
 	}
 
 	for paramname, param := range node.Params {
-		var newparam Params
-		config.Nodes[nodeID].Params[paramname] = &newparam
-		config.Nodes[nodeID].Params[paramname].Value = param.Value.GetReal()
+		config.Nodes[nodeID].Params[paramname] = param.GetReal()
 	}
 
 	return nil
@@ -160,6 +157,8 @@ func (config *nodeYaml) ProfileUpdate(profile NodeInfo) error {
 
 	config.NodeProfiles[profileID].Profiles = profile.Profiles
 	config.NodeProfiles[profileID].NetDevs = make(map[string]*NetDevs)
+	
+	config.NodeProfiles[profileID].Params = make(map[string]string)
 
 	for devname, netdev := range profile.NetDevs {
 		var newdev NetDevs
@@ -171,6 +170,10 @@ func (config *nodeYaml) ProfileUpdate(profile NodeInfo) error {
 		config.NodeProfiles[profileID].NetDevs[devname].Gateway = netdev.Gateway.GetReal()
 		config.NodeProfiles[profileID].NetDevs[devname].Type = netdev.Type.GetReal()
 		config.NodeProfiles[profileID].NetDevs[devname].Default = netdev.Default.GetRealB()
+	}
+
+	for paramname, param := range profile.Params {
+		config.NodeProfiles[profileID].Params[paramname] = param.GetReal()
 	}
 
 	return nil

--- a/internal/pkg/node/modifiers.go
+++ b/internal/pkg/node/modifiers.go
@@ -27,6 +27,7 @@ func (config *nodeYaml) AddNode(nodeID string) (NodeInfo, error) {
 	config.Nodes[nodeID] = &node
 	config.Nodes[nodeID].Profiles = []string{"default"}
 	config.Nodes[nodeID].NetDevs = make(map[string]*NetDevs)
+	// config.Nodes[nodeID].Params = make(map[string]*Params)
 
 	n.Id.Set(nodeID)
 	n.Profiles = []string{"default"}
@@ -75,6 +76,8 @@ func (config *nodeYaml) NodeUpdate(node NodeInfo) error {
 	config.Nodes[nodeID].Profiles = node.Profiles
 	config.Nodes[nodeID].NetDevs = make(map[string]*NetDevs)
 
+	config.Nodes[nodeID].Params = make(map[string]*Params)
+
 	for devname, netdev := range node.NetDevs {
 		var newdev NetDevs
 		config.Nodes[nodeID].NetDevs[devname] = &newdev
@@ -85,6 +88,12 @@ func (config *nodeYaml) NodeUpdate(node NodeInfo) error {
 		config.Nodes[nodeID].NetDevs[devname].Gateway = netdev.Gateway.GetReal()
 		config.Nodes[nodeID].NetDevs[devname].Type = netdev.Type.GetReal()
 		config.Nodes[nodeID].NetDevs[devname].Default = netdev.Default.GetRealB()
+	}
+
+	for paramname, param := range node.Params {
+		var newparam Params
+		config.Nodes[nodeID].Params[paramname] = &newparam
+		config.Nodes[nodeID].Params[paramname].Value = param.Value.GetReal()
 	}
 
 	return nil

--- a/internal/pkg/node/modifiers.go
+++ b/internal/pkg/node/modifiers.go
@@ -75,7 +75,7 @@ func (config *nodeYaml) NodeUpdate(node NodeInfo) error {
 	config.Nodes[nodeID].Profiles = node.Profiles
 	config.Nodes[nodeID].NetDevs = make(map[string]*NetDevs)
 
-	config.Nodes[nodeID].Params = make(map[string]string)
+	config.Nodes[nodeID].Keys = make(map[string]string)
 
 	for devname, netdev := range node.NetDevs {
 		var newdev NetDevs
@@ -89,8 +89,8 @@ func (config *nodeYaml) NodeUpdate(node NodeInfo) error {
 		config.Nodes[nodeID].NetDevs[devname].Default = netdev.Default.GetRealB()
 	}
 
-	for paramname, param := range node.Params {
-		config.Nodes[nodeID].Params[paramname] = param.GetReal()
+	for keyname, key := range node.Keys {
+		config.Nodes[nodeID].Keys[keyname] = key.GetReal()
 	}
 
 	return nil
@@ -158,7 +158,7 @@ func (config *nodeYaml) ProfileUpdate(profile NodeInfo) error {
 	config.NodeProfiles[profileID].Profiles = profile.Profiles
 	config.NodeProfiles[profileID].NetDevs = make(map[string]*NetDevs)
 	
-	config.NodeProfiles[profileID].Params = make(map[string]string)
+	config.NodeProfiles[profileID].Keys = make(map[string]string)
 
 	for devname, netdev := range profile.NetDevs {
 		var newdev NetDevs
@@ -172,8 +172,8 @@ func (config *nodeYaml) ProfileUpdate(profile NodeInfo) error {
 		config.NodeProfiles[profileID].NetDevs[devname].Default = netdev.Default.GetRealB()
 	}
 
-	for paramname, param := range profile.Params {
-		config.NodeProfiles[profileID].Params[paramname] = param.GetReal()
+	for keyname, key := range profile.Keys {
+		config.NodeProfiles[profileID].Keys[keyname] = key.GetReal()
 	}
 
 	return nil

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -31,6 +31,7 @@ type TemplateStruct struct {
 	IpmiUserName string
 	IpmiPassword string
 	NetDevs      map[string]*node.NetDevs
+	Params       map[string]string
 	AllNodes     []node.NodeInfo
 }
 
@@ -149,6 +150,7 @@ func buildOverlay(nodeList []node.NodeInfo, overlayType string) error {
 		t.IpmiUserName = n.IpmiUserName.Get()
 		t.IpmiPassword = n.IpmiPassword.Get()
 		t.NetDevs = make(map[string]*node.NetDevs)
+		t.Params = make(map[string]string)
 		for devname, netdev := range n.NetDevs {
 			var nd node.NetDevs
 			t.NetDevs[devname] = &nd
@@ -158,6 +160,11 @@ func buildOverlay(nodeList []node.NodeInfo, overlayType string) error {
 			t.NetDevs[devname].Gateway = netdev.Gateway.Get()
 			t.NetDevs[devname].Type = netdev.Type.Get()
 			t.NetDevs[devname].Default = netdev.Default.GetB()
+		}
+		for paramname, param := range n.Params {
+			// var nd node.Params
+			// t.Params[paramname] = &nd
+			t.Params[paramname] = param.Get()
 		}
 		t.AllNodes = allNodes
 

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -162,8 +162,6 @@ func buildOverlay(nodeList []node.NodeInfo, overlayType string) error {
 			t.NetDevs[devname].Default = netdev.Default.GetB()
 		}
 		for paramname, param := range n.Params {
-			// var nd node.Params
-			// t.Params[paramname] = &nd
 			t.Params[paramname] = param.Get()
 		}
 		t.AllNodes = allNodes

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -31,7 +31,7 @@ type TemplateStruct struct {
 	IpmiUserName string
 	IpmiPassword string
 	NetDevs      map[string]*node.NetDevs
-	Params       map[string]string
+	Keys       map[string]string
 	AllNodes     []node.NodeInfo
 }
 
@@ -150,7 +150,7 @@ func buildOverlay(nodeList []node.NodeInfo, overlayType string) error {
 		t.IpmiUserName = n.IpmiUserName.Get()
 		t.IpmiPassword = n.IpmiPassword.Get()
 		t.NetDevs = make(map[string]*node.NetDevs)
-		t.Params = make(map[string]string)
+		t.Keys = make(map[string]string)
 		for devname, netdev := range n.NetDevs {
 			var nd node.NetDevs
 			t.NetDevs[devname] = &nd
@@ -161,8 +161,8 @@ func buildOverlay(nodeList []node.NodeInfo, overlayType string) error {
 			t.NetDevs[devname].Type = netdev.Type.Get()
 			t.NetDevs[devname].Default = netdev.Default.GetB()
 		}
-		for paramname, param := range n.Params {
-			t.Params[paramname] = param.Get()
+		for keyname, key := range n.Keys {
+			t.Keys[keyname] = key.Get()
 		}
 		t.AllNodes = allNodes
 


### PR DESCRIPTION
Feature to add custom parameters to the node configuration and profiles.
It's intended to increase the flexibility of the config.

I allows for instance to import profile-specific files.
```
wwctl profile set -p dummy --value "/var/warewulf/opt/dummyImportProfile.txt" default
```
by using
```
{{Include (printf "%v" $.Params.dummy)}}
```
in a foobar.ww overlay-template, the `dummy` parameter is resolved and the respective file is imported.
As `dummy` is can be specified in the profile, a generic overlay can be used and files can still be managed by profiles. 