### PR TITLE
Better error handling for some of wwctl commands

### DIFF
--- a/cmd/wwctl/main.go
+++ b/cmd/wwctl/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/hpcng/warewulf/internal/app/wwctl"
@@ -11,6 +12,10 @@ func main() {
 
 	err := root.Execute()
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: %s\n", os.Args[0], err)
+		if wwctl.DebugFlag {
+			fmt.Printf("\nSTACK TRACE: %+v\n", err)
+		}
 		os.Exit(255)
 	}
 }

--- a/internal/app/wwctl/node/add/main.go
+++ b/internal/app/wwctl/node/add/main.go
@@ -1,9 +1,6 @@
 package add
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/hpcng/warewulf/internal/pkg/node"
 	"github.com/hpcng/warewulf/internal/pkg/wwlog"
 	"github.com/pkg/errors"
@@ -13,32 +10,28 @@ import (
 func CobraRunE(cmd *cobra.Command, args []string) error {
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Failed to open node database: %s\n", err)
-		os.Exit(1)
+		return errors.Wrap(err, "failed to open node database")
 	}
 
 	for _, a := range args {
 		n, err := nodeDB.AddNode(a)
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "%s\n", err)
-			os.Exit(1)
+			return errors.Wrap(err, "failed to add node")
 		}
-		fmt.Printf("Added node: %s\n", a)
+		wwlog.Printf(wwlog.INFO, "Added node: %s\n", a)
 
 		if SetClusterName != "" {
 			wwlog.Printf(wwlog.VERBOSE, "Node: %s, Setting cluster name to: %s\n", n.Id.Get(), SetClusterName)
 			n.ClusterName.Set(SetClusterName)
 			err := nodeDB.NodeUpdate(n)
 			if err != nil {
-				wwlog.Printf(wwlog.ERROR, "%s\n", err)
-				os.Exit(1)
+				return errors.Wrap(err, "failed to update node")
 			}
 		}
 
 		if SetIpaddr != "" {
 			if SetNetDev == "" {
-				wwlog.Printf(wwlog.ERROR, "You must include the '--netdev' option\n")
-				os.Exit(1)
+				return errors.New("you must include the '--netdev' option")
 			}
 
 			if _, ok := n.NetDevs[SetNetDev]; !ok {
@@ -52,85 +45,72 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 			n.NetDevs[SetNetDev].Default.SetB(true)
 			err := nodeDB.NodeUpdate(n)
 			if err != nil {
-				wwlog.Printf(wwlog.ERROR, "%s\n", err)
-				os.Exit(1)
+				return errors.Wrap(err, "failed to update nodedb")
 			}
 		}
 		if SetNetmask != "" {
 			if SetNetDev == "" {
-				wwlog.Printf(wwlog.ERROR, "You must include the '--netdev' option\n")
-				os.Exit(1)
+				return errors.New("you must include the '--netdev' option")
 			}
 
 			if _, ok := n.NetDevs[SetNetDev]; !ok {
-				wwlog.Printf(wwlog.ERROR, "Network Device doesn't exist: %s\n", SetNetDev)
-				os.Exit(1)
+				return errors.New("network device does not exist: " + SetNetDev)
 			}
 			wwlog.Printf(wwlog.VERBOSE, "Node: %s:%s, Setting netmask to: %s\n", n.Id.Get(), SetNetDev, SetNetmask)
 
 			n.NetDevs[SetNetDev].Netmask.Set(SetNetmask)
 			err := nodeDB.NodeUpdate(n)
 			if err != nil {
-				wwlog.Printf(wwlog.ERROR, "%s\n", err)
-				os.Exit(1)
+				return errors.Wrap(err, "failed to update nodedb")
 			}
 		}
 		if SetGateway != "" {
 			if SetNetDev == "" {
-				wwlog.Printf(wwlog.ERROR, "You must include the '--netdev' option\n")
-				os.Exit(1)
+				return errors.New("you must include the '--netdev' option")
 			}
 
 			if _, ok := n.NetDevs[SetNetDev]; !ok {
-				wwlog.Printf(wwlog.ERROR, "Network Device doesn't exist: %s\n", SetNetDev)
-				os.Exit(1)
+				return errors.New("network device does not exist: " + SetNetDev)
 			}
 			wwlog.Printf(wwlog.VERBOSE, "Node: %s:%s, Setting gateway to: %s\n", n.Id.Get(), SetNetDev, SetGateway)
 
 			n.NetDevs[SetNetDev].Gateway.Set(SetGateway)
 			err := nodeDB.NodeUpdate(n)
 			if err != nil {
-				wwlog.Printf(wwlog.ERROR, "%s\n", err)
-				os.Exit(1)
+				return errors.Wrap(err, "failed to update nodedb")
 			}
 		}
 		if SetHwaddr != "" {
 			if SetNetDev == "" {
-				wwlog.Printf(wwlog.ERROR, "You must include the '--netdev' option\n")
-				os.Exit(1)
+				return errors.New("you must include the '--netdev' option")
 			}
 
 			if _, ok := n.NetDevs[SetNetDev]; !ok {
-				wwlog.Printf(wwlog.ERROR, "Network Device doesn't exist: %s\n", SetNetDev)
-				os.Exit(1)
+				return errors.New("network device does not exist: " + SetNetDev)
 			}
 			wwlog.Printf(wwlog.VERBOSE, "Node: %s:%s, Setting HW address to: %s\n", n.Id.Get(), SetNetDev, SetHwaddr)
 
 			n.NetDevs[SetNetDev].Hwaddr.Set(SetHwaddr)
 			err := nodeDB.NodeUpdate(n)
 			if err != nil {
-				wwlog.Printf(wwlog.ERROR, "%s\n", err)
-				os.Exit(1)
+				return errors.Wrap(err, "failed to update nodedb")
 			}
 		}
 
 		if SetType != "" {
 			if SetNetDev == "" {
-				wwlog.Printf(wwlog.ERROR, "You must include the '--netdev' option\n")
-				os.Exit(1)
+				return errors.New("you must include the '--netdev' option")
 			}
 
 			if _, ok := n.NetDevs[SetNetDev]; !ok {
-				wwlog.Printf(wwlog.ERROR, "Network Device doesn't exist: %s\n", SetNetDev)
-				os.Exit(1)
+				return errors.New("network device does not exist: " + SetNetDev)
 			}
 			wwlog.Printf(wwlog.VERBOSE, "Node: %s:%s, Setting Type to: %s\n", n.Id.Get(), SetNetDev, SetType)
 
 			n.NetDevs[SetNetDev].Type.Set(SetType)
 			err := nodeDB.NodeUpdate(n)
 			if err != nil {
-				wwlog.Printf(wwlog.ERROR, "%s\n", err)
-				os.Exit(1)
+				return errors.Wrap(err, "failed to update nodedb")
 			}
 		}
 
@@ -140,8 +120,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 			n.Discoverable.SetB(true)
 			err := nodeDB.NodeUpdate(n)
 			if err != nil {
-				wwlog.Printf(wwlog.ERROR, "%s\n", err)
-				os.Exit(1)
+				return errors.Wrap(err, "failed to update nodedb")
 			}
 		}
 

