### PR TITLE
Some improvements for handling NFS mounts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/brotherpowers/ipsubnet v0.0.0-20170914094241-30bc98f0a5b1
 	github.com/containers/image/v5 v5.7.0
 	github.com/containers/storage v1.30.0
+	github.com/creasty/defaults v1.5.2
 	github.com/manifoldco/promptui v0.8.0
 	github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6
 	github.com/opencontainers/umoci v0.4.6

--- a/go.sum
+++ b/go.sum
@@ -212,6 +212,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creasty/defaults v1.5.2 h1:/VfB6uxpyp6h0fr7SPp7n8WJBoV8jfxQXPCnkVSjyls=
+github.com/creasty/defaults v1.5.2/go.mod h1:FPZ+Y0WNrbqOVw+c6av63eyHUAl6pMHZwqLPvXUZGfY=
 github.com/cyphar/filepath-securejoin v0.2.2 h1:jCwT2GTP+PY5nBz3c/YL5PAIbusElVrPujOBSCj8xRg=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1SMSibvLzxjeJLnrYEVLULFNiHY9YfQ=

--- a/internal/app/wwctl/configure/nfs/main.go
+++ b/internal/app/wwctl/configure/nfs/main.go
@@ -63,6 +63,13 @@ func Configure(show bool) error {
 				fmt.Fprintf(fstab, "%s:%s %s nfs defaults 0 0\n", controller.Ipaddr, export, export)
 			}
 
