### PR TITLE
Vendor make fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ export GOPROXY
 # built tags needed for wwbuild binary
 WW_BUILD_GO_BUILD_TAGS := containers_image_openpgp containers_image_ostree
 
-all: setup_tools vendor wwctl wwclient bash_completion man_page
+all: vendor wwctl wwclient bash_completion man_page
 
 # set the go tools into the tools bin.
 setup_tools: $(GO_TOOLS_BIN) $(GOLANGCI_LINT)

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ $(TOOLS_DIR):
 	@mkdir -p $@
 
 # Lint
-lint:
+lint: setup_tools
 	@echo Running golangci-lint...
 	@$(GOLANGCI_LINT) run --build-tags "$(WW_BUILD_GO_BUILD_TAGS)" --skip-dirs internal/pkg/staticfiles ./...
 
@@ -89,7 +89,7 @@ debfiles: debian
 	cp wwclient $(DESTDIR)/var/warewulf/overlays/system/debian/warewulf/bin/
 
 wwctl:
-	cd cmd/wwctl; go build -mod vendor -tags "$(WW_BUILD_GO_BUILD_TAGS)" -o ../../wwctl
+	cd cmd/wwctl; GOOS=linux go build -mod vendor -tags "$(WW_BUILD_GO_BUILD_TAGS)" -o ../../wwctl
 
 wwclient:
 	cd cmd/wwclient; CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -ldflags '-extldflags -static' -o ../../wwclient


### PR DESCRIPTION
This is a minor fix to ensure that Warewulf can be built from the `make dist` tarball offline. 