### PR TITLE
Added overlay chown subcommand

### DIFF
--- a/internal/app/wwctl/overlay/chmod/main.go
+++ b/internal/app/wwctl/overlay/chmod/main.go
@@ -16,9 +16,9 @@ import (
 func CobraRunE(cmd *cobra.Command, args []string) error {
 	var overlaySourceDir string
 	overlayName := args[0]
-	fileName := args[2]
+	fileName := args[1]
 
-	permissionMode, err := strconv.ParseInt(args[1], 8, 32)
+	permissionMode, err := strconv.ParseInt(args[2], 8, 32)
 	if err != nil {
 		wwlog.Printf(wwlog.ERROR, "Could not convert requested mode: %s\n", err)
 		os.Exit(1)

--- a/internal/app/wwctl/overlay/chmod/root.go
+++ b/internal/app/wwctl/overlay/chmod/root.go
@@ -4,7 +4,7 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "chmod [flags] <overlay> <mode> <path>",
+		Use:   "chmod [flags] <overlay> <path> <mode>",
 		Short: "Change file permissions within an overlay",
 		Long: "This command will allow you to change the permissions of a file within an\n" +
 			"overlay.",

--- a/internal/app/wwctl/overlay/chown/main.go
+++ b/internal/app/wwctl/overlay/chown/main.go
@@ -1,0 +1,98 @@
+package chown
+
+import (
+	"os"
+	"path"
+	"strconv"
+
+	"github.com/hpcng/warewulf/internal/pkg/config"
+	"github.com/hpcng/warewulf/internal/pkg/node"
+	"github.com/hpcng/warewulf/internal/pkg/overlay"
+	"github.com/hpcng/warewulf/internal/pkg/util"
+	"github.com/hpcng/warewulf/internal/pkg/wwlog"
+
+	"github.com/spf13/cobra"
+)
+
+func CobraRunE(cmd *cobra.Command, args []string) error {
+	var overlaySourceDir string
+	overlayName := args[0]
+	fileName := args[1]
+	var uid int
+	var gid int
+	var err error
+
+	uid, err = strconv.Atoi(args[2])
+	if err != nil {
+		wwlog.Printf(wwlog.ERROR, "UID is not an integer: %s\n", args[2])
+		os.Exit(1)
+	}
+
+	if len(args) > 3 {
+		gid, err = strconv.Atoi(args[3])
+		if err != nil {
+			wwlog.Printf(wwlog.ERROR, "GID is not an integer: %s\n", args[3])
+			os.Exit(1)
+		}
+	} else {
+		gid = 0
+	}
+
+	if SystemOverlay {
+		overlaySourceDir = config.SystemOverlaySource(overlayName)
+	} else {
+		overlaySourceDir = config.RuntimeOverlaySource(overlayName)
+	}
+
+	if !util.IsDir(overlaySourceDir) {
+		wwlog.Printf(wwlog.ERROR, "Overlay does not exist: %s\n", overlayName)
+		os.Exit(1)
+	}
+
+	overlayFile := path.Join(overlaySourceDir, fileName)
+
+	if !util.IsFile(overlayFile) && !util.IsDir(overlayFile) {
+		wwlog.Printf(wwlog.ERROR, "File does not exist within overlay: %s:%s\n", overlayName, fileName)
+		os.Exit(1)
+	}
+
+	err = os.Chown(overlayFile, uid, gid)
+	if err != nil {
+		wwlog.Printf(wwlog.ERROR, "Could not set ownership: %s\n", err)
+		os.Exit(1)
+	}
+
+	if !NoOverlayUpdate {
+		n, err := node.New()
+		if err != nil {
+			wwlog.Printf(wwlog.ERROR, "Could not open node configuration: %s\n", err)
+			os.Exit(1)
+		}
+
+		nodes, err := n.FindAllNodes()
+		if err != nil {
+			wwlog.Printf(wwlog.ERROR, "Could not get node list: %s\n", err)
+			os.Exit(1)
+		}
+
+		var updateNodes []node.NodeInfo
+
+		for _, node := range nodes {
+			if SystemOverlay == true && node.SystemOverlay.Get() == overlayName {
+				updateNodes = append(updateNodes, node)
+			} else if node.RuntimeOverlay.Get() == overlayName {
+				updateNodes = append(updateNodes, node)
+			}
+		}
+
+		if SystemOverlay {
+			wwlog.Printf(wwlog.INFO, "Updating System Overlays...\n")
+			return overlay.BuildSystemOverlay(updateNodes)
+		} else {
+			wwlog.Printf(wwlog.INFO, "Updating Runtime Overlays...\n")
+			return overlay.BuildRuntimeOverlay(updateNodes)
+		}
+	}
+
+	return nil
+}

--- a/internal/app/wwctl/overlay/chown/root.go
+++ b/internal/app/wwctl/overlay/chown/root.go
@@ -1,0 +1,26 @@
+package chown
+
+import "github.com/spf13/cobra"
+
+var (
+	baseCmd = &cobra.Command{
+		Use:   "chown [flags] <overlay> <path> <UID> [<GID>]",
+		Short: "Change file ownership within an overlay",
+		Long: "This command will allow you to change the ownership of a file within an\n" +
+			"overlay.",
+		RunE: CobraRunE,
+		Args: cobra.RangeArgs(3, 4),
+	}
+	SystemOverlay   bool
+	NoOverlayUpdate bool
+)
+
+func init() {
+	baseCmd.PersistentFlags().BoolVarP(&SystemOverlay, "system", "s", false, "Show System Overlays as well")
+	baseCmd.PersistentFlags().BoolVarP(&NoOverlayUpdate, "noupdate", "n", false, "Don't update overlays")
+}
+
+// GetRootCommand returns the root cobra.Command for the application.
+func GetCommand() *cobra.Command {
+	return baseCmd
+}

--- a/internal/app/wwctl/overlay/root.go
+++ b/internal/app/wwctl/overlay/root.go
@@ -3,6 +3,7 @@ package overlay
 import (
 	"github.com/hpcng/warewulf/internal/app/wwctl/overlay/build"
 	"github.com/hpcng/warewulf/internal/app/wwctl/overlay/chmod"
+	"github.com/hpcng/warewulf/internal/app/wwctl/overlay/chown"
 	"github.com/hpcng/warewulf/internal/app/wwctl/overlay/create"
 	"github.com/hpcng/warewulf/internal/app/wwctl/overlay/delete"
 	"github.com/hpcng/warewulf/internal/app/wwctl/overlay/edit"
@@ -32,6 +33,7 @@ func init() {
 	baseCmd.AddCommand(build.GetCommand())
 	baseCmd.AddCommand(imprt.GetCommand())
 	baseCmd.AddCommand(chmod.GetCommand())
+	baseCmd.AddCommand(chown.GetCommand())
 }
 
 // GetRootCommand returns the root cobra.Command for the application.

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -157,7 +157,7 @@ func IsFile(path string) bool {
 		return false
 	}
 
-	if _, err := os.Stat(path); err == nil {
+	if stat, err := os.Stat(path); err == nil && !stat.IsDir() {
 		return true
 	}
 	return false


### PR DESCRIPTION
Now that we have the appropriate backend to handle overlay file ownership, this PR adds a frontend command to change ownership on files and directories.