### PR TITLE
Bash-completion dynamic nouns

### DIFF
--- a/internal/app/wwctl/container/build/root.go
+++ b/internal/app/wwctl/container/build/root.go
@@ -1,6 +1,9 @@
 package build
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/hpcng/warewulf/internal/pkg/container"
+	"github.com/spf13/cobra"
+)
 
 var (
 	baseCmd = &cobra.Command{
@@ -9,6 +12,13 @@ var (
 		Long:  "This command will build a bootable VNFS image from an imported container image.",
 		RunE:  CobraRunE,
 		Args:  cobra.MinimumNArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) != 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			list, _ := container.ListSources()
+			return list, cobra.ShellCompDirectiveNoFileComp
+		},
 	}
 	BuildForce bool
 	BuildAll   bool

--- a/internal/app/wwctl/container/delete/root.go
+++ b/internal/app/wwctl/container/delete/root.go
@@ -1,6 +1,9 @@
 package delete
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/hpcng/warewulf/internal/pkg/container"
+	"github.com/spf13/cobra"
+)
 
 var (
 	baseCmd = &cobra.Command{
@@ -8,7 +11,13 @@ var (
 		Short: "Delete an imported container",
 		Long:  "This command will delete a container that has been imported into Warewulf.",
 		RunE:  CobraRunE,
-		Args:  cobra.MinimumNArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) != 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			list, _ := container.ListSources()
+			return list, cobra.ShellCompDirectiveNoFileComp
+		},
 	}
 )
 

--- a/internal/app/wwctl/container/exec/root.go
+++ b/internal/app/wwctl/container/exec/root.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"github.com/hpcng/warewulf/internal/app/wwctl/container/exec/child"
+	"github.com/hpcng/warewulf/internal/pkg/container"
 	"github.com/spf13/cobra"
 )
 
@@ -12,8 +13,15 @@ var (
 		Long: "This command will allow you to run any command inside of a given\n" +
 			"warewulf container. This is commonly used with an interactive shell such as /bin/bash\n" +
 			"to run a virtual environment within the container.",
-		RunE:               CobraRunE,
-		Args:               cobra.MinimumNArgs(2),
+		RunE: CobraRunE,
+		Args: cobra.MinimumNArgs(2),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) != 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			list, _ := container.ListSources()
+			return list, cobra.ShellCompDirectiveNoFileComp
+		},
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 	}
 	binds []string

--- a/internal/app/wwctl/kernel/delete/root.go
+++ b/internal/app/wwctl/kernel/delete/root.go
@@ -1,6 +1,9 @@
 package delete
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/hpcng/warewulf/internal/pkg/kernel"
+	"github.com/spf13/cobra"
+)
 
 var (
 	baseCmd = &cobra.Command{
@@ -9,6 +12,13 @@ var (
 		Long:  "This command will delete a kernel that has been imported into Warewulf.",
 		RunE:  CobraRunE,
 		Args:  cobra.MinimumNArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) != 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			list, _ := kernel.ListKernels()
+			return list, cobra.ShellCompDirectiveNoFileComp
+		},
 	}
 )
 

--- a/internal/app/wwctl/kernel/imprt/root.go
+++ b/internal/app/wwctl/kernel/imprt/root.go
@@ -1,6 +1,8 @@
 package imprt
 
 import (
+	"log"
+
 	"github.com/hpcng/warewulf/internal/pkg/container"
 	"github.com/spf13/cobra"
 )
@@ -27,10 +29,13 @@ func init() {
 	baseCmd.PersistentFlags().BoolVar(&SetDefault, "setdefault", false, "Set this kernel for the default profile")
 	baseCmd.PersistentFlags().StringVarP(&OptRoot, "root", "r", "/", "Import kernel from root (chroot) directory")
 	baseCmd.PersistentFlags().StringVarP(&OptContainer, "container", "C", "", "Import kernel from container")
-	baseCmd.RegisterFlagCompletionFunc("container", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	err := baseCmd.RegisterFlagCompletionFunc("container", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		list, _ := container.ListSources()
 		return list, cobra.ShellCompDirectiveNoFileComp
 	})
+	if err != nil {
+		log.Println(err)
+	}
 }
 
 // GetRootCommand returns the root cobra.Command for the application.

