### PR TITLE
Duplicate entries in passwd file

### DIFF
--- a/overlays/runtime/default/etc/passwd.ww
+++ b/overlays/runtime/default/etc/passwd.ww
@@ -1,3 +1,1 @@
-root::0:0:root:/root:/bin/bash
-{{IncludeFrom $.Container "/etc/passwd"}}
 {{Include "/etc/passwd"}}


### PR DESCRIPTION
A Mention in the documentation that this file needs to be modified for different setups should be added. By leaving the overlay this way the compute nodes will pull from two sources for users and have duplicate entries in passwd file.