--- a/internal/app/wwctl/root.go
+++ b/internal/app/wwctl/root.go
@@ -25,12 +25,12 @@ var (
 		SilenceUsage:      true,
 	}
 	verboseArg bool
-	debugArg   bool
+	DebugFlag  bool
 )
 
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&verboseArg, "verbose", "v", false, "Run with increased verbosity.")
-	rootCmd.PersistentFlags().BoolVarP(&debugArg, "debug", "d", false, "Run with debugging messages enabled.")
+	rootCmd.PersistentFlags().BoolVarP(&DebugFlag, "debug", "d", false, "Run with debugging messages enabled.")
 
 	rootCmd.AddCommand(overlay.GetCommand())
 	rootCmd.AddCommand(container.GetCommand())
@@ -49,7 +49,7 @@ func GetRootCommand() *cobra.Command {
 }
 
 func rootPersistentPreRunE(cmd *cobra.Command, args []string) error {
-	if debugArg {
+	if DebugFlag {
 		wwlog.SetLevel(wwlog.DEBUG)
 	} else if verboseArg {
 		wwlog.SetLevel(wwlog.VERBOSE)


### PR DESCRIPTION
Better error handling, use less `os.Exit()`, and more error returns. Also prints a stack trace for `wwctl` if
`--debug` flag is used.

Example: 

```console
$ ./wwctl node add foo # no debug flag
[ERROR] 	  2021/09/10 11:56:52 Could not create new configuration file: open /etc/warewulf/nodes.conf: no such file or directory
[ERROR] 	  2021/09/10 11:56:52 Configuration file not found: /etc/warewulf/warewulf.conf
error reading node configuration file
Error: failed to open node database: open /etc/warewulf/nodes.conf: no such file or directory
./wwctl: failed to open node database: open /etc/warewulf/nodes.conf: no such file or directory

$ ./wwctl -d node add foo # with debug flag
[ERROR] 	  2021/09/10 11:56:55 Could not create new configuration file: open /etc/warewulf/nodes.conf: no such file or directory
[ERROR] 	  2021/09/10 11:56:55 Configuration file not found: /etc/warewulf/warewulf.conf
2021/09/10 11:56:55.569948 [DEBUG]    Set log level to: 5
2021/09/10 11:56:55.569966 [DEBUG]    Opening node configuration file: /etc/warewulf/nodes.conf
error reading node configuration file
Error: failed to open node database: open /etc/warewulf/nodes.conf: no such file or directory
./wwctl: failed to open node database: open /etc/warewulf/nodes.conf: no such file or directory

STACK TRACE: open /etc/warewulf/nodes.conf: no such file or directory
failed to open node database
github.com/hpcng/warewulf/internal/app/wwctl/node/add.CobraRunE
	/home/westley/dev-ctrliq/warewulf/internal/app/wwctl/node/add/main.go:13
github.com/spf13/cobra.(*Command).execute
	/home/westley/dev-ctrliq/warewulf/vendor/github.com/spf13/cobra/command.go:850
github.com/spf13/cobra.(*Command).ExecuteC
	/home/westley/dev-ctrliq/warewulf/vendor/github.com/spf13/cobra/command.go:958
github.com/spf13/cobra.(*Command).Execute
	/home/westley/dev-ctrliq/warewulf/vendor/github.com/spf13/cobra/command.go:895
main.main
	/home/westley/dev-ctrliq/warewulf/cmd/wwctl/main.go:13
runtime.main
	/usr/local/go/src/runtime/proc.go:255
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1581
```