--- a/internal/app/wwctl/kernel/imprt/root.go
+++ b/internal/app/wwctl/kernel/imprt/root.go
@@ -1,6 +1,7 @@
 package imprt
 
 import (
+	"github.com/hpcng/warewulf/internal/pkg/container"
 	"github.com/spf13/cobra"
 )
 
@@ -26,6 +27,10 @@ func init() {
 	baseCmd.PersistentFlags().BoolVar(&SetDefault, "setdefault", false, "Set this kernel for the default profile")
 	baseCmd.PersistentFlags().StringVarP(&OptRoot, "root", "r", "/", "Import kernel from root (chroot) directory")
 	baseCmd.PersistentFlags().StringVarP(&OptContainer, "container", "C", "", "Import kernel from container")
+	baseCmd.RegisterFlagCompletionFunc("container", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		list, _ := container.ListSources()
+		return list, cobra.ShellCompDirectiveNoFileComp
+	})
 }
 
 // GetRootCommand returns the root cobra.Command for the application.

--- a/internal/app/wwctl/node/delete/root.go
+++ b/internal/app/wwctl/node/delete/root.go
@@ -1,6 +1,9 @@
 package delete
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/hpcng/warewulf/internal/pkg/node"
+	"github.com/spf13/cobra"
+)
 
 var (
 	baseCmd = &cobra.Command{
@@ -10,6 +13,19 @@ var (
 		Args:    cobra.MinimumNArgs(1),
 		RunE:    CobraRunE,
 		Aliases: []string{"rm", "del"},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) != 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+
+			nodeDB, _ := node.New()
+			nodes, _ := nodeDB.FindAllNodes()
+			var node_names []string
+			for _, node := range nodes {
+				node_names = append(node_names, node.Id.Get())
+			}
+			return node_names, cobra.ShellCompDirectiveNoFileComp
+		},
 	}
 	SetYes   bool
 	SetForce string

--- a/internal/app/wwctl/node/ready/root.go
+++ b/internal/app/wwctl/node/ready/root.go
@@ -1,6 +1,7 @@
 package ready
 
 import (
+	"github.com/hpcng/warewulf/internal/pkg/node"
 	"github.com/spf13/cobra"
 )
 
@@ -9,6 +10,19 @@ var (
 		Use:   "ready",
 		Short: "Warewulf Status Check",
 		RunE:  CobraRunE,
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) != 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+
+			nodeDB, _ := node.New()
+			nodes, _ := nodeDB.FindAllNodes()
+			var node_names []string
+			for _, node := range nodes {
+				node_names = append(node_names, node.Id.Get())
+			}
+			return node_names, cobra.ShellCompDirectiveNoFileComp
+		},
 	}
 )
 

--- a/internal/app/wwctl/node/sensors/root.go
+++ b/internal/app/wwctl/node/sensors/root.go
@@ -1,6 +1,7 @@
 package sensors
 
 import (
+	"github.com/hpcng/warewulf/internal/pkg/node"
 	"github.com/spf13/cobra"
 )
 
@@ -11,6 +12,19 @@ var (
 		Long:  "Show IPMI sensors for a single node.",
 		Args:  cobra.MinimumNArgs(1),
 		RunE:  CobraRunE,
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) != 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+
+			nodeDB, _ := node.New()
+			nodes, _ := nodeDB.FindAllNodes()
+			var node_names []string
+			for _, node := range nodes {
+				node_names = append(node_names, node.Id.Get())
+			}
+			return node_names, cobra.ShellCompDirectiveNoFileComp
+		},
 	}
 	full bool
 )

