### PR TITLE
Wicked integration into default overlay

### DIFF
--- a/internal/pkg/node/datastructure.go
+++ b/internal/pkg/node/datastructure.go
@@ -44,6 +44,8 @@ type NetDevs struct {
 	Default bool   `yaml:"default"`
 	Hwaddr  string
 	Ipaddr  string
+	IpCIDR  string
+	Prefix  string
 	Netmask string
 	Gateway string `yaml:"gateway,omitempty"`
 }
@@ -91,6 +93,8 @@ type NetDevEntry struct {
 	Default Entry `yaml:"default"`
 	Hwaddr  Entry
 	Ipaddr  Entry
+	IpCIDR  Entry
+	Prefix  Entry
 	Netmask Entry
 	Gateway Entry `yaml:"gateway,omitempty"`
 }

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -3,11 +3,13 @@ package overlay
 import (
 	"fmt"
 	"io/ioutil"
+  "net"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
 	"regexp"
+  "strconv"
 	"strings"
 	"text/template"
 
@@ -160,6 +162,13 @@ func buildOverlay(nodeList []node.NodeInfo, overlayType string) error {
 			t.NetDevs[devname].Gateway = netdev.Gateway.Get()
 			t.NetDevs[devname].Type = netdev.Type.Get()
 			t.NetDevs[devname].Default = netdev.Default.GetB()
+      mask := net.IPMask(net.ParseIP(netdev.Netmask.Get()).To4())
+      ipaddr := net.ParseIP(netdev.Ipaddr.Get()).To4()
+      netaddr := net.IPNet{IP: ipaddr,Mask: mask}
+      netPrefix, _ := net.IPMask(net.ParseIP(netdev.Netmask.Get()).To4()).Size()
+      t.NetDevs[devname].Prefix = strconv.Itoa(netPrefix)
+      t.NetDevs[devname].IpCIDR = netaddr.String()
+
 		}
 		for keyname, key := range n.Keys {
 			t.Keys[keyname] = key.Get()

--- a/overlays/system/default/etc/wicked/ifconfig/ifcfg-eth0.xml.ww
+++ b/overlays/system/default/etc/wicked/ifconfig/ifcfg-eth0.xml.ww
@@ -1,0 +1,27 @@
+<interface origin="static generated warewulf config">
+  <name>eth0</name>
+  <control>
+    <mode>boot</mode>
+  </control>
+  <firewall/>
+  <link/>
+  <ipv4>
+    <enabled>true</enabled>
+    <arp-verify>true</arp-verify>
+  </ipv4>
+  <ipv4:static>
+    <address>
+      <local>{{$.NetDevs.eth0.IpCIDR}}</local>
+    </address>
+    <route>
+      <nexthop>
+        <gateway>{{$.NetDevs.eth0.Gateway}}</gateway>
+      </nexthop>
+    </route>
+  </ipv4:static>
+  <ipv6>
+    <enabled>true</enabled>
+    <privacy>prefer-public</privacy>
+    <accept-redirects>false</accept-redirects>
+  </ipv6>
+</interface>


### PR DESCRIPTION
It is possible to configure wicked (the SUSE network daemon) via xml files in `/etc/wicked/ifconfig/ifcg-$NAME.xml`, so a SUSE and EL like network configuration can coexist without having issues with `/etc/sysconfig/network`. This PR addes this files and also modifications in the node code, as the xml files needs the CIDR notation as is has not neimask option.
This is an alternative to #83