### PR TITLE
Fix panic when failing to include the command to be run by the

### DIFF
--- a/internal/app/wwctl/container/exec/root.go
+++ b/internal/app/wwctl/container/exec/root.go
@@ -7,13 +7,13 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "exec [flags] [container name]",
+		Use:   "exec [flags] [container name] [command]",
 		Short: "Run a command inside of a Warewulf container",
 		Long: "This command will allow you to run any command inside of a given\n" +
 			"warewulf container. This is commonly used with an interactive shell such as /bin/bash\n" +
 			"to run a virtual environment within the container.",
 		RunE:               CobraRunE,
-		Args:               cobra.MinimumNArgs(1),
+		Args:               cobra.MinimumNArgs(2),
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 	}
 	binds []string


### PR DESCRIPTION
'container exec' command.

Update documentation for the 'container exec' command.