--- a/internal/app/wwctl/node/set/root.go
+++ b/internal/app/wwctl/node/set/root.go
@@ -1,6 +1,8 @@
 package set
 
 import (
+	"log"
+
 	"github.com/hpcng/warewulf/internal/pkg/container"
 	"github.com/hpcng/warewulf/internal/pkg/kernel"
 	"github.com/hpcng/warewulf/internal/pkg/node"
@@ -71,30 +73,38 @@ var (
 func init() {
 	baseCmd.PersistentFlags().StringVar(&SetComment, "comment", "", "Set a comment for this node")
 	baseCmd.PersistentFlags().StringVarP(&SetContainer, "container", "C", "", "Set the container (VNFS) for this node")
-	baseCmd.RegisterFlagCompletionFunc("container", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if err := baseCmd.RegisterFlagCompletionFunc("container", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		list, _ := container.ListSources()
 		return list, cobra.ShellCompDirectiveNoFileComp
-	})
+	}); err != nil {
+		log.Println(err)
+	}
 	baseCmd.PersistentFlags().StringVarP(&SetKernel, "kernel", "K", "", "Set Kernel version for nodes")
-	baseCmd.RegisterFlagCompletionFunc("kernel", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if err := baseCmd.RegisterFlagCompletionFunc("kernel", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		list, _ := kernel.ListKernels()
 		return list, cobra.ShellCompDirectiveNoFileComp
-	})
+	}); err != nil {
+		log.Println(err)
+	}
 	baseCmd.PersistentFlags().StringVarP(&SetKernelArgs, "kernelargs", "A", "", "Set Kernel argument for nodes")
 	baseCmd.PersistentFlags().StringVarP(&SetClusterName, "cluster", "c", "", "Set the node's cluster group")
 	baseCmd.PersistentFlags().StringVar(&SetIpxe, "ipxe", "", "Set the node's iPXE template name")
 	baseCmd.PersistentFlags().StringVarP(&SetInit, "init", "i", "", "Define the init process to boot the container")
 	baseCmd.PersistentFlags().StringVar(&SetRoot, "root", "", "Define the rootfs")
 	baseCmd.PersistentFlags().StringVarP(&SetRuntimeOverlay, "runtime", "R", "", "Set the node's runtime overlay")
-	baseCmd.RegisterFlagCompletionFunc("runtime", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if err := baseCmd.RegisterFlagCompletionFunc("runtime", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		list, _ := overlay.FindRuntimeOverlays()
 		return list, cobra.ShellCompDirectiveNoFileComp
-	})
+	}); err != nil {
+		log.Println(err)
+	}
 	baseCmd.PersistentFlags().StringVarP(&SetSystemOverlay, "system", "S", "", "Set the node's system overlay")
-	baseCmd.RegisterFlagCompletionFunc("system", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if err := baseCmd.RegisterFlagCompletionFunc("system", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		list, _ := overlay.FindSystemOverlays()
 		return list, cobra.ShellCompDirectiveNoFileComp
-	})
+	}); err != nil {
+		log.Println(err)
+	}
 	baseCmd.PersistentFlags().StringVar(&SetIpmiIpaddr, "ipmi", "", "Set the node's IPMI IP address")
 	baseCmd.PersistentFlags().StringVar(&SetIpmiNetmask, "ipminetmask", "", "Set the node's IPMI netmask")
 	baseCmd.PersistentFlags().StringVar(&SetIpmiPort, "ipmiport", "", "Set the node's IPMI port")
@@ -105,7 +115,7 @@ func init() {
 	baseCmd.PersistentFlags().StringSliceVar(&SetAddProfile, "addprofile", []string{}, "Add Profile(s) to node")
 	baseCmd.PersistentFlags().StringSliceVar(&SetDelProfile, "delprofile", []string{}, "Remove Profile(s) to node")
 	baseCmd.PersistentFlags().StringVarP(&SetProfile, "profile", "P", "", "Set the node's profile members (comma separated)")
-	baseCmd.RegisterFlagCompletionFunc("profile", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if err := baseCmd.RegisterFlagCompletionFunc("profile", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		var list []string
 		nodeDB, _ := node.New()
 		profiles, _ := nodeDB.FindAllProfiles()
@@ -113,8 +123,9 @@ func init() {
 			list = append(list, profile.Id.Get())
 		}
 		return list, cobra.ShellCompDirectiveNoFileComp
-
-	})
+	}); err != nil {
+		log.Println(err)
+	}
 	baseCmd.PersistentFlags().StringVarP(&SetNetDev, "netdev", "N", "", "Define the network device to configure")
 	baseCmd.PersistentFlags().StringVarP(&SetIpaddr, "ipaddr", "I", "", "Set the node's network device IP address")
 	baseCmd.PersistentFlags().StringVarP(&SetNetmask, "netmask", "M", "", "Set the node's network device netmask")

