### PR TITLE
use ctime instead of mtime to detect file owner/permission change

### DIFF
--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -27,9 +27,14 @@ func DirModTime(path string) (time.Time, error) {
 			return err
 		}
 
-		cur := info.ModTime()
+		fi, err := os.Stat(path)
+		if err != nil {
+			return err
+		}
+		stat := fi.Sys().(*syscall.Stat_t)
+		cur := time.Unix(int64(stat.Ctim.Sec), int64(stat.Ctim.Nsec))
 		if cur.After(lastTime) {
-			lastTime = info.ModTime()
+			lastTime = time.Unix(int64(stat.Ctim.Sec), int64(stat.Ctim.Nsec))
 		}
 
 		return nil

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -29,7 +29,7 @@ func DirModTime(path string) (time.Time, error) {
 
 		fi, err := os.Stat(path)
 		if err != nil {
-			return err
+			return nil
 		}
 		stat := fi.Sys().(*syscall.Stat_t)
 		cur := time.Unix(int64(stat.Ctim.Sec), int64(stat.Ctim.Nsec))


### PR DESCRIPTION
`wwctl container exec` doesn't detect file owner/permission change when exit and decide not to build VNFS(https://github.com/hpcng/warewulf/issues/193).

This request implemented to use 'ctime' instead of 'mtime' to detect owner/permission changes.


