### PR TITLE
Add GitHub action to build new release assets and upload them

### DIFF
--- a/.github/workflows/releasebuild.yml
+++ b/.github/workflows/releasebuild.yml
@@ -1,0 +1,88 @@
+---
+name: releasebuild
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+
+  distbuild:
+    name: Checkout code and build tar.gz
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set the version
+        id: version_number
+        run: |
+          echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+      - name: Set the git source location
+        id: source_loc
+        run: |
+          echo "SRC=${GITHUB_REF}" >> $GITHUB_ENV
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Install Go
+        uses: actions/setup-go@v2
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Build tar.gz
+        run: make dist
+      - name: Upload mock script
+        uses: actions/upload-artifact@v2
+        with:
+          name: mockbuild.sh
+          path: ci/mockbuild.sh
+      - name: Upload tar.gz
+        uses: actions/upload-artifact@v2
+        with:
+          name: warewulf-${{ env.VERSION }}.tar.gz
+          path: warewulf-${{ env.VERSION }}.tar.gz
+
+  rpmbuild:
+      name: Build using Rocky Linux
+      needs: distbuild
+      runs-on: ubuntu-latest
+      container: 
+        image: rockylinux/rockylinux
+        options: --privileged
+      steps:
+        - name: Set the version
+          id: version_number
+          run: |
+            echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+        - name: Download mock build script
+          uses: actions/download-artifact@v2
+          with:
+            name: mockbuild.sh
+        - name: Download tar.gz
+          uses: actions/download-artifact@v2
+          with:
+            name: warewulf-${{ env.VERSION }}.tar.gz
+        - name: Set execute bit
+          run: chmod +x mockbuild.sh
+        - name: Run rpm build script
+          run: ./mockbuild.sh  ${{ env.VERSION }}
+        - name: Upload EL8 RPM
+          uses: actions/upload-artifact@v2
+          with:
+            name: warewulf-${{ env.VERSION }}-${{ env.RELEASE }}.el8.x86_64.rpm
+            path: warewulf-${{ env.VERSION }}-${{ env.RELEASE }}.el8.x86_64.rpm
+        - name: Upload EL7 RPM
+          uses: actions/upload-artifact@v2
+          with:
+            name: warewulf-${{ env.VERSION }}-${{ env.RELEASE }}.el7.x86_64.rpm
+            path: warewulf-${{ env.VERSION }}-${{ env.RELEASE }}.el7.x86_64.rpm
+        - name: Upload Assets To Release
+          uses: xresloader/upload-to-github-release@master
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            file: 'warewulf-${{ env.VERSION }}.tar.gz;warewulf-${{ env.VERSION }}-${{ env.RELEASE }}.*.rpm'
+            draft: false
+            update_latest_release: true
+            tags: true

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,7 @@
 VERSION ?= 4.2.0
 RELEASE ?= 1
 
-ifndef SRC
-	SRC := main
-endif
+SRC ?= main
 
 # auto installed tooling
 TOOLS_DIR := .tools

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 .PHONY: all
 
 VERSION := 4.2.0
+RELEASE := 1
+
+ifndef SRC
+	SRC := main
+endif
 
 # auto installed tooling
 TOOLS_DIR := .tools
@@ -103,9 +108,9 @@ man_page:
 dist: vendor
 	rm -rf _dist/warewulf-$(VERSION)
 	mkdir -p _dist/warewulf-$(VERSION)
-	git archive --format=tar main | tar -xf - -C _dist/warewulf-$(VERSION)
+	git archive --format=tar $(SRC) | tar -xf - -C _dist/warewulf-$(VERSION)
 	cp -r vendor _dist/warewulf-$(VERSION)/
-	sed -e 's/@VERSION@/$(VERSION)/g' warewulf.spec.in > _dist/warewulf-$(VERSION)/warewulf.spec
+	sed -e 's/@VERSION@/$(VERSION)/g; s/@RELEASE@/$(RELEASE)/g' warewulf.spec.in > _dist/warewulf-$(VERSION)/warewulf.spec
 	cd _dist; tar -czf ../warewulf-$(VERSION).tar.gz warewulf-$(VERSION)
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all
 
-VERSION := 4.2.0
-RELEASE := 1
+VERSION ?= 4.2.0
+RELEASE ?= 1
 
 ifndef SRC
 	SRC := main

--- a/ci/mockbuild.sh
+++ b/ci/mockbuild.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/bash
+
+VERSION=$1
+
+dnf install -y epel-release
+dnf install -y mock
+
+tar -xf warewulf-${VERSION}.tar.gz warewulf-${VERSION}/warewulf.spec
+
+RELEASE=$(grep 'Release: ' warewulf-${VERSION}/warewulf.spec | cut -d ':' -f2 | awk -F'%' '{print $1}' | tr -d ' ')
+echo RELEASE=${RELEASE} >> $GITHUB_ENV
+
+mock -r epel-8-x86_64 --rebuild --spec=warewulf-${VERSION}/warewulf.spec --sources=.
+mv /var/lib/mock/epel-8-x86_64/result/warewulf-${VERSION}-${RELEASE}.el8.x86_64.rpm .
+
+mock -r epel-7-x86_64 --rebuild --spec=warewulf-${VERSION}/warewulf.spec --sources=.
+mv /var/lib/mock/epel-7-x86_64/result/warewulf-${VERSION}-${RELEASE}.el7.x86_64.rpm .

--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -3,7 +3,7 @@
 Name: warewulf
 Summary: A suite of tools for bare metal provisioning of containers
 Version: @VERSION@
-Release: 1%{?dist}
+Release: @RELEASE@%{?dist}
 License: BSD
 Source: https://github.com/hpcng/warewulf/archive/refs/tags/%{name}-%{version}.tar.gz
 ExclusiveOS: linux


### PR DESCRIPTION
When a new release is published, the GH workflow will:
- Build the distribution tarball
- Use the tarball to build el7 and el8 RPMS using mock on Rocky Linux
- Upload the tarball and RPMs to the release