+			for _, export := range controller.Nfs.ExportsExtended {
+				fmt.Fprintf(exports, "%s %s/%s(%s)\n", export.Path, controller.Network, controller.Netmask, export.Options)
+				if export.Mount {
+					fmt.Fprintf(fstab, "%s:%s %s nfs defaults 0 0\n", controller.Ipaddr, export.Path, export.Path)
+				}
+			}
+
 			fmt.Printf("Enabling and restarting the NFS services\n")
 			if controller.Nfs.SystemdName == "" {
 				err := util.SystemdStart("nfs-server")
@@ -81,12 +88,17 @@ func Configure(show bool) error {
 		for _, export := range controller.Nfs.Exports {
 			fmt.Printf("%s %s/%s\n", export, controller.Network, controller.Netmask)
 		}
+		for _, export := range controller.Nfs.ExportsExtended {
+			fmt.Printf("%s %s/%s\n", export.Path, controller.Network, controller.Netmask)
+		}
 		fmt.Printf("\n")
 		fmt.Printf("SYSTEM OVERLAY: default/etc/fstab:\n")
 		for _, export := range controller.Nfs.Exports {
 			fmt.Printf("%s:%s %s nfs defaults 0 0\n", controller.Ipaddr, export, export)
 		}
-
+		for _, export := range controller.Nfs.ExportsExtended {
+			fmt.Printf("%s:%s %s nfs defaults 0 0\n", controller.Ipaddr, export.Path, export.Path)
+		}
 	}
 
 	return nil

--- a/internal/app/wwctl/configure/nfs/main.go
+++ b/internal/app/wwctl/configure/nfs/main.go
@@ -33,13 +33,6 @@ func Configure(show bool) error {
 	}
 
 	if !SetShow {
-		exports, err := os.OpenFile("/etc/exports", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
-		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "%s\n", err)
-			os.Exit(1)
-		}
-		defer exports.Close()
-
 		fstab, err := os.OpenFile("/var/warewulf/overlays/system/default/etc/fstab", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 		if err != nil {
 			wwlog.Printf(wwlog.ERROR, "%s\n", err)
@@ -47,7 +40,6 @@ func Configure(show bool) error {
 		}
 		defer fstab.Close()
 
-		fmt.Fprintf(exports, "# This file was written by Warewulf (wwctl configure nfs)\n")
 		fmt.Fprintf(fstab, "# This file was written by Warewulf (wwctl configure nfs)\n")
 
 		fmt.Fprintf(fstab, "rootfs / tmpfs defaults 0 0\n")
@@ -56,24 +48,34 @@ func Configure(show bool) error {
 		fmt.Fprintf(fstab, "sysfs /sys sysfs defaults 0 0\n")
 		fmt.Fprintf(fstab, "proc /proc proc defaults 0 0\n")
 
-		for _, export := range controller.Nfs.Exports {
-			fmt.Fprintf(exports, "%s %s/%s(sync)\n", export, controller.Network, controller.Netmask)
-			fmt.Fprintf(fstab, "%s:%s %s nfs defaults 0 0\n", controller.Ipaddr, export, export)
-		}
-
-		fmt.Printf("Enabling and restarting the NFS services\n")
-		if controller.Nfs.SystemdName == "" {
-			err := util.SystemdStart("nfs-server")
+		if controller.Nfs.Enabled {
+			exports, err := os.OpenFile("/etc/exports", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 			if err != nil {
-				return errors.Wrap(err, "failed to start nfs-server")
+				wwlog.Printf(wwlog.ERROR, "%s\n", err)
+				os.Exit(1)
 			}
-		} else {
-			err := util.SystemdStart(controller.Nfs.SystemdName)
-			if err != nil {
-				return errors.Wrap(err, "failed to start")
+			defer exports.Close()
+
+			fmt.Fprintf(exports, "# This file was written by Warewulf (wwctl configure nfs)\n")
+
+			for _, export := range controller.Nfs.Exports {
+				fmt.Fprintf(exports, "%s %s/%s(sync)\n", export, controller.Network, controller.Netmask)
+				fmt.Fprintf(fstab, "%s:%s %s nfs defaults 0 0\n", controller.Ipaddr, export, export)
+			}
+
+			fmt.Printf("Enabling and restarting the NFS services\n")
+			if controller.Nfs.SystemdName == "" {
+				err := util.SystemdStart("nfs-server")
+				if err != nil {
+					return errors.Wrap(err, "failed to start nfs-server")
+				}
+			} else {
+				err := util.SystemdStart(controller.Nfs.SystemdName)
+				if err != nil {
+					return errors.Wrap(err, "failed to start")
+				}
 			}
 		}
-
 	} else {
 		fmt.Printf("/etc/exports:\n")
 		for _, export := range controller.Nfs.Exports {

--- a/internal/pkg/warewulfconf/datastructure.go
+++ b/internal/pkg/warewulfconf/datastructure.go
@@ -3,6 +3,7 @@ package warewulfconf
 import (
 	"github.com/hpcng/warewulf/internal/pkg/util"
 	"github.com/hpcng/warewulf/internal/pkg/wwlog"
+	"github.com/creasty/defaults"
 )
 
 const ConfigFile = "/etc/warewulf/warewulf.conf"
@@ -43,10 +44,21 @@ type TftpConf struct {
 }
 
 type NfsConf struct {
-	Enabled     bool     `yaml:"enabled"`
+	Enabled     bool     `default:"true" yaml:"enabled"`
 	Exports     []string `yaml:"exports"`
 	ExportsExtended []*NfsExportConf `yaml:"exports extended"`
 	SystemdName string   `yaml:"systemd name"`
+}
+
+func (s *NfsConf) UnmarshalYAML(unmarshal func(interface{}) error) error {
+    defaults.Set(s)
+
+    type plain NfsConf
+    if err := unmarshal((*plain)(s)); err != nil {
+        return err
+    }
+
+    return nil
 }
 
 type NfsExportConf struct {

--- a/internal/pkg/warewulfconf/datastructure.go
+++ b/internal/pkg/warewulfconf/datastructure.go
@@ -45,7 +45,14 @@ type TftpConf struct {
 type NfsConf struct {
 	Enabled     bool     `yaml:"enabled"`
 	Exports     []string `yaml:"exports"`
+	ExportsExtended []*NfsExportConf `yaml:"exports extended"`
 	SystemdName string   `yaml:"systemd name"`
+}
+
+type NfsExportConf struct {
+	Path     string  `yaml:"path"`
+	Options  string  `yaml:"options"`
+	Mount    bool    `yaml:"mount"`
 }
 
 func init() {

--- a/internal/pkg/warewulfconf/datastructure.go
+++ b/internal/pkg/warewulfconf/datastructure.go
@@ -51,7 +51,9 @@ type NfsConf struct {
 }
 
 func (s *NfsConf) UnmarshalYAML(unmarshal func(interface{}) error) error {
-    defaults.Set(s)
+    if err := defaults.Set(s); err != nil {
+		return err
+	}
 
     type plain NfsConf
     if err := unmarshal((*plain)(s)); err != nil {


### PR DESCRIPTION
This fixes the bug where wwctl ignores the `enabled` option from `/etc/warewulf/warewulf.conf`, and also adds a new `NfsExtended` namespace to expose configuration of NFS mount options and static-fstab mounts.

Refs #183