### PR TITLE
Always rebuild the go binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all
+.PHONY: all wwctl wwclient bash_completion man_page
 
 VERSION := 4.1.0
 


### PR DESCRIPTION
Its not practical to run `make clean ; make` every time you want to
rebuild one of the go binaries. Go will automatically cache builds and
file changes.