### PR TITLE
Adding a 'build' target to Makefile and other adjustments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: all wwctl wwclient bash_completion man_page
+.PHONY: all build wwctl wwclient bash_completion man_page
 
-VERSION := 4.1.0
+VERSION := 4.2.0
 
 # auto installed tooling
 TOOLS_DIR := .tools
@@ -20,6 +20,8 @@ export GOPROXY
 WW_BUILD_GO_BUILD_TAGS := containers_image_openpgp containers_image_ostree
 
 all: setup_tools vendor wwctl wwclient bash_completion man_page
+
+build: wwctl wwclient bash_completion man_page
 
 # set the go tools into the tools bin.
 setup_tools: $(GO_TOOLS_BIN) $(GOLANGCI_LINT)
@@ -115,6 +117,7 @@ clean:
 	rm -f warewulf-$(VERSION).tar.gz
 	rm -f bash_completion
 	rm -f man_page
+	rm -rf .tools
 
 install: files
 


### PR DESCRIPTION
This target will allow for the a build to occur without calling the
vendor target.

Remove the .tools directory when running the 'clean' target.

Up the version number.