### PR TITLE
Add node list capability for users

### DIFF
--- a/etc/warewulf.conf
+++ b/etc/warewulf.conf
@@ -3,6 +3,7 @@ netmask: 255.255.255.0
 warewulf:
   port: 9873
   secure: true
+  disable info: false
   autobuild overlays: true
   update interval: 60
   syslog: false

--- a/internal/pkg/warewulfconf/datastructure.go
+++ b/internal/pkg/warewulfconf/datastructure.go
@@ -22,6 +22,7 @@ type ControllerConf struct {
 type WarewulfConf struct {
 	Port              int  `yaml:"port"`
 	Secure            bool `yaml:"secure"`
+	DisableInfo       bool `yaml:"disable info"`
 	UpdateInterval    int  `yaml:"update interval"`
 	AutobuildOverlays bool `yaml:"autobuild overlays"`
 	Syslog            bool `yaml:"syslog"`

--- a/internal/pkg/warewulfd/info.go
+++ b/internal/pkg/warewulfd/info.go
@@ -35,8 +35,9 @@ func InfoSend(w http.ResponseWriter, req *http.Request) {
 		stdout = []byte(err.Error() + "\n")
 	}
 
-	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "text/plain")
-	w.Write(stdout)
-	return
+	err := w.Write(stdout)
+	if err != nil {
+		daemonLogf("ERROR: %s\n", err)
+	}
 }

--- a/internal/pkg/warewulfd/info.go
+++ b/internal/pkg/warewulfd/info.go
@@ -36,7 +36,7 @@ func InfoSend(w http.ResponseWriter, req *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/plain")
-	err := w.Write(stdout)
+	_, err := w.Write(stdout)
 	if err != nil {
 		daemonLogf("ERROR: %s\n", err)
 	}

--- a/internal/pkg/warewulfd/info.go
+++ b/internal/pkg/warewulfd/info.go
@@ -1,0 +1,42 @@
+package warewulfd
+
+import (
+	"net/http"
+	"os/exec"
+	"strings"
+)
+
+func InfoSend(w http.ResponseWriter, req *http.Request) {
+
+	var cmd *exec.Cmd
+	url := strings.Split(req.URL.Path, "/")
+
+	if url[2] == "" {
+		daemonLogf("ERROR: Info request from %s missing argument\n", req.RemoteAddr)
+		w.WriteHeader(400)
+		return
+	}
+
+	switch url[2] {
+	case "nodes":
+		cmd = exec.Command("/usr/bin/wwctl", "node", "list")
+	case "ready":
+		cmd = exec.Command("/usr/bin/wwctl", "node", "ready")
+	default:
+		daemonLogf("ERROR: Unrecognized info request from %s\n", req.RemoteAddr)
+		w.WriteHeader(400)
+		return
+	}
+
+	stdout, err := cmd.CombinedOutput()
+
+	if err != nil {
+		daemonLogf("ERROR: wwctl exec error: " + err.Error() + "\n")
+		stdout = []byte(err.Error() + "\n")
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "text/plain")
+	w.Write(stdout)
+	return
+}

--- a/internal/pkg/warewulfd/warewulfd.go
+++ b/internal/pkg/warewulfd/warewulfd.go
@@ -34,16 +34,19 @@ func RunServer() error {
 		fmt.Printf("ERROR: Could not load database: %s\n", err)
 	}
 
+	conf, err := warewulfconf.New()
+	if err != nil {
+		return errors.Wrap(err, "could not get Warewulf configuration")
+	}
+
 	http.HandleFunc("/ipxe/", IpxeSend)
 	http.HandleFunc("/kernel/", KernelSend)
 	http.HandleFunc("/kmods/", KmodsSend)
 	http.HandleFunc("/container/", ContainerSend)
 	http.HandleFunc("/overlay-system/", SystemOverlaySend)
 	http.HandleFunc("/overlay-runtime/", RuntimeOverlaySend)
-
-	conf, err := warewulfconf.New()
-	if err != nil {
-		return errors.Wrap(err, "could not get Warewulf configuration")
+	if !conf.Warewulf.DisableInfo {
+		http.HandleFunc("/info/", InfoSend)
 	}
 
 	daemonPort := conf.Warewulf.Port


### PR DESCRIPTION
Signed-off-by: jcsiadal <jeremy.c.siadal@intel.com>

Assuming that wwctl remains locked down for users, this will provide the capability to warewaulfd to proxy pre-determined calls to wwctl. This adds the ability to print "node list" and "node ready" through HTTP. Users on any node could query using curl or wget. This feature could be easily expanded to include other unprivileged output.

I added a YAML element to turn off this feature. I used a system call instead of embedded functions to avoid the need for code duplication.