### PR TITLE
added ifcfg-eth0 for SUSE based system 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,9 @@ files: all
 	cp -r etc/dhcp $(DESTDIR)/etc/warewulf/
 	cp -r etc/ipxe $(DESTDIR)/etc/warewulf/
 	cp -r overlays $(DESTDIR)/var/warewulf/
+	# remove conflicting files from RedHat or SUSE distros
+	test -d /etc/sysconfig/network/ && rm $(DESTDIR)/var/warewulf/overlays//etc/sysconfig/network.ww \
+		|| rm -r $(DESTDIR)/var/warewulf/overlays//etc/sysconfig/network
 	chmod +x $(DESTDIR)/var/warewulf/overlays/system/default/init
 	chmod 600 $(DESTDIR)/var/warewulf/overlays/system/default/etc/ssh/ssh*
 	chmod 644 $(DESTDIR)/var/warewulf/overlays/system/default/etc/ssh/ssh*.pub.ww

--- a/overlays/system/default/etc/sysconfig/network.ww
+++ b/overlays/system/default/etc/sysconfig/network.ww
@@ -1,0 +1,2 @@
+NETWORKING=yes
+HOSTNAME={{$.Id}}

--- a/overlays/system/default/etc/sysconfig/network.ww
+++ b/overlays/system/default/etc/sysconfig/network.ww
@@ -1,2 +1,0 @@
-NETWORKING=yes
-HOSTNAME={{$.Id}}

--- a/overlays/system/default/etc/sysconfig/network/ifcfg-eth0.ww
+++ b/overlays/system/default/etc/sysconfig/network/ifcfg-eth0.ww
@@ -1,0 +1,9 @@
+DEVICE='eth0'
+NAME='eth0'
+IPADDR={{$.NetDevs.eth0.Ipaddr}}
+NETMASK={{$.NetDevs.eth0.Netmask}}
+GATEWAY={{$.NetDevs.eth0.Gateway}}
+HWADDR={{$.NetDevs.eth0.Hwaddr}}
+BOOTPROTO='static'
+DEVTIMEOUT=10
+STARTMODE='onboot'


### PR DESCRIPTION
removed network.cc due to conflicting name as the ifcfg-eth0 for SUSE systems reside in `/etc/sysconfig/network/ifcg-eth0`
Is `network,ww` needed for centos/rocky systems? 
Or would it be better to have OS specific overlays?