--- a/internal/app/wwctl/overlay/list/root.go
+++ b/internal/app/wwctl/overlay/list/root.go
@@ -10,9 +10,10 @@ var (
 		Short: "List Warewulf Overlays and files",
 		Long: "This command will show you information about Warewulf overlays and the\n" +
 			"files contained within.",
-		RunE:    CobraRunE,
-		Args:    cobra.MinimumNArgs(1),
-		Aliases: []string{"ls"},
+		RunE:      CobraRunE,
+		Args:      cobra.MinimumNArgs(1),
+		Aliases:   []string{"ls"},
+		ValidArgs: []string{"system", "runtime"},
 	}
 	ListContents bool
 	ListLong     bool

--- a/internal/app/wwctl/power/off/root.go
+++ b/internal/app/wwctl/power/off/root.go
@@ -1,6 +1,7 @@
 package poweroff
 
 import (
+	"github.com/hpcng/warewulf/internal/pkg/node"
 	"github.com/spf13/cobra"
 )
 
@@ -10,6 +11,19 @@ var (
 		Short: "Power off the given node(s)",
 		Long:  "This command will shutdown the power to a given set of nodes.",
 		RunE:  CobraRunE,
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) != 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+
+			nodeDB, _ := node.New()
+			nodes, _ := nodeDB.FindAllNodes()
+			var node_names []string
+			for _, node := range nodes {
+				node_names = append(node_names, node.Id.Get())
+			}
+			return node_names, cobra.ShellCompDirectiveNoFileComp
+		},
 	}
 )
 

--- a/internal/app/wwctl/power/on/root.go
+++ b/internal/app/wwctl/power/on/root.go
@@ -1,6 +1,7 @@
 package poweron
 
 import (
+	"github.com/hpcng/warewulf/internal/pkg/node"
 	"github.com/spf13/cobra"
 )
 
@@ -10,6 +11,19 @@ var (
 		Short: "Power on the given node(s)",
 		Long:  "This command will power on a given set of nodes.",
 		RunE:  CobraRunE,
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) != 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+
+			nodeDB, _ := node.New()
+			nodes, _ := nodeDB.FindAllNodes()
+			var node_names []string
+			for _, node := range nodes {
+				node_names = append(node_names, node.Id.Get())
+			}
+			return node_names, cobra.ShellCompDirectiveNoFileComp
+		},
 	}
 )
 

--- a/internal/app/wwctl/power/reset/root.go
+++ b/internal/app/wwctl/power/reset/root.go
@@ -1,6 +1,7 @@
 package powerreset
 
 import (
+	"github.com/hpcng/warewulf/internal/pkg/node"
 	"github.com/spf13/cobra"
 )
 
@@ -10,6 +11,19 @@ var (
 		Short: "Issue a reset to the given node(s)",
 		Long:  "This command will issue a reset to the given set of nodes.",
 		RunE:  CobraRunE,
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) != 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+
+			nodeDB, _ := node.New()
+			nodes, _ := nodeDB.FindAllNodes()
+			var node_names []string
+			for _, node := range nodes {
+				node_names = append(node_names, node.Id.Get())
+			}
+			return node_names, cobra.ShellCompDirectiveNoFileComp
+		},
 	}
 )
 

--- a/internal/app/wwctl/power/soft/root.go
+++ b/internal/app/wwctl/power/soft/root.go
@@ -1,6 +1,7 @@
 package powersoft
 
 import (
+	"github.com/hpcng/warewulf/internal/pkg/node"
 	"github.com/spf13/cobra"
 )
 
@@ -10,6 +11,19 @@ var (
 		Short: "Gracefully shuts down the given node(s)",
 		Long:  "This command will gracefully shutdown the given set of nodes.",
 		RunE:  CobraRunE,
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) != 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+
+			nodeDB, _ := node.New()
+			nodes, _ := nodeDB.FindAllNodes()
+			var node_names []string
+			for _, node := range nodes {
+				node_names = append(node_names, node.Id.Get())
+			}
+			return node_names, cobra.ShellCompDirectiveNoFileComp
+		},
 	}
 )
 

--- a/internal/app/wwctl/power/status/root.go
+++ b/internal/app/wwctl/power/status/root.go
@@ -1,6 +1,7 @@
 package powerstatus
 
 import (
+	"github.com/hpcng/warewulf/internal/pkg/node"
 	"github.com/spf13/cobra"
 )
 
@@ -10,6 +11,19 @@ var (
 		Short: "Show power status for the given node(s)",
 		Long:  "This command will show the power status of a given set of nodes.",
 		RunE:  CobraRunE,
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) != 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+
+			nodeDB, _ := node.New()
+			nodes, _ := nodeDB.FindAllNodes()
+			var node_names []string
+			for _, node := range nodes {
+				node_names = append(node_names, node.Id.Get())
+			}
+			return node_names, cobra.ShellCompDirectiveNoFileComp
+		},
 	}
 )
 

--- a/internal/app/wwctl/profile/set/root.go
+++ b/internal/app/wwctl/profile/set/root.go
@@ -1,6 +1,8 @@
 package set
 
 import (
+	"log"
+
 	"github.com/hpcng/warewulf/internal/pkg/container"
 	"github.com/hpcng/warewulf/internal/pkg/kernel"
 	"github.com/hpcng/warewulf/internal/pkg/node"
@@ -64,15 +66,19 @@ var (
 func init() {
 	baseCmd.PersistentFlags().StringVar(&SetComment, "comment", "", "Set a comment for this node")
 	baseCmd.PersistentFlags().StringVarP(&SetContainer, "container", "C", "", "Set the container (VNFS) for this node")
-	baseCmd.RegisterFlagCompletionFunc("container", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if err := baseCmd.RegisterFlagCompletionFunc("container", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		list, _ := container.ListSources()
 		return list, cobra.ShellCompDirectiveNoFileComp
-	})
+	}); err != nil {
+		log.Println(err)
+	}
 	baseCmd.PersistentFlags().StringVarP(&SetKernel, "kernel", "K", "", "Set Kernel version for nodes")
-	baseCmd.RegisterFlagCompletionFunc("kernel", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if err := baseCmd.RegisterFlagCompletionFunc("kernel", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		list, _ := kernel.ListKernels()
 		return list, cobra.ShellCompDirectiveNoFileComp
-	})
+	}); err != nil {
+		log.Println(err)
+	}
 	baseCmd.PersistentFlags().StringVarP(&SetKernelArgs, "kernelargs", "A", "", "Set Kernel argument for nodes")
 	baseCmd.PersistentFlags().StringVarP(&SetClusterName, "cluster", "c", "", "Set the node's cluster group")
 	baseCmd.PersistentFlags().StringVarP(&SetIpxe, "ipxe", "P", "", "Set the node's iPXE template name")
@@ -80,15 +86,20 @@ func init() {
 	baseCmd.PersistentFlags().StringVar(&SetRoot, "root", "", "Define the rootfs")
 
 	baseCmd.PersistentFlags().StringVarP(&SetRuntimeOverlay, "runtime", "R", "", "Set the node's runtime overlay")
-	baseCmd.RegisterFlagCompletionFunc("runtime", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if err := baseCmd.RegisterFlagCompletionFunc("runtime", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		list, _ := overlay.FindRuntimeOverlays()
 		return list, cobra.ShellCompDirectiveNoFileComp
-	})
+	}); err != nil {
+		log.Println(err)
+
+	}
 	baseCmd.PersistentFlags().StringVarP(&SetSystemOverlay, "system", "S", "", "Set the node's system overlay")
-	baseCmd.RegisterFlagCompletionFunc("system", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if err := baseCmd.RegisterFlagCompletionFunc("system", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		list, _ := overlay.FindSystemOverlays()
 		return list, cobra.ShellCompDirectiveNoFileComp
-	})
+	}); err != nil {
+		log.Println(err)
+	}
 	baseCmd.PersistentFlags().StringVar(&SetIpmiNetmask, "ipminetmask", "", "Set the node's IPMI netmask")
 	baseCmd.PersistentFlags().StringVar(&SetIpmiGateway, "ipmigateway", "", "Set the node's IPMI gateway")
 	baseCmd.PersistentFlags().StringVar(&SetIpmiUsername, "ipmiuser", "", "Set the node's IPMI username")


### PR DESCRIPTION
Adds dynamic nouns, so that e.g.
```
wwctl kernel delete <TAB><TAB>
```
will give you a list of the installed kernels. Works now for various subcommands.
