### PR TITLE
Patch for RPM builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ files: all
 	install -d -m 0755 $(DESTDIR)/usr/share/man/man1
 	test -f $(DESTDIR)/etc/warewulf/warewulf.conf || install -m 644 etc/warewulf.conf $(DESTDIR)/etc/warewulf/
 	test -f $(DESTDIR)/etc/warewulf/hosts.tmpl || install -m 644 etc/hosts.tmpl $(DESTDIR)/etc/warewulf/
+	test -f $(DESTDIR)/etc/warewulf/nodes.conf || install -m 640 etc/nodes.conf $(DESTDIR)/etc/warewulf/
 	cp -r etc/dhcp $(DESTDIR)/etc/warewulf/
 	cp -r etc/ipxe $(DESTDIR)/etc/warewulf/
 	cp -r overlays $(DESTDIR)/var/warewulf/
@@ -74,12 +75,13 @@ files: all
 	install -c -m 0644 include/firewalld/warewulf.xml $(DESTDIR)/usr/lib/firewalld/services
 	mkdir -p $(DESTDIR)/usr/lib/systemd/system
 	install -c -m 0644 include/systemd/warewulfd.service $(DESTDIR)/usr/lib/systemd/system
-	./bash_completion  $(DESTDIR)/etc/bash_completion.d/warewulf
-	./man_page $(DESTDIR)/usr/share/man/man1
-	gzip --force $(DESTDIR)/usr/share/man/man1/wwctl*1
-#	systemctl daemon-reload
-#	cp -r tftpboot/* /var/lib/tftpboot/warewulf/ipxe/
-#	restorecon -r /var/lib/tftpboot/warewulf
+	cp etc/bash_completion.d/warewulf $(DESTDIR)/etc/bash_completion.d/
+	cp usr/share/man/man1/* $(DESTDIR)/usr/share/man/man1/
+
+init:
+	systemctl daemon-reload
+	cp -r tftpboot/* /var/lib/tftpboot/warewulf/ipxe/
+	restorecon -r /var/lib/tftpboot/warewulf
 
 debfiles: debian
 	chmod +x $(DESTDIR)/var/warewulf/overlays/system/debian/init
@@ -95,10 +97,15 @@ wwclient:
 	cd cmd/wwclient; CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -ldflags '-extldflags -static' -o ../../wwclient
 
 bash_completion:
-	cd cmd/bash_completion; go build -mod vendor -tags "$(WW_BUILD_GO_BUILD_TAGS)" -o ../../bash_completion
+	cd cmd/bash_completion && go build -mod vendor -tags "$(WW_BUILD_GO_BUILD_TAGS)" -o ../../bash_completion
+	install -d -m 0755 ./etc/bash_completion.d/
+	./bash_completion  ./etc/bash_completion.d/warewulf
 
 man_page:
-	cd cmd/man_page; go build -mod vendor -tags "$(WW_BUILD_GO_BUILD_TAGS)" -o ../../man_page
+	cd cmd/man_page && go build -mod vendor -tags "$(WW_BUILD_GO_BUILD_TAGS)" -o ../../man_page
+	install -d -m 0755 ./usr/share/man/man1
+	./man_page ./usr/share/man/man1
+	gzip --force ./usr/share/man/man1/wwctl*1
 
 dist: vendor
 	rm -rf _dist/warewulf-$(VERSION)

--- a/etc/nodes.conf
+++ b/etc/nodes.conf
@@ -1,0 +1,4 @@
+nodeprofiles:
+  default:
+    comment: This profile is automatically included for each node
+nodes: {}

--- a/internal/app/wwctl/overlay/build/root.go
+++ b/internal/app/wwctl/overlay/build/root.go
@@ -4,7 +4,7 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "build [flags] <overlay kind> <overlay name>",
+		Use:   "build [flags] (overlay kind) (overlay name)",
 		Short: "(Re)build an overlay",
 		Long:  "This command will build a system or runtime overlay.",
 		RunE:  CobraRunE,

--- a/internal/app/wwctl/overlay/chmod/root.go
+++ b/internal/app/wwctl/overlay/chmod/root.go
@@ -4,7 +4,7 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "chmod [flags] <overlay kind> <overlay name> <path> <mode>",
+		Use:   "chmod [flags] (overlay kind) (overlay name) (path) (mode)",
 		Short: "Change file permissions within an overlay",
 		Long: "This command will allow you to change the permissions of a file within an\n" +
 			"overlay.",

--- a/internal/app/wwctl/overlay/chown/root.go
+++ b/internal/app/wwctl/overlay/chown/root.go
@@ -4,7 +4,7 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "chown [flags] <overlay kind> <overlay name> <path> <UID> [<GID>]",
+		Use:   "chown [flags] (overlay kind) (overlay name) (path) (UID) [(GID)]",
 		Short: "Change file ownership within an overlay",
 		Long: "This command will allow you to change the ownership of a file within an\n" +
 			"overlay.",

--- a/internal/app/wwctl/overlay/create/root.go
+++ b/internal/app/wwctl/overlay/create/root.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "create [flags] <overlay kind> <overlay name>",
+		Use:   "create [flags] (overlay kind) (overlay name)",
 		Short: "Initialize a new Overlay",
 		Long:  "This command will create a new empty overlay.",
 		RunE:  CobraRunE,

--- a/internal/app/wwctl/overlay/delete/root.go
+++ b/internal/app/wwctl/overlay/delete/root.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "delete [flags] <overlay kind> <overlay name> [overlay file]",
+		Use:   "delete [flags] (overlay kind) (overlay name) [overlay file]",
 		Short: "Delete Warewulf Overlay or files",
 		Long: "This command will delete files within an overlay or an entire overlay if no\n" +
 			"files are given to remove (use with caution).",

--- a/internal/app/wwctl/overlay/edit/root.go
+++ b/internal/app/wwctl/overlay/edit/root.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "edit [flags] <overlay kind> <overlay name> <file path>",
+		Use:   "edit [flags] (overlay kind) (overlay name) (file path)",
 		Short: "Edit/Create a file within a Warewulf Overlay",
 		Long: "This command will allow you to edit or create a new file within a given\n" +
 			"overlay. Note: when creating files ending in a '.ww' suffix this will always be\n" +

--- a/internal/app/wwctl/overlay/imprt/root.go
+++ b/internal/app/wwctl/overlay/imprt/root.go
@@ -4,7 +4,7 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:     "import [flags] <overlay kind> <overlay name> <host source> [overlay target]",
+		Use:     "import [flags] (overlay kind) (overlay name) (host source) [overlay target]",
 		Short:   "Import a file into a Warewulf Overlay",
 		Long:    "This command will import a file into a given Warewulf overlay.",
 		RunE:    CobraRunE,

--- a/internal/app/wwctl/overlay/list/root.go
+++ b/internal/app/wwctl/overlay/list/root.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "list [flags] <overlay kind> [overlay name]",
+		Use:   "list [flags] (overlay kind) [overlay name]",
 		Short: "List Warewulf Overlays and files",
 		Long: "This command will show you information about Warewulf overlays and the\n" +
 			"files contained within.",

--- a/internal/app/wwctl/overlay/mkdir/root.go
+++ b/internal/app/wwctl/overlay/mkdir/root.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "mkdir [flags] <overlay kind> <overlay name> <directory path>",
+		Use:   "mkdir [flags] (overlay kind) (overlay name) (directory path)",
 		Short: "Create a new directory within an Overlay",
 		Long:  "This command will allow you to create a new file within a given Warewulf overlay.",
 		RunE:  CobraRunE,

--- a/internal/app/wwctl/overlay/show/root.go
+++ b/internal/app/wwctl/overlay/show/root.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "show [flags] <overlay kind> <overlay name> <overlay file>",
+		Use:   "show [flags] (overlay kind) (overlay name) (overlay file)",
 		Short: "Show (cat) a file within a Warewulf Overlay",
 		Long: "This command will output the contents of a file within a given\n" +
 			"Warewulf overlay.",

--- a/internal/app/wwctl/power/cycle/root.go
+++ b/internal/app/wwctl/power/cycle/root.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	powerCmd = &cobra.Command{
-		Use:   "cycle [flags] <node pattern>...",
+		Use:   "cycle [flags] (node pattern)...",
 		Short: "Power cycle the given node(s)",
 		Long:  "This command will cycle the power for a given set of nodes.",
 		RunE:  CobraRunE,

--- a/internal/app/wwctl/profile/add/root.go
+++ b/internal/app/wwctl/profile/add/root.go
@@ -4,7 +4,7 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "add <profile name>",
+		Use:   "add (profile name)",
 		Short: "Add a new node profile",
 		Long:  "This command will add a new node profile.",
 		RunE:  CobraRunE,

--- a/internal/app/wwctl/profile/delete/root.go
+++ b/internal/app/wwctl/profile/delete/root.go
@@ -4,7 +4,7 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "delete [flags] <profile pattern>",
+		Use:   "delete [flags] (profile pattern)",
 		Short: "Delete a node profile",
 		Long:  "This command will delete a node profile.",
 		RunE:  CobraRunE,

--- a/internal/app/wwctl/profile/set/root.go
+++ b/internal/app/wwctl/profile/set/root.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "set [flags] <profile pattern>...",
+		Use:   "set [flags] (profile pattern)...",
 		Short: "Configure node profile properties",
 		Long: "This command will allow you to set configuration properties for node profiles.\n\n" +
 			"Note: use the string 'UNSET' to remove a configuration",

--- a/internal/pkg/node/datastructure.go
+++ b/internal/pkg/node/datastructure.go
@@ -1,9 +1,6 @@
 package node
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/hpcng/warewulf/internal/pkg/util"
 	"github.com/hpcng/warewulf/internal/pkg/wwlog"
 )
@@ -104,22 +101,10 @@ type NetDevEntry struct {
 }
 
 func init() {
-	//TODO: Check to make sure nodes.conf is found
+	// Check that nodes.conf is found
 	if !util.IsFile(ConfigFile) {
-		c, err := os.OpenFile(ConfigFile, os.O_RDWR|os.O_CREATE, 0640)
-		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "Could not create new configuration file: %s\n", err)
-			// just return silently, as init is also called for bash_completion
-			return
-		}
-
-		fmt.Fprintf(c, "nodeprofiles:\n")
-		fmt.Fprintf(c, "  default:\n")
-		fmt.Fprintf(c, "    comment: This profile is automatically included for each node\n")
-		fmt.Fprintf(c, "nodes: {}\n")
-
-		c.Close()
-
-		wwlog.Printf(wwlog.INFO, "Created default node configuration\n")
+		wwlog.Printf(wwlog.WARN, "Missing node configuration file\n")
+		// just return silently, as init is also called for bash_completion
+		return
 	}
 }

--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -5,7 +5,7 @@
 Name: warewulf
 Summary: A provisioning system for large clusters of bare metal and/or virtual systems
 Version: @VERSION@
-Release: 1
+Release: 1%{?dist}
 License: BSD-3-Clause
 URL:     https://github.com/hpcng/warewulf
 Source:  https://github.com/hpcng/warewulf/archive/refs/tags/v%{version}.tar.gz

--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -1,74 +1,107 @@
+%global wwgroup warewulf
+%{!?wwshared: %global wwshared %{_localstatedir}}
 %define debug_package %{nil}
 
 Name: warewulf
-Summary: A suite of tools for bare metal provisioning of containers
+Summary: A provisioning system for large clusters of bare metal and/or virtual systems
 Version: @VERSION@
-Release: 1%{?dist}
-License: BSD
-Source: https://github.com/hpcng/warewulf/archive/refs/tags/%{name}-%{version}.tar.gz
+Release: 1
+License: BSD-3-Clause
+URL:     https://github.com/hpcng/warewulf
+Source:  https://github.com/hpcng/warewulf/archive/refs/tags/v%{version}.tar.gz
+
 ExclusiveOS: linux
 
+Conflicts: warewulf < 4
+Conflicts: warewulf-common
+Conflicts: warewulf-cluster
+Conflicts: warewulf-vnfs
+Conflicts: warewulf-provision
+Conflicts: warewulf-ipmi
+
 BuildRequires: make
-BuildRequires: golang
 
 %if 0%{?rhel}
 BuildRequires: systemd
+BuildRequires: golang
+Requires: tftp-server
+Requires: nfs-utils
 %else
+# sle_version
 BuildRequires: systemd-rpm-macros
+BuildRequires: go
+Requires: tftp
+Requires: nfs-kernel-server
 %endif
 
-%if 0%{?rhel} > 7
+%if 0%{?rhel} >= 8 || 0%{?sle_version}
 Requires: dhcp-server
 %else
+# rhel < 8
 Requires: dhcp
 %endif
 
-Requires: tftp-server
-Requires: nfs-utils
-
 %description
-Warewulf is a bare metal container provisioning system.
+Warewulf is a stateless and diskless container operating system provisioning
+system for large clusters of bare metal and/or virtual systems.
+
 
 %prep
-%setup -q
+%setup -q -n %{name}-%{version}
+
 
 %build
 make all
 
+
 %install
 %make_install DESTDIR=%{buildroot} %{?mflags_install}
 
+
 %pre
-getent group warewulf >/dev/null || groupadd -r warewulf
+getent group %{wwgroup} >/dev/null || groupadd -r %{wwgroup}
+
 
 %post
 %systemd_post warewulfd.service
 
+
 %preun
 %systemd_preun warewulfd.service
+
 
 %postun
 %systemd_postun_with_restart warewulfd.service
 
-%files
-%attr(0755, root, warewulf) %dir %{_sysconfdir}/%{name}
-%config(noreplace) %{_sysconfdir}/%{name}/*
 
+%files
+%defattr(-, root, %{wwgroup})
+%dir %{_sysconfdir}/%{name}
+%config(noreplace) %{_sysconfdir}/%{name}/*
+%config(noreplace) %attr(0640,-,-) %{_sysconfdir}/%{name}/nodes.conf
 %{_sysconfdir}/bash_completion.d/warewulf
 
-%{_bindir}/wwctl
+%dir %{wwshared}/%{name}
+%{wwshared}/%{name}/overlays/runtime/*
+%{wwshared}/%{name}/overlays/system/*
 
-%{_prefix}/lib/firewalld/services/warewulf.xml
-
-%{_unitdir}/warewulfd.service
-
-%attr(0755, root, warewulf) %dir %{_localstatedir}/%{name}
-%{_localstatedir}/%{name}/overlays/runtime/*
-%{_localstatedir}/%{name}/overlays/system/*
-
-%{_mandir}/man1/wwctl*
+%attr(-, root, root) %{_bindir}/wwctl
+%if 0%{?rhel}
+%attr(-, root, root) %{_prefix}/lib/firewalld/services/warewulf.xml
+%else
+# sle_version
+%attr(-, root, root) %{_libexecdir}/firewalld/services/warewulf.xml
+%endif
+%attr(-, root, root) %{_unitdir}/warewulfd.service
+%attr(-, root, root) %{_mandir}/man1/wwctl*
 
 %changelog
+* Mon Nov 1 2021 Jeremy Siadal <jeremy.c.siadal@intel.com> - 4.2.0-1
+- Add support for OpenSUSE
+- Update file attribs
+- Update license string
+- Make shared store relocatable
+
 * Fri Sep 24 2021 Michael L. Young <myoung@ciq.co> - 4.2.0-1
 - Update spec file to use systemd macros
 - Use macros to refer to system paths


### PR DESCRIPTION
These changes allow RPMs to build without errors or unwanted behavior.

- The GT/LT signs in help were simply swapped for parentheses to avoid the man page errors. The user output is correct now.
- Automatic node.conf generation was removed and replaced with a warning. It's nice to have autocreation, but it shouldn't be triggered when node information isn't needed. RPM assembly is done in BUILD subdirectory, yet before this patch, simply using go functions under pkg would trigger nodefile generation in system /etc.
- Man and bash completion generation were moved to %build. New content shouldn't be generated in %install; this is important when debugging rpmbuild.
- Lots of other changes to the specfile.