### PR TITLE
wwclient with node identification by hardware adresses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ files: all
 	install -d -m 0755 $(DESTDIR)/usr/share/man/man1
 	test -f $(DESTDIR)/etc/warewulf/warewulf.conf || install -m 644 etc/warewulf.conf $(DESTDIR)/etc/warewulf/
 	test -f $(DESTDIR)/etc/warewulf/hosts.tmpl || install -m 644 etc/hosts.tmpl $(DESTDIR)/etc/warewulf/
+	test -f $(DESTDIR)/etc/warewulf/nodes.conf || install -m 640 etc/nodes.conf $(DESTDIR)/etc/warewulf/
 	cp -r etc/dhcp $(DESTDIR)/etc/warewulf/
 	cp -r etc/ipxe $(DESTDIR)/etc/warewulf/
 	cp -r overlays $(DESTDIR)/var/warewulf/
@@ -74,12 +75,13 @@ files: all
 	install -c -m 0644 include/firewalld/warewulf.xml $(DESTDIR)/usr/lib/firewalld/services
 	mkdir -p $(DESTDIR)/usr/lib/systemd/system
 	install -c -m 0644 include/systemd/warewulfd.service $(DESTDIR)/usr/lib/systemd/system
-	./bash_completion  $(DESTDIR)/etc/bash_completion.d/warewulf
-	./man_page $(DESTDIR)/usr/share/man/man1
-	gzip --force $(DESTDIR)/usr/share/man/man1/wwctl*1
-#	systemctl daemon-reload
-#	cp -r tftpboot/* /var/lib/tftpboot/warewulf/ipxe/
-#	restorecon -r /var/lib/tftpboot/warewulf
+	cp etc/bash_completion.d/warewulf $(DESTDIR)/etc/bash_completion.d/
+	cp usr/share/man/man1/* $(DESTDIR)/usr/share/man/man1/
+
+init:
+	systemctl daemon-reload
+	cp -r tftpboot/* /var/lib/tftpboot/warewulf/ipxe/
+	restorecon -r /var/lib/tftpboot/warewulf
 
 debfiles: debian
 	chmod +x $(DESTDIR)/var/warewulf/overlays/system/debian/init
@@ -95,10 +97,15 @@ wwclient:
 	cd cmd/wwclient; CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -ldflags '-extldflags -static' -o ../../wwclient
 
 bash_completion:
-	cd cmd/bash_completion; go build -mod vendor -tags "$(WW_BUILD_GO_BUILD_TAGS)" -o ../../bash_completion
+	cd cmd/bash_completion && go build -mod vendor -tags "$(WW_BUILD_GO_BUILD_TAGS)" -o ../../bash_completion
+	install -d -m 0755 ./etc/bash_completion.d/
+	./bash_completion  ./etc/bash_completion.d/warewulf
 
 man_page:
-	cd cmd/man_page; go build -mod vendor -tags "$(WW_BUILD_GO_BUILD_TAGS)" -o ../../man_page
+	cd cmd/man_page && go build -mod vendor -tags "$(WW_BUILD_GO_BUILD_TAGS)" -o ../../man_page
+	install -d -m 0755 ./usr/share/man/man1
+	./man_page ./usr/share/man/man1
+	gzip --force ./usr/share/man/man1/wwctl*1
 
 dist: vendor
 	rm -rf _dist/warewulf-$(VERSION)

--- a/cmd/wwclient/datastructure.go
+++ b/cmd/wwclient/datastructure.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"net"
+	"net/url"
+)
+
+type DaemonConnection struct {
+	URL            url.URL
+	TCPAddr        net.TCPAddr
+	updateInterval int
+	Values         url.Values
+}

--- a/cmd/wwclient/methods.go
+++ b/cmd/wwclient/methods.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"fmt"
+	"github.com/hpcng/warewulf/internal/pkg/warewulfconf"
+	"github.com/hpcng/warewulf/internal/pkg/wwlog"
+	"github.com/pkg/errors"
+	"net"
+	"net/url"
+	"os"
+)
+
+func (c *DaemonConnection) init() {
+	c.Values = url.Values{}
+}
+
+func (c *DaemonConnection) AddInterfaces() error {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return errors.Wrap(err, "Failed to obtain network interfaces")
+	}
+	for _, i := range interfaces {
+		hwAddr := i.HardwareAddr.String()
+		if len(hwAddr) == 0 {
+			continue
+		}
+		c.Values.Add("hwAddr", hwAddr)
+	}
+	return err
+}
+
+func (c *DaemonConnection) AddHostname() error {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return errors.Wrap(err, "Failed to get hostname")
+	}
+	c.Values.Add("name", hostname)
+	return err
+}
+
+func (c *DaemonConnection) New() error {
+	conf, err := warewulfconf.New()
+	if err != nil {
+		return errors.Wrap(err, "Could not get Warewulf configuration")
+	}
+
+	c.updateInterval = conf.Warewulf.UpdateInterval
+
+	if conf.Warewulf.Secure {
+		c.TCPAddr.Port = 987
+	} else {
+		wwlog.Println(wwlog.WARN, "Running from an insecure port")
+	}
+
+	// build the URL
+	base := fmt.Sprintf("%s:%d", conf.Ipaddr, conf.Warewulf.Port)
+	c.URL = url.URL{Scheme: "http", Host: base}
+	c.URL.Path += "overlay-runtime"
+
+	wwlog.Printf(wwlog.DEBUG, "baseURL: %s", c.URL.String())
+
+	return err
+}

--- a/cmd/wwclient/methods_test.go
+++ b/cmd/wwclient/methods_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"net"
+	"net/url"
+	"testing"
+)
+
+func TestDaemonConnection_AddHostname(t *testing.T) {
+	type fields struct {
+		URL            url.URL
+		TCPAddr        net.TCPAddr
+		updateInterval int
+		Values         url.Values
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{"t1", fields{url.URL{Scheme: "http", Host: "test"}, net.TCPAddr{}, 10, url.Values{}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &DaemonConnection{
+				URL:            tt.fields.URL,
+				TCPAddr:        tt.fields.TCPAddr,
+				updateInterval: tt.fields.updateInterval,
+				Values:         tt.fields.Values,
+			}
+			if err := c.AddHostname(); (err != nil) != tt.wantErr {
+				t.Errorf("AddHostname() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDaemonConnection_AddInterfaces(t *testing.T) {
+	type fields struct {
+		URL            url.URL
+		TCPAddr        net.TCPAddr
+		updateInterval int
+		Values         url.Values
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{"t1", fields{url.URL{Scheme: "http", Host: "test"}, net.TCPAddr{}, 10, url.Values{}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &DaemonConnection{
+				URL:            tt.fields.URL,
+				TCPAddr:        tt.fields.TCPAddr,
+				updateInterval: tt.fields.updateInterval,
+				Values:         tt.fields.Values,
+			}
+			if err := c.AddInterfaces(); (err != nil) != tt.wantErr {
+				t.Errorf("AddInterfaces() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDaemonConnection_New(t *testing.T) {
+	type fields struct {
+		URL            url.URL
+		TCPAddr        net.TCPAddr
+		updateInterval int
+		Values         url.Values
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{"t1", fields{url.URL{}, net.TCPAddr{}, 10, url.Values{}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &DaemonConnection{
+				URL:            tt.fields.URL,
+				TCPAddr:        tt.fields.TCPAddr,
+				updateInterval: tt.fields.updateInterval,
+				Values:         tt.fields.Values,
+			}
+			if err := c.New(); (err != nil) != tt.wantErr {
+				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/cmd/wwclient/wwclient.go
+++ b/cmd/wwclient/wwclient.go
@@ -44,7 +44,6 @@ func main() {
 		wwlog.Printf(wwlog.ERROR, "Could not get Warewulf configuration: %s\n", err)
 		os.Exit(1)
 	}
-	fmt.Printf("conf: \n %v\n", conf)
 
 	localTCPAddr := net.TCPAddr{}
 	if conf.Warewulf.Secure {

--- a/cmd/wwclient/wwclient.go
+++ b/cmd/wwclient/wwclient.go
@@ -103,14 +103,13 @@ func main() {
 	}
 
 	// listen on SIGHUP
-	sigs := make(chan os.Signal)
+	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGHUP)
 
 	go func() {
-		for sig := range sigs {
-			wwlog.Printf(wwlog.INFO, "Received SIGNAL: %s\n", sig)
-			updateSystem(webclient, *conn)
-		}
+		s := <-sigs
+		wwlog.Printf(wwlog.INFO, "Received SIGNAL: %s\n", s)
+		updateSystem(webclient, *conn)
 	}()
 
 	for {

--- a/cmd/wwclient/wwclient.go
+++ b/cmd/wwclient/wwclient.go
@@ -29,7 +29,7 @@ func (c *DaemonConnection) init() {
 func (c *DaemonConnection) AddInterfaces() error {
 	interfaces, err := net.Interfaces()
 	if err != nil {
-		return errors.Wrap(err, "failed to obtain network interfaces")
+		return errors.Wrap(err, "Failed to obtain network interfaces")
 	}
 	for _, i := range interfaces {
 		hwAddr := i.HardwareAddr.String()
@@ -44,7 +44,7 @@ func (c *DaemonConnection) AddInterfaces() error {
 func (c *DaemonConnection) AddHostname() error {
 	hostname, err := os.Hostname()
 	if err != nil {
-		return errors.Wrap(err, "failed to get hostname")
+		return errors.Wrap(err, "Failed to get hostname")
 	}
 	c.Values.Add("name", hostname)
 	return err
@@ -76,18 +76,18 @@ func (c *DaemonConnection) New() error {
 
 func NewDaemonConnection() (*DaemonConnection, error) {
 	ret := DaemonConnection{}
+	ret.init()
 	err := ret.New()
 	if err != nil {
-		return &DaemonConnection{}, errors.Wrap(err, "failed to prepare daemon connection")
+		return &DaemonConnection{}, errors.Wrap(err, "Failed to prepare daemon connection")
 	}
-	ret.init()
 	return &ret, err
 }
 
 func runProductionEnv() error {
 	err := os.Chdir("/")
 	if err != nil {
-		return errors.Wrap(err, "failed to change dir")
+		return errors.Wrap(err, "Failed to change dir")
 	}
 	wwlog.Println(wwlog.WARN, "Updating live file system LIVE, cancel now if this is in error")
 	time.Sleep(5000 * time.Millisecond)
@@ -99,12 +99,12 @@ func runTestEnv() error {
 	wwlog.Println(wwlog.WARN, "Runtime overlay is being put in '/warewulf/wwclient-test' rather than '/'")
 	err := os.MkdirAll("/warewulf/wwclient-test", 0755)
 	if err != nil {
-		return errors.Wrap(err, "failed to create dir")
+		return errors.Wrap(err, "Failed to create dir")
 	}
 
 	err = os.Chdir("/warewulf/wwclient-test")
 	if err != nil {
-		return errors.Wrap(err, "failed to change dir")
+		return errors.Wrap(err, "Failed to change dir")
 	}
 	return nil
 }
@@ -114,32 +114,32 @@ func main() {
 	if os.Args[0] == "/warewulf/bin/wwclient" {
 		err := runProductionEnv()
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "failed to run in production environment: %s\n", err)
+			wwlog.Printf(wwlog.ERROR, "Failed to run in production environment: %s\n", err)
 			return
 		}
 	} else {
 		err := runTestEnv()
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "failed to run in test environment: %s\n", err)
+			wwlog.Printf(wwlog.ERROR, "Failed to run in test environment: %s\n", err)
 			return
 		}
 	}
 
 	conn, err := NewDaemonConnection()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "failed to create daemon connection: %s\n", err)
+		wwlog.Printf(wwlog.ERROR, "Failed to create daemon connection: %s\n", err)
 		return
 	}
 
 	err = conn.AddHostname()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "failed to add hostname to query string: %s\n", err)
+		wwlog.Printf(wwlog.ERROR, "Failed to add hostname to query string: %s\n", err)
 		return
 	}
 
 	err = conn.AddInterfaces()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "failed to add interfaces to query string: %s\n", err)
+		wwlog.Printf(wwlog.ERROR, "Failed to add interfaces to query string: %s\n", err)
 		return
 	}
 
@@ -195,7 +195,7 @@ func main() {
 		command.Stdin = resp.Body
 		err := command.Run()
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "ERROR: Failed running CPIO: %s\n", err)
+			wwlog.Printf(wwlog.ERROR, "Failed running CPIO: %s\n", err)
 		}
 
 		if conn.updateInterval > 0 {

--- a/cmd/wwclient/wwclient.go
+++ b/cmd/wwclient/wwclient.go
@@ -1,80 +1,19 @@
 package main
 
 import (
-	"fmt"
-	"github.com/pkg/errors"
 	"log"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
 	"syscall"
 	"time"
 
-	"github.com/hpcng/warewulf/internal/pkg/warewulfconf"
+	"github.com/pkg/errors"
+
 	"github.com/hpcng/warewulf/internal/pkg/wwlog"
 )
-
-type DaemonConnection struct {
-	URL            url.URL
-	TCPAddr        net.TCPAddr
-	updateInterval int
-	Values         url.Values
-}
-
-func (c *DaemonConnection) init() {
-	c.Values = url.Values{}
-}
-
-func (c *DaemonConnection) AddInterfaces() error {
-	interfaces, err := net.Interfaces()
-	if err != nil {
-		return errors.Wrap(err, "Failed to obtain network interfaces")
-	}
-	for _, i := range interfaces {
-		hwAddr := i.HardwareAddr.String()
-		if len(hwAddr) == 0 {
-			continue
-		}
-		c.Values.Add("hwAddr", hwAddr)
-	}
-	return err
-}
-
-func (c *DaemonConnection) AddHostname() error {
-	hostname, err := os.Hostname()
-	if err != nil {
-		return errors.Wrap(err, "Failed to get hostname")
-	}
-	c.Values.Add("name", hostname)
-	return err
-}
-
-func (c *DaemonConnection) New() error {
-	conf, err := warewulfconf.New()
-	if err != nil {
-		return errors.Wrap(err, "Could not get Warewulf configuration")
-	}
-
-	c.updateInterval = conf.Warewulf.UpdateInterval
-
-	if conf.Warewulf.Secure {
-		c.TCPAddr.Port = 987
-	} else {
-		wwlog.Println(wwlog.WARN, "Running from an insecure port")
-	}
-
-	// build the URL
-	base := fmt.Sprintf("%s:%d", conf.Ipaddr, conf.Warewulf.Port)
-	c.URL = url.URL{Scheme: "http", Host: base}
-	c.URL.Path += "overlay-runtime"
-
-	wwlog.Printf(wwlog.DEBUG, "baseURL: %s", c.URL.String())
-
-	return err
-}
 
 func NewDaemonConnection() (*DaemonConnection, error) {
 	ret := DaemonConnection{}

--- a/etc/nodes.conf
+++ b/etc/nodes.conf
@@ -1,0 +1,4 @@
+nodeprofiles:
+  default:
+    comment: This profile is automatically included for each node
+nodes: {}

--- a/internal/app/wwctl/overlay/build/root.go
+++ b/internal/app/wwctl/overlay/build/root.go
@@ -4,7 +4,7 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "build [flags] <overlay kind> <overlay name>",
+		Use:   "build [flags] (overlay kind) (overlay name)",
 		Short: "(Re)build an overlay",
 		Long:  "This command will build a system or runtime overlay.",
 		RunE:  CobraRunE,

--- a/internal/app/wwctl/overlay/chmod/root.go
+++ b/internal/app/wwctl/overlay/chmod/root.go
@@ -4,7 +4,7 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "chmod [flags] <overlay kind> <overlay name> <path> <mode>",
+		Use:   "chmod [flags] (overlay kind) (overlay name) (path) (mode)",
 		Short: "Change file permissions within an overlay",
 		Long: "This command will allow you to change the permissions of a file within an\n" +
 			"overlay.",

--- a/internal/app/wwctl/overlay/chown/root.go
+++ b/internal/app/wwctl/overlay/chown/root.go
@@ -4,7 +4,7 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "chown [flags] <overlay kind> <overlay name> <path> <UID> [<GID>]",
+		Use:   "chown [flags] (overlay kind) (overlay name) (path) (UID) [(GID)]",
 		Short: "Change file ownership within an overlay",
 		Long: "This command will allow you to change the ownership of a file within an\n" +
 			"overlay.",

--- a/internal/app/wwctl/overlay/create/root.go
+++ b/internal/app/wwctl/overlay/create/root.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "create [flags] <overlay kind> <overlay name>",
+		Use:   "create [flags] (overlay kind) (overlay name)",
 		Short: "Initialize a new Overlay",
 		Long:  "This command will create a new empty overlay.",
 		RunE:  CobraRunE,

--- a/internal/app/wwctl/overlay/delete/root.go
+++ b/internal/app/wwctl/overlay/delete/root.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "delete [flags] <overlay kind> <overlay name> [overlay file]",
+		Use:   "delete [flags] (overlay kind) (overlay name) [overlay file]",
 		Short: "Delete Warewulf Overlay or files",
 		Long: "This command will delete files within an overlay or an entire overlay if no\n" +
 			"files are given to remove (use with caution).",

--- a/internal/app/wwctl/overlay/edit/root.go
+++ b/internal/app/wwctl/overlay/edit/root.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "edit [flags] <overlay kind> <overlay name> <file path>",
+		Use:   "edit [flags] (overlay kind) (overlay name) (file path)",
 		Short: "Edit/Create a file within a Warewulf Overlay",
 		Long: "This command will allow you to edit or create a new file within a given\n" +
 			"overlay. Note: when creating files ending in a '.ww' suffix this will always be\n" +

--- a/internal/app/wwctl/overlay/imprt/root.go
+++ b/internal/app/wwctl/overlay/imprt/root.go
@@ -4,7 +4,7 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:     "import [flags] <overlay kind> <overlay name> <host source> [overlay target]",
+		Use:     "import [flags] (overlay kind) (overlay name) (host source) [overlay target]",
 		Short:   "Import a file into a Warewulf Overlay",
 		Long:    "This command will import a file into a given Warewulf overlay.",
 		RunE:    CobraRunE,

--- a/internal/app/wwctl/overlay/list/root.go
+++ b/internal/app/wwctl/overlay/list/root.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "list [flags] <overlay kind> [overlay name]",
+		Use:   "list [flags] (overlay kind) [overlay name]",
 		Short: "List Warewulf Overlays and files",
 		Long: "This command will show you information about Warewulf overlays and the\n" +
 			"files contained within.",

--- a/internal/app/wwctl/overlay/mkdir/root.go
+++ b/internal/app/wwctl/overlay/mkdir/root.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "mkdir [flags] <overlay kind> <overlay name> <directory path>",
+		Use:   "mkdir [flags] (overlay kind) (overlay name) (directory path)",
 		Short: "Create a new directory within an Overlay",
 		Long:  "This command will allow you to create a new file within a given Warewulf overlay.",
 		RunE:  CobraRunE,

--- a/internal/app/wwctl/overlay/show/root.go
+++ b/internal/app/wwctl/overlay/show/root.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "show [flags] <overlay kind> <overlay name> <overlay file>",
+		Use:   "show [flags] (overlay kind) (overlay name) (overlay file)",
 		Short: "Show (cat) a file within a Warewulf Overlay",
 		Long: "This command will output the contents of a file within a given\n" +
 			"Warewulf overlay.",

--- a/internal/app/wwctl/power/cycle/root.go
+++ b/internal/app/wwctl/power/cycle/root.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	powerCmd = &cobra.Command{
-		Use:   "cycle [flags] <node pattern>...",
+		Use:   "cycle [flags] (node pattern)...",
 		Short: "Power cycle the given node(s)",
 		Long:  "This command will cycle the power for a given set of nodes.",
 		RunE:  CobraRunE,

--- a/internal/app/wwctl/profile/add/root.go
+++ b/internal/app/wwctl/profile/add/root.go
@@ -4,7 +4,7 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "add <profile name>",
+		Use:   "add (profile name)",
 		Short: "Add a new node profile",
 		Long:  "This command will add a new node profile.",
 		RunE:  CobraRunE,

--- a/internal/app/wwctl/profile/delete/root.go
+++ b/internal/app/wwctl/profile/delete/root.go
@@ -4,7 +4,7 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "delete [flags] <profile pattern>",
+		Use:   "delete [flags] (profile pattern)",
 		Short: "Delete a node profile",
 		Long:  "This command will delete a node profile.",
 		RunE:  CobraRunE,

--- a/internal/app/wwctl/profile/set/root.go
+++ b/internal/app/wwctl/profile/set/root.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "set [flags] <profile pattern>...",
+		Use:   "set [flags] (profile pattern)...",
 		Short: "Configure node profile properties",
 		Long: "This command will allow you to set configuration properties for node profiles.\n\n" +
 			"Note: use the string 'UNSET' to remove a configuration",

--- a/internal/pkg/node/constructors.go
+++ b/internal/pkg/node/constructors.go
@@ -1,15 +1,13 @@
 package node
 
 import (
+	"errors"
 	"fmt"
+	"github.com/hpcng/warewulf/internal/pkg/wwlog"
+	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"sort"
 	"strings"
-
-	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
-
-	"github.com/hpcng/warewulf/internal/pkg/wwlog"
 )
 
 const ConfigFile = "/etc/warewulf/nodes.conf"
@@ -265,36 +263,4 @@ func (config *nodeYaml) FindDiscoverableNode() (NodeInfo, string, error) {
 	}
 
 	return ret, "", errors.New("No unconfigured nodes found")
-}
-
-func (config *nodeYaml) FindByHwaddr(hwa string) (NodeInfo, error) {
-	var ret NodeInfo
-
-	n, _ := config.FindAllNodes()
-
-	for _, node := range n {
-		for _, dev := range node.NetDevs {
-			if dev.Hwaddr.Get() == hwa {
-				return node, nil
-			}
-		}
-	}
-
-	return ret, errors.New("No nodes found with HW Addr: " + hwa)
-}
-
-func (config *nodeYaml) FindByIpaddr(ipaddr string) (NodeInfo, error) {
-	var ret NodeInfo
-
-	n, _ := config.FindAllNodes()
-
-	for _, node := range n {
-		for _, dev := range node.NetDevs {
-			if dev.Ipaddr.Get() == ipaddr {
-				return node, nil
-			}
-		}
-	}
-
-	return ret, errors.New("No nodes found with IP Addr: " + ipaddr)
 }

--- a/internal/pkg/node/datastructure.go
+++ b/internal/pkg/node/datastructure.go
@@ -1,9 +1,6 @@
 package node
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/hpcng/warewulf/internal/pkg/util"
 	"github.com/hpcng/warewulf/internal/pkg/wwlog"
 )
@@ -104,22 +101,10 @@ type NetDevEntry struct {
 }
 
 func init() {
-	//TODO: Check to make sure nodes.conf is found
+	// Check that nodes.conf is found
 	if !util.IsFile(ConfigFile) {
-		c, err := os.OpenFile(ConfigFile, os.O_RDWR|os.O_CREATE, 0640)
-		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "Could not create new configuration file: %s\n", err)
-			// just return silently, as init is also called for bash_completion
-			return
-		}
-
-		fmt.Fprintf(c, "nodeprofiles:\n")
-		fmt.Fprintf(c, "  default:\n")
-		fmt.Fprintf(c, "    comment: This profile is automatically included for each node\n")
-		fmt.Fprintf(c, "nodes: {}\n")
-
-		c.Close()
-
-		wwlog.Printf(wwlog.INFO, "Created default node configuration\n")
+		wwlog.Printf(wwlog.WARN, "Missing node configuration file\n")
+		// just return silently, as init is also called for bash_completion
+		return
 	}
 }

--- a/internal/pkg/node/util.go
+++ b/internal/pkg/node/util.go
@@ -1,0 +1,47 @@
+package node
+
+import (
+	"errors"
+	"net"
+	"strings"
+)
+
+func (config *nodeYaml) FindByHwaddr(hwa string) (NodeInfo, error) {
+	if _, err := net.ParseMAC(hwa); err != nil {
+		return NodeInfo{}, errors.New("invalid hardware address: " + hwa)
+	}
+
+	var ret NodeInfo
+
+	n, _ := config.FindAllNodes()
+
+	for _, node := range n {
+		for _, dev := range node.NetDevs {
+			if strings.EqualFold(dev.Hwaddr.Get(), hwa) {
+				return node, nil
+			}
+		}
+	}
+
+	return ret, errors.New("No nodes found with HW Addr: " + hwa)
+}
+
+func (config *nodeYaml) FindByIpaddr(ipaddr string) (NodeInfo, error) {
+	if net.ParseIP(ipaddr) == nil {
+		return NodeInfo{}, errors.New("invalid IP:" + ipaddr)
+	}
+
+	var ret NodeInfo
+
+	n, _ := config.FindAllNodes()
+
+	for _, node := range n {
+		for _, dev := range node.NetDevs {
+			if dev.Ipaddr.Get() == ipaddr {
+				return node, nil
+			}
+		}
+	}
+
+	return ret, errors.New("No nodes found with IP Addr: " + ipaddr)
+}

--- a/internal/pkg/node/util_test.go
+++ b/internal/pkg/node/util_test.go
@@ -1,0 +1,135 @@
+package node
+
+import (
+	"gopkg.in/yaml.v2"
+	"testing"
+)
+
+func NewTestNode() (nodeYaml, error) {
+	var data = `
+nodeprofiles:
+  default:
+    comment: This profile is automatically included for each node
+nodes:
+  test_node:
+    profiles:
+    - default
+    network devices:
+      eth0:
+        default: true
+        hwaddr: 00:00:00:00:12:34
+        ipaddr: 1.2.3.4
+        ipcidr: ""
+        prefix: ""
+        netmask: ""
+      eno1:
+        default: true
+        hwaddr: ab:cd:ef:00:12:34
+        ipaddr: 1.2.3.4
+        ipcidr: ""
+        prefix: ""
+        netmask: ""
+      eno2:
+        default: true
+        hwaddr: aB:Cd:eF:12:34:56
+        ipaddr: 1.2.3.4
+        ipcidr: ""
+        prefix: ""
+        netmask: ""
+  test_node_IPv6:
+    profiles:
+    - default
+    network devices:
+      eth1:
+        default: false
+        hwaddr: ""
+        ipaddr: fd1a:2b3c:4d5e:06f0:1234:5678:90ab:cdef
+        ipcidr: ""
+        prefix: ""
+        netmask: ""
+`
+	var ret nodeYaml
+	err := yaml.Unmarshal([]byte(data), &ret)
+	if err != nil {
+		return ret, err
+	}
+	return ret, nil
+}
+
+func Test_nodeYaml_FindByHwaddr(t *testing.T) {
+	c, _ := NewTestNode()
+	//type fields struct {
+	//	NodeProfiles map[string]*NodeConf
+	//	Nodes        map[string]*NodeConf
+	//}
+	type args struct {
+		hwa string
+	}
+	tests := []struct {
+		name string
+		//fields  fields
+		config  nodeYaml
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{"emptyString", c, args{hwa: ""}, "", true},
+		{"noIpString", c, args{hwa: "this is not a MAC"}, "", true},
+		{"intString", c, args{hwa: "4294967296"}, "", true},
+		{"invalidMAC", c, args{hwa: "xx:00:00:00:12:34"}, "", true},
+		{"validMACNotFound", c, args{hwa: "aa:FF:ee:65:43:21"}, "", true},
+		{"validMAC", c, args{hwa: "ab:cd:ef:00:12:34"}, "test_node", false},
+		{"validMAC2", c, args{hwa: "aB:Cd:eF:00:12:34"}, "test_node", false},
+		{"validMAC3", c, args{hwa: "Ab:cD:Ef:12:34:56"}, "test_node", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := tt.config
+			got, err := config.FindByHwaddr(tt.args.hwa)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FindByHwaddr() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !(got.Id.Get() == tt.want) {
+				t.Errorf("FindByHwaddr() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_nodeYaml_FindByIpaddr(t *testing.T) {
+	c, _ := NewTestNode()
+	type args struct {
+		ipaddr string
+	}
+	tests := []struct {
+		name    string
+		config  nodeYaml
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{"emptyString", c, args{ipaddr: ""}, "", true},
+		{"noIpString", c, args{ipaddr: "this is not an IP"}, "", true},
+		{"intString", c, args{ipaddr: "4294967296"}, "", true},
+		{"invalidIPv4", c, args{ipaddr: "1.2.3.256"}, "", true},
+		{"invalidIPv6", c, args{ipaddr: "xd1a:2b3c:4d5e:06f0:1234:5678:90ab:cdef"}, "", true},
+		{"validIPv4NotFound", c, args{ipaddr: "1.1.1.1"}, "", true},
+		{"validIPv6NotFound", c, args{ipaddr: "fd1a:2b3c:4d5e:06f0:1234:5678:90ab:fedc"}, "", true},
+		{"validIPv4", c, args{ipaddr: "1.2.3.4"}, "test_node", false},
+		{"validIPv6", c, args{ipaddr: "fd1a:2b3c:4d5e:06f0:1234:5678:90ab:cdef"}, "test_node_IPv6", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := tt.config
+			got, err := config.FindByIpaddr(tt.args.ipaddr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FindByIpaddr() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !(got.Id.Get() == tt.want) {
+				t.Errorf("FindByHwaddr() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/pkg/warewulfconf/datastructure.go
+++ b/internal/pkg/warewulfconf/datastructure.go
@@ -25,6 +25,7 @@ type WarewulfConf struct {
 	UpdateInterval    int  `yaml:"update interval"`
 	AutobuildOverlays bool `yaml:"autobuild overlays"`
 	Syslog            bool `yaml:"syslog"`
+	MacIdentify       bool `yaml:"MAC identification"`
 }
 
 type DhcpConf struct {

--- a/internal/pkg/warewulfd/util.go
+++ b/internal/pkg/warewulfd/util.go
@@ -89,7 +89,7 @@ func sendFile(w http.ResponseWriter, filename string, sendto string) error {
 	defer func(fd *os.File) {
 		err := fd.Close()
 		if err != nil {
-
+            daemonLogf("failed to close file: %s", err)
 		}
 	}(fd)
 

--- a/internal/pkg/warewulfd/util_test.go
+++ b/internal/pkg/warewulfd/util_test.go
@@ -24,8 +24,10 @@ func Test_getHostPort(t *testing.T) {
 	}{
 		{"IPv4", args{w, req}, "10.0.0.1:987", "10.0.0.1", 987, false},
 		{"IPv4noPort", args{w, req}, "10.0.0.1", "", 0, true},
+		{"IPv4noInt", args{w, req}, "10.0.0.1:foo", "10.0.0.1", 0, true},
 		{"IPv6", args{w, req}, "[::ffff:192.0.2.128]:8080", "::ffff:192.0.2.128", 8080, false},
 		{"IPv6noBrackets", args{w, req}, "::ffff:192.0.2.128:8080", "", 0, true},
+		{"IPv6", args{w, req}, "[::ffff:192.0.2.128]:foo", "::ffff:192.0.2.128", 0, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/pkg/warewulfd/util_test.go
+++ b/internal/pkg/warewulfd/util_test.go
@@ -1,0 +1,46 @@
+package warewulfd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func Test_getHostPort(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/upper?word=abc", nil)
+	w := httptest.NewRecorder()
+
+	type args struct {
+		w   http.ResponseWriter
+		req *http.Request
+	}
+	tests := []struct {
+		name       string
+		args       args
+		RemoteAddr string
+		hostIP     string
+		port       int
+		wantErr    bool
+	}{
+		{"IPv4", args{w, req}, "10.0.0.1:987", "10.0.0.1", 987, false},
+		{"IPv4noPort", args{w, req}, "10.0.0.1", "", 0, true},
+		{"IPv6", args{w, req}, "[::ffff:192.0.2.128]:8080", "::ffff:192.0.2.128", 8080, false},
+		{"IPv6noBrackets", args{w, req}, "::ffff:192.0.2.128:8080", "", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.args.req.RemoteAddr = tt.RemoteAddr
+			got, got1, err := getHostPort(tt.args.w, tt.args.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getHostPort() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.hostIP {
+				t.Errorf("getHostPort() got = %v, hostIP %v", got, tt.hostIP)
+			}
+			if got1 != tt.port {
+				t.Errorf("getHostPort() got1 = %v, hostIP %v", got1, tt.port)
+			}
+		})
+	}
+}

--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -1,74 +1,107 @@
+%global wwgroup warewulf
+%{!?wwshared: %global wwshared %{_localstatedir}}
 %define debug_package %{nil}
 
 Name: warewulf
-Summary: A suite of tools for bare metal provisioning of containers
+Summary: A provisioning system for large clusters of bare metal and/or virtual systems
 Version: @VERSION@
 Release: 1%{?dist}
-License: BSD
-Source: https://github.com/hpcng/warewulf/archive/refs/tags/%{name}-%{version}.tar.gz
+License: BSD-3-Clause
+URL:     https://github.com/hpcng/warewulf
+Source:  https://github.com/hpcng/warewulf/archive/refs/tags/v%{version}.tar.gz
+
 ExclusiveOS: linux
 
+Conflicts: warewulf < 4
+Conflicts: warewulf-common
+Conflicts: warewulf-cluster
+Conflicts: warewulf-vnfs
+Conflicts: warewulf-provision
+Conflicts: warewulf-ipmi
+
 BuildRequires: make
-BuildRequires: golang
 
 %if 0%{?rhel}
 BuildRequires: systemd
+BuildRequires: golang
+Requires: tftp-server
+Requires: nfs-utils
 %else
+# sle_version
 BuildRequires: systemd-rpm-macros
+BuildRequires: go
+Requires: tftp
+Requires: nfs-kernel-server
 %endif
 
-%if 0%{?rhel} > 7
+%if 0%{?rhel} >= 8 || 0%{?sle_version}
 Requires: dhcp-server
 %else
+# rhel < 8
 Requires: dhcp
 %endif
 
-Requires: tftp-server
-Requires: nfs-utils
-
 %description
-Warewulf is a bare metal container provisioning system.
+Warewulf is a stateless and diskless container operating system provisioning
+system for large clusters of bare metal and/or virtual systems.
+
 
 %prep
-%setup -q
+%setup -q -n %{name}-%{version}
+
 
 %build
 make all
 
+
 %install
 %make_install DESTDIR=%{buildroot} %{?mflags_install}
 
+
 %pre
-getent group warewulf >/dev/null || groupadd -r warewulf
+getent group %{wwgroup} >/dev/null || groupadd -r %{wwgroup}
+
 
 %post
 %systemd_post warewulfd.service
 
+
 %preun
 %systemd_preun warewulfd.service
+
 
 %postun
 %systemd_postun_with_restart warewulfd.service
 
-%files
-%attr(0755, root, warewulf) %dir %{_sysconfdir}/%{name}
-%config(noreplace) %{_sysconfdir}/%{name}/*
 
+%files
+%defattr(-, root, %{wwgroup})
+%dir %{_sysconfdir}/%{name}
+%config(noreplace) %{_sysconfdir}/%{name}/*
+%config(noreplace) %attr(0640,-,-) %{_sysconfdir}/%{name}/nodes.conf
 %{_sysconfdir}/bash_completion.d/warewulf
 
-%{_bindir}/wwctl
+%dir %{wwshared}/%{name}
+%{wwshared}/%{name}/overlays/runtime/*
+%{wwshared}/%{name}/overlays/system/*
 
-%{_prefix}/lib/firewalld/services/warewulf.xml
-
-%{_unitdir}/warewulfd.service
-
-%attr(0755, root, warewulf) %dir %{_localstatedir}/%{name}
-%{_localstatedir}/%{name}/overlays/runtime/*
-%{_localstatedir}/%{name}/overlays/system/*
-
-%{_mandir}/man1/wwctl*
+%attr(-, root, root) %{_bindir}/wwctl
+%if 0%{?rhel}
+%attr(-, root, root) %{_prefix}/lib/firewalld/services/warewulf.xml
+%else
+# sle_version
+%attr(-, root, root) %{_libexecdir}/firewalld/services/warewulf.xml
+%endif
+%attr(-, root, root) %{_unitdir}/warewulfd.service
+%attr(-, root, root) %{_mandir}/man1/wwctl*
 
 %changelog
+* Mon Nov 1 2021 Jeremy Siadal <jeremy.c.siadal@intel.com> - 4.2.0-1
+- Add support for OpenSUSE
+- Update file attribs
+- Update license string
+- Make shared store relocatable
+
 * Fri Sep 24 2021 Michael L. Young <myoung@ciq.co> - 4.2.0-1
 - Update spec file to use systemd macros
 - Use macros to refer to system paths


### PR DESCRIPTION
closes #192 
### new feature

- adds the ability to identify nodes by hardware address, rather than sender IP only.

### mechanism

- the wwclient send Mac addresses encoded via http query.

### fix
The splitting of `host` and `port` is now IPv6 save, at least I think so :)
