### PR TITLE
MS_REC added to MS_PRIVATE mount on root

### DIFF
--- a/internal/app/wwctl/container/exec/child/main.go
+++ b/internal/app/wwctl/container/exec/child/main.go
@@ -31,7 +31,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	containerPath := container.RootFsDir(containerName)
 
-	err := syscall.Mount("", "/", "", syscall.MS_PRIVATE, "")
+	err := syscall.Mount("", "/", "", syscall.MS_PRIVATE|syscall.MS_REC, "")
 	if err != nil {
 		return errors.Wrap(err, "failed to mount")
 	}


### PR DESCRIPTION
Hoping this fixes what @mslacken found on SLES Leap with regards to mounts not going away when the mount namespace shuts down.