### PR TITLE
Update help output

### DIFF
--- a/cmd/man_page/man_page.go
+++ b/cmd/man_page/man_page.go
@@ -1,4 +1,5 @@
-// usage: ./bash_completion <FILE>
+// Generate man pages for wwctl command.
+// usage: ./man_page <DIRECTORY>
 package main
 
 import (

--- a/internal/app/wwctl/configure/dhcp/root.go
+++ b/internal/app/wwctl/configure/dhcp/root.go
@@ -6,7 +6,8 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "dhcp",
+		DisableFlagsInUseLine: true,
+		Use:   "dhcp [OPTIONS]",
 		Short: "Manage and initialize DHCP",
 		Long: "DHCP is a dependent service to Warewulf. This command will configure DHCP as defined\n" +
 			"in the warewulf.conf file.",

--- a/internal/app/wwctl/configure/hosts/root.go
+++ b/internal/app/wwctl/configure/hosts/root.go
@@ -4,7 +4,8 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "hosts",
+                DisableFlagsInUseLine: true,
+		Use:   "hosts [OPTIONS]",
 		Short: "Update the /etc/hosts file",
 		Long: "Write out the /etc/hosts file based on the Warewulf template (hosts.tmpl) in the\n" +
 			"Warewulf configuration directory.",

--- a/internal/app/wwctl/configure/nfs/root.go
+++ b/internal/app/wwctl/configure/nfs/root.go
@@ -4,7 +4,8 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "nfs",
+		DisableFlagsInUseLine: true,
+		Use:   "nfs [OPTIONS]",
 		Short: "Manage and initialize NFS",
 		Long: "NFS is an optional dependent service of Warewulf, this tool will automatically\n" +
 			"configure NFS as per the configuration in the warewulf.conf file.",

--- a/internal/app/wwctl/configure/root.go
+++ b/internal/app/wwctl/configure/root.go
@@ -15,7 +15,8 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "configure",
+		DisableFlagsInUseLine: true,
+		Use:   "configure [OPTIONS]",
 		Short: "Manage system services",
 		Long: "This application allows you to manage and initialize Warewulf dependent system\n" +
 			"services based on the configuration in the warewulf.conf file.",

--- a/internal/app/wwctl/configure/ssh/root.go
+++ b/internal/app/wwctl/configure/ssh/root.go
@@ -4,7 +4,8 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "ssh",
+		DisableFlagsInUseLine: true,
+		Use:   "ssh [OPTIONS]",
 		Short: "Manage and initialize SSH",
 		Long: "SSH is an optionally dependent service for Warewulf, this tool will automatically\n" +
 			"setup the ssh keys nodes using the 'default' system overlay as well as user owned\n" +

--- a/internal/app/wwctl/configure/tftp/root.go
+++ b/internal/app/wwctl/configure/tftp/root.go
@@ -4,7 +4,8 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "tftp",
+		DisableFlagsInUseLine: true,
+		Use:   "tftp [OPTIONS]",
 		Short: "Manage and initialize TFTP",
 		Long: "TFTP is a dependent service of Warewulf, this tool will enable the tftp services\n" +
 			"on your Warewulf master.",

--- a/internal/app/wwctl/container/build/root.go
+++ b/internal/app/wwctl/container/build/root.go
@@ -7,9 +7,10 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "build [flags] [container name]...",
+		DisableFlagsInUseLine: true,
+		Use:   "build [OPTIONS] CONTAINER [...]",
 		Short: "(Re)build a bootable VNFS image",
-		Long:  "This command will build a bootable VNFS image from an imported container image.",
+		Long:  "This command will build a bootable VNFS image from imported CONTAINER image(s).",
 		RunE:  CobraRunE,
 		Args:  cobra.MinimumNArgs(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/internal/app/wwctl/container/delete/root.go
+++ b/internal/app/wwctl/container/delete/root.go
@@ -7,9 +7,10 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "delete [flags] [container name]...",
+		DisableFlagsInUseLine: true,
+		Use:   "delete [OPTIONS] CONTAINER [...]",
 		Short: "Delete an imported container",
-		Long:  "This command will delete a container that has been imported into Warewulf.",
+		Long:  "This command will delete CONTAINERs that have been imported into Warewulf.",
 		RunE:  CobraRunE,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) != 0 {

--- a/internal/app/wwctl/container/exec/child/root.go
+++ b/internal/app/wwctl/container/exec/child/root.go
@@ -4,6 +4,7 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
+		DisableFlagsInUseLine: true,
 		Use:                "__child",
 		Hidden:             true,
 		RunE:               CobraRunE,

--- a/internal/app/wwctl/container/exec/root.go
+++ b/internal/app/wwctl/container/exec/root.go
@@ -8,10 +8,11 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "exec [flags] [container name] [command]",
+		DisableFlagsInUseLine: true,
+		Use:   "exec [OPTIONS] CONTAINER COMMAND",
 		Short: "Run a command inside of a Warewulf container",
-		Long: "This command will allow you to run any command inside of a given\n" +
-			"warewulf container. This is commonly used with an interactive shell such as /bin/bash\n" +
+		Long: "Run a COMMAND inside of a warewulf CONTAINER.\n" +
+		      "This is commonly used with an interactive shell such as /bin/bash\n" +
 			"to run a virtual environment within the container.",
 		RunE: CobraRunE,
 		Args: cobra.MinimumNArgs(2),

--- a/internal/app/wwctl/container/imprt/root.go
+++ b/internal/app/wwctl/container/imprt/root.go
@@ -4,10 +4,14 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "import [flags] [container source URI]",
+		DisableFlagsInUseLine: true,
+		Use:   "imprt [OPTIONS] SOURCE [NAME]",
 		Short: "Import a container into Warewulf",
-		Long: "This command will pull and import a container into Warewulf so it can be used\n" +
-			"as a source to create a bootable VNFS image.",
+		Long:
+`This command will pull and import a container into Warewulf from SOURCE,
+optionally renaming it to NAME. The SOURCE must be in a supported URI format.
+Imported containers are used to create bootable VNFS images.`,
+		Example: "wwctl container import docker://warewulf/centos-8 my_container",
 		RunE: CobraRunE,
 		Args: cobra.MinimumNArgs(1),
 	}

--- a/internal/app/wwctl/container/list/root.go
+++ b/internal/app/wwctl/container/list/root.go
@@ -4,7 +4,8 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:     "list [flags]",
+		DisableFlagsInUseLine: true,
+		Use:     "list [OPTIONS]",
 		Short:   "List imported Warewulf containers",
 		Long:    "This command will show you the containers that are imported into Warewulf.",
 		RunE:    CobraRunE,

--- a/internal/app/wwctl/container/root.go
+++ b/internal/app/wwctl/container/root.go
@@ -11,11 +11,12 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "container",
+		DisableFlagsInUseLine: true,
+		Use:   "container COMMAND [OPTIONS]",
 		Short: "Container / VNFS image management",
 		Long: "Starting with version 4, Warewulf uses containers to build the bootable VNFS\n" +
-			"images for nodes to boot. These commands will help you import, management, and\n" +
-			"transform containers into bootable Warewulf VNFS images.",
+			"node images. These commands will help you import, manage, and transform\n" +
+			"containers into bootable Warewulf VNFS images.",
 		Aliases: []string{"vnfs"},
 	}
 )

--- a/internal/app/wwctl/kernel/delete/root.go
+++ b/internal/app/wwctl/kernel/delete/root.go
@@ -7,9 +7,10 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "delete [flags] [kernel version]...",
-		Short: "Delete an imported kernel",
-		Long:  "This command will delete a kernel that has been imported into Warewulf.",
+		DisableFlagsInUseLine: true,
+		Use:   "delete [OPTIONS] KERNEL [...]",
+		Short: "Delete imported kernels",
+		Long:  "This command will delete KERNEL versions that have been imported into Warewulf.",
 		RunE:  CobraRunE,
 		Args:  cobra.MinimumNArgs(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/internal/app/wwctl/kernel/imprt/root.go
+++ b/internal/app/wwctl/kernel/imprt/root.go
@@ -9,10 +9,10 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "import [flags] [kernel version]",
+		DisableFlagsInUseLine: true,
+		Use:   "import [OPTIONS] KERNEL",
 		Short: "Import Kernel version into Warewulf",
-		Long: "This will import a Kernel version from the control node into Warewulf for nodes\n" +
-			"to be configured to boot on.",
+		Long: "This will import a boot KERNEL version from the control node into Warewulf",
 		RunE: CobraRunE,
 		Args: cobra.MinimumNArgs(1),
 	}

--- a/internal/app/wwctl/kernel/list/root.go
+++ b/internal/app/wwctl/kernel/list/root.go
@@ -4,7 +4,8 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:     "list [flags]",
+		DisableFlagsInUseLine: true,
+		Use:     "list [OPTIONS]",
 		Short:   "List imported Kernel images",
 		Long:    "This command will list the kernels that have been imported into Warewulf.",
 		RunE:    CobraRunE,

--- a/internal/app/wwctl/kernel/root.go
+++ b/internal/app/wwctl/kernel/root.go
@@ -9,10 +9,10 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "kernel",
+		DisableFlagsInUseLine: true,
+		Use:   "kernel COMMAND [OPTIONS]",
 		Short: "Kernel Image Management",
-		Long: "This command is for management of Warewulf Kernels to be used for\n" +
-			"bootstrapping nodes",
+		Long: "This command manages Warewulf Kernels used for bootstrapping nodes",
 	}
 )
 

--- a/internal/app/wwctl/node/add/root.go
+++ b/internal/app/wwctl/node/add/root.go
@@ -4,9 +4,10 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "add [flags] [node pattern]",
+		DisableFlagsInUseLine: true,
+		Use:   "add [OPTIONS] NODENAME",
 		Short: "Add new node to Warewulf",
-		Long:  "This command will add a new node to Warewulf.",
+		Long:  "This command will add a new node named NODENAME to Warewulf.",
 		RunE:  CobraRunE,
 		Args:  cobra.MinimumNArgs(1),
 	}

--- a/internal/app/wwctl/node/console/root.go
+++ b/internal/app/wwctl/node/console/root.go
@@ -6,9 +6,10 @@ import (
 
 var (
 	powerCmd = &cobra.Command{
-		Use:   "console [flags] [node pattern]",
+		DisableFlagsInUseLine: true,
+		Use:   "console [OPTIONS] NODENAME",
 		Short: "Connect to IPMI console",
-		Long:  "Start IPMI console for a singe node.",
+		Long:  "Start a new IPMI console for NODENAME.",
 		Args:  cobra.MinimumNArgs(1),
 		RunE:  CobraRunE,
 	}

--- a/internal/app/wwctl/node/delete/root.go
+++ b/internal/app/wwctl/node/delete/root.go
@@ -7,9 +7,10 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:     "delete [flags] [exact node name]...",
+		DisableFlagsInUseLine: true,
+		Use:     "delete [OPTIONS] NODE [NODE ...]",
 		Short:   "Delete a node from Warewulf",
-		Long:    "This command will remove a node from the Warewulf node configuration.",
+		Long:    "This command will remove NODE(s) from the Warewulf node configuration.",
 		Args:    cobra.MinimumNArgs(1),
 		RunE:    CobraRunE,
 		Aliases: []string{"rm", "del"},

--- a/internal/app/wwctl/node/list/root.go
+++ b/internal/app/wwctl/node/list/root.go
@@ -4,9 +4,11 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:     "list [flags] (node pattern)",
-		Short:   "List nodes matching pattern",
-		Long:    "This command will show you configured nodes.",
+		DisableFlagsInUseLine: true,
+		Use:     "list [OPTIONS] [PATTERN]",
+		Short:   "List nodes",
+		Long:    "This command lists all configured nodes. Optionally, it will list only\n" +
+		         "nodes matching a glob PATTERN.",
 		RunE:    CobraRunE,
 		Aliases: []string{"ls"},
 	}

--- a/internal/app/wwctl/node/ready/root.go
+++ b/internal/app/wwctl/node/ready/root.go
@@ -7,8 +7,10 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "ready",
-		Short: "Warewulf Status Check",
+		DisableFlagsInUseLine: true,
+		Use:   "ready [OPTIONS]",
+		Short: "Warewulf status check",
+		Long:  "Provides the current status of all Warewulf nodes.",
 		RunE:  CobraRunE,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) != 0 {

--- a/internal/app/wwctl/node/root.go
+++ b/internal/app/wwctl/node/root.go
@@ -13,7 +13,8 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "node",
+		DisableFlagsInUseLine: true,
+		Use:   "node COMMAND [OPTONS]",
 		Short: "Node management",
 		Long: "Management of node settings. All node ranges can use brackets to identify\n" +
 			"node ranges. For example: n00[00-4].cluster[0-1] will identify the first 5 nodes\n" +

--- a/internal/app/wwctl/node/sensors/root.go
+++ b/internal/app/wwctl/node/sensors/root.go
@@ -7,9 +7,10 @@ import (
 
 var (
 	powerCmd = &cobra.Command{
-		Use:   "sensors [flags] [node pattern]",
-		Short: "Show node's IPMI sensor information",
-		Long:  "Show IPMI sensors for a single node.",
+		DisableFlagsInUseLine: true,
+		Use:   "sensors [OPTIONS] PATTERN",
+		Short: "Show node IPMI sensor information",
+		Long:  "Show IPMI sensor information for nodes matching PATTERN.",
 		Args:  cobra.MinimumNArgs(1),
 		RunE:  CobraRunE,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/internal/app/wwctl/node/set/root.go
+++ b/internal/app/wwctl/node/set/root.go
@@ -12,9 +12,10 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "set [flags] [node pattern]...",
+		DisableFlagsInUseLine: true,
+		Use:   "set [OPTIONS] PATTERN [PATTERN ...]",
 		Short: "Configure node properties",
-		Long: "This command will allow you to set configuration properties for nodes.\n\n" +
+		Long: "This command sets configuration properties for nodes matching PATTERN.\n\n" +
 			"Note: use the string 'UNSET' to remove a configuration",
 		Args: cobra.MinimumNArgs(1),
 		RunE: CobraRunE,

--- a/internal/app/wwctl/overlay/build/root.go
+++ b/internal/app/wwctl/overlay/build/root.go
@@ -4,9 +4,10 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "build [flags] (overlay kind) (overlay name)",
+		DisableFlagsInUseLine: true,
+		Use:   "build [OPTIONS] {system|runtime} OVERLAY_NAME",
 		Short: "(Re)build an overlay",
-		Long:  "This command will build a system or runtime overlay.",
+		Long:  "This command builds a new system or runtime overlay named OVERLAY_NAME.",
 		RunE:  CobraRunE,
 		Args:  cobra.RangeArgs(0, 2),
 	}

--- a/internal/app/wwctl/overlay/chmod/root.go
+++ b/internal/app/wwctl/overlay/chmod/root.go
@@ -1,15 +1,21 @@
 package chmod
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+)
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "chmod [flags] (overlay kind) (overlay name) (path) (mode)",
-		Short: "Change file permissions within an overlay",
-		Long: "This command will allow you to change the permissions of a file within an\n" +
-			"overlay.",
-		RunE: CobraRunE,
-		Args: cobra.ExactArgs(4),
+		DisableFlagsInUseLine: true,
+		Use:                   "chmod [OPTIONS] {runtime|system} OVERLAY_NAME FILENAME MODE",
+		Short:                 "Change file permissions in an overlay",
+		Long: `Changes the permissions of a single FILENAME within an overlay specified by
+overlay type (system or runtime) and its OVERLAY_NAME.
+
+You can use any MODE format supported by the chmod command.`,
+		Example: "wwctl overlay chmod system default /etc/hostname.ww 0660",
+		RunE:    CobraRunE,
+		Args:    cobra.ExactArgs(4),
 	}
 )
 

--- a/internal/app/wwctl/overlay/chown/root.go
+++ b/internal/app/wwctl/overlay/chown/root.go
@@ -4,10 +4,10 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "chown [flags] (overlay kind) (overlay name) (path) (UID) [(GID)]",
+		Use:   "chown [OPTIONS] {system|runtime} OVERLAY_NAME FILE UID [GID]",
 		Short: "Change file ownership within an overlay",
-		Long: "This command will allow you to change the ownership of a file within an\n" +
-			"overlay.",
+		Long: "This command changes the ownership of a FILE within the system or runtime OVERLAY_NAME\n" +
+			"to the user specified by UID. Optionally, it will also change group ownership to GID.",
 		RunE: CobraRunE,
 		Args: cobra.RangeArgs(4, 5),
 	}

--- a/internal/app/wwctl/overlay/create/root.go
+++ b/internal/app/wwctl/overlay/create/root.go
@@ -6,9 +6,10 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "create [flags] (overlay kind) (overlay name)",
+		DisableFlagsInUseLine: true,
+		Use:   "create [OPTIONS] {system|runtime} OVERLAY_NAME",
 		Short: "Initialize a new Overlay",
-		Long:  "This command will create a new empty overlay.",
+		Long:  "This command creates a new empty system or runtime overlay named OVERLAY_NAME.",
 		RunE:  CobraRunE,
 		Args:  cobra.ExactArgs(2),
 	}

--- a/internal/app/wwctl/overlay/delete/root.go
+++ b/internal/app/wwctl/overlay/delete/root.go
@@ -6,10 +6,11 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "delete [flags] (overlay kind) (overlay name) [overlay file]",
+		DisableFlagsInUseLine: true,
+		Use:   "delete [OPTIONS] {runtime|system} OVERLAY_NAME [FILE [FILE ...]]",
 		Short: "Delete Warewulf Overlay or files",
-		Long: "This command will delete files within an overlay or an entire overlay if no\n" +
-			"files are given to remove (use with caution).",
+		Long: "This command will delete FILEs within OVERLAY_NAME or the entire OVERLAY_NAME if no\n" +
+			"files are listed. Use with caution!",
 		RunE:    CobraRunE,
 		Args:    cobra.RangeArgs(2, 3),
 		Aliases: []string{"rm", "del"},

--- a/internal/app/wwctl/overlay/edit/root.go
+++ b/internal/app/wwctl/overlay/edit/root.go
@@ -6,11 +6,12 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "edit [flags] (overlay kind) (overlay name) (file path)",
-		Short: "Edit/Create a file within a Warewulf Overlay",
-		Long: "This command will allow you to edit or create a new file within a given\n" +
-			"overlay. Note: when creating files ending in a '.ww' suffix this will always be\n" +
-			"parsed as a Warewulf template file, and the suffix will be removed automatically.",
+		DisableFlagsInUseLine: true,
+		Use:   "edit [OPTIONS] {system|runtime} OVERLAY_NAME FILE",
+		Short: "Edit or create a file within a Warewulf Overlay",
+		Long: "This command will open the FILE for editing or create a new file within the\n" +
+			"OVERLAY_NAME. Note: files created with a '.ww' suffix will always be\n" +
+			"parsed as Warewulf template files, and the suffix will be removed automatically.",
 		RunE: CobraRunE,
 		Args: cobra.ExactArgs(3),
 	}

--- a/internal/app/wwctl/overlay/imprt/root.go
+++ b/internal/app/wwctl/overlay/imprt/root.go
@@ -4,9 +4,11 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:     "import [flags] (overlay kind) (overlay name) (host source) [overlay target]",
+		DisableFlagsInUseLine: true,
+		Use:     "import [OPTIONS] {system|runtime} OVERLAY_NAME FILE [NEW_NAME]",
 		Short:   "Import a file into a Warewulf Overlay",
-		Long:    "This command will import a file into a given Warewulf overlay.",
+		Long:    "This command imports the FILE into the Warewulf OVERLAY_NAME.\n" +
+		         "Optionally, the file can be renamed to NEW_NAME",
 		RunE:    CobraRunE,
 		Args:    cobra.RangeArgs(3, 4),
 		Aliases: []string{"cp"},

--- a/internal/app/wwctl/overlay/list/root.go
+++ b/internal/app/wwctl/overlay/list/root.go
@@ -6,10 +6,11 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "list [flags] (overlay kind) [overlay name]",
+		DisableFlagsInUseLine: true,
+		Use:   "list [OPTIONS] {system|runtime} [OVERLAY_NAME]",
 		Short: "List Warewulf Overlays and files",
-		Long: "This command will show you information about Warewulf overlays and the\n" +
-			"files contained within.",
+		Long: "This command displays information about all Warewulf overlays or the specified\n" +
+			"OVERLAY_NAME. It also supports listing overlay content information.",
 		RunE:      CobraRunE,
 		Args:      cobra.MinimumNArgs(1),
 		Aliases:   []string{"ls"},

--- a/internal/app/wwctl/overlay/mkdir/root.go
+++ b/internal/app/wwctl/overlay/mkdir/root.go
@@ -6,9 +6,10 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "mkdir [flags] (overlay kind) (overlay name) (directory path)",
+		DisableFlagsInUseLine: true,
+		Use:   "mkdir [OPTIONS] {system|runtime} OVERLAY_NAME DIRECTORY",
 		Short: "Create a new directory within an Overlay",
-		Long:  "This command will allow you to create a new file within a given Warewulf overlay.",
+		Long:  "This command creates a new directory within the Warewulf OVERLAY_NAME.",
 		RunE:  CobraRunE,
 		Args:  cobra.MinimumNArgs(3),
 	}

--- a/internal/app/wwctl/overlay/root.go
+++ b/internal/app/wwctl/overlay/root.go
@@ -16,7 +16,8 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "overlay",
+		DisableFlagsInUseLine: true,
+		Use:   "overlay COMMAND [OPTIONS]",
 		Short: "Warewulf Overlay Management",
 		Long:  "Management interface for Warewulf overlays",
 	}

--- a/internal/app/wwctl/overlay/show/root.go
+++ b/internal/app/wwctl/overlay/show/root.go
@@ -6,10 +6,9 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "show [flags] (overlay kind) (overlay name) (overlay file)",
+		Use:   "show [OPTIONS] {system|runtime} OVERLAY_NAME FILE",
 		Short: "Show (cat) a file within a Warewulf Overlay",
-		Long: "This command will output the contents of a file within a given\n" +
-			"Warewulf overlay.",
+		Long: "This command displays the contents of FILE within OVERLAY_NAME.",
 		RunE:    CobraRunE,
 		Aliases: []string{"cat"},
 		Args:    cobra.ExactArgs(3),

--- a/internal/app/wwctl/power/cycle/root.go
+++ b/internal/app/wwctl/power/cycle/root.go
@@ -6,9 +6,10 @@ import (
 
 var (
 	powerCmd = &cobra.Command{
-		Use:   "cycle [flags] (node pattern)...",
+		DisableFlagsInUseLine: true,
+		Use:   "cycle [OPTIONS] [PATTERN ...]",
 		Short: "Power cycle the given node(s)",
-		Long:  "This command will cycle the power for a given set of nodes.",
+		Long:  "This command cycles power for a set of nodes specified by PATTERN.",
 		RunE:  CobraRunE,
 	}
 )

--- a/internal/app/wwctl/power/off/root.go
+++ b/internal/app/wwctl/power/off/root.go
@@ -7,9 +7,10 @@ import (
 
 var (
 	powerCmd = &cobra.Command{
-		Use:   "off",
+		DisableFlagsInUseLine: true,
+		Use:   "off [OPTIONS] [PATTERN ...]",
 		Short: "Power off the given node(s)",
-		Long:  "This command will shutdown the power to a given set of nodes.",
+		Long:  "This command will shutdown power to a set of nodes specified by PATTERN.",
 		RunE:  CobraRunE,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) != 0 {

--- a/internal/app/wwctl/power/on/root.go
+++ b/internal/app/wwctl/power/on/root.go
@@ -7,9 +7,9 @@ import (
 
 var (
 	powerCmd = &cobra.Command{
-		Use:   "on",
+		Use:   "on [OPTIONS] [PATTERN ...]",
 		Short: "Power on the given node(s)",
-		Long:  "This command will power on a given set of nodes.",
+		Long:  "This command will power on a set of nodes specified by PATTERN.",
 		RunE:  CobraRunE,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) != 0 {

--- a/internal/app/wwctl/power/reset/root.go
+++ b/internal/app/wwctl/power/reset/root.go
@@ -7,9 +7,10 @@ import (
 
 var (
 	powerCmd = &cobra.Command{
-		Use:   "reset",
-		Short: "Issue a reset to the given node(s)",
-		Long:  "This command will issue a reset to the given set of nodes.",
+		DisableFlagsInUseLine: true,
+		Use:   "reset [OPTIONS] [PATTERN ...]",
+		Short: "Issue a reset to node(s)",
+		Long:  "This command will issue a reset to a set of nodes specified by PATTERN.",
 		RunE:  CobraRunE,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) != 0 {

--- a/internal/app/wwctl/power/root.go
+++ b/internal/app/wwctl/power/root.go
@@ -12,9 +12,10 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "power",
+		DisableFlagsInUseLine: true,
+		Use:   "power COMMAND [OPTIONS]",
 		Short: "Warewulf node power management",
-		Long:  "This command can control the power state of nodes.",
+		Long:  "This command controls the power state of nodes.",
 	}
 )
 

--- a/internal/app/wwctl/power/soft/root.go
+++ b/internal/app/wwctl/power/soft/root.go
@@ -7,9 +7,10 @@ import (
 
 var (
 	powerCmd = &cobra.Command{
+		DisableFlagsInUseLine: true,
 		Use:   "soft",
 		Short: "Gracefully shuts down the given node(s)",
-		Long:  "This command will gracefully shutdown the given set of nodes.",
+		Long:  "This command uses the operationg system to shut down the set of nodes specified by PATTERN.",
 		RunE:  CobraRunE,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) != 0 {

--- a/internal/app/wwctl/power/status/root.go
+++ b/internal/app/wwctl/power/status/root.go
@@ -7,9 +7,10 @@ import (
 
 var (
 	powerCmd = &cobra.Command{
-		Use:   "status",
+		DisableFlagsInUseLine: true,
+		Use:   "status [OPTIONS] [PATTERN ...]",
 		Short: "Show power status for the given node(s)",
-		Long:  "This command will show the power status of a given set of nodes.",
+		Long:  "This command displays the power status of a set of nodes specified by PATTERN.",
 		RunE:  CobraRunE,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) != 0 {

--- a/internal/app/wwctl/profile/add/root.go
+++ b/internal/app/wwctl/profile/add/root.go
@@ -4,9 +4,10 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "add (profile name)",
+		DisableFlagsInUseLine: true,
+		Use:   "add PROFILE",
 		Short: "Add a new node profile",
-		Long:  "This command will add a new node profile.",
+		Long:  "This command adds a new named PROFILE.",
 		RunE:  CobraRunE,
 		Args:  cobra.MinimumNArgs(1),
 	}

--- a/internal/app/wwctl/profile/delete/root.go
+++ b/internal/app/wwctl/profile/delete/root.go
@@ -4,9 +4,10 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "delete [flags] (profile pattern)",
+		DisableFlagsInUseLine: true,
+		Use:   "delete [OPTIONS] PROFILE",
 		Short: "Delete a node profile",
-		Long:  "This command will delete a node profile.",
+		Long:  "This command deletes the node PROFILE. You may use a pattern for PROFILE.",
 		RunE:  CobraRunE,
 		Args:  cobra.MinimumNArgs(1),
 	}

--- a/internal/app/wwctl/profile/list/root.go
+++ b/internal/app/wwctl/profile/list/root.go
@@ -4,9 +4,10 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:     "list [flags] [profile pattern]...",
+		DisableFlagsInUseLine: true,
+		Use:     "list [OPTIONS] [PROFILE ...]",
 		Short:   "List profiles and configurations",
-		Long:    "This command will list and show the profile configurations.",
+		Long:    "This command will display configurations for PROFILE.",
 		RunE:    CobraRunE,
 		Aliases: []string{"ls"},
 	}

--- a/internal/app/wwctl/profile/root.go
+++ b/internal/app/wwctl/profile/root.go
@@ -10,7 +10,8 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "profile",
+		DisableFlagsInUseLine: true,
+		Use:   "profile COMMAND [OPTIONS]",
 		Short: "Node configuration profile management",
 		Long:  "Management of node profile settings",
 	}

--- a/internal/app/wwctl/profile/set/root.go
+++ b/internal/app/wwctl/profile/set/root.go
@@ -12,9 +12,9 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "set [flags] (profile pattern)...",
+		Use:   "set [OPTIONS] [PROFILE ...]",
 		Short: "Configure node profile properties",
-		Long: "This command will allow you to set configuration properties for node profiles.\n\n" +
+		Long: "This command sets configuration properties for the node PROFILE(s).\n\n" +
 			"Note: use the string 'UNSET' to remove a configuration",
 		Args: cobra.MinimumNArgs(1),
 		RunE: CobraRunE,

--- a/internal/app/wwctl/root.go
+++ b/internal/app/wwctl/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hpcng/warewulf/internal/app/wwctl/profile"
 	"github.com/hpcng/warewulf/internal/app/wwctl/server"
 	"github.com/hpcng/warewulf/internal/pkg/wwlog"
+	"github.com/hpcng/warewulf/internal/pkg/help"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 
@@ -18,9 +19,10 @@ import (
 
 var (
 	rootCmd = &cobra.Command{
-		Use:               "wwctl",
+		DisableFlagsInUseLine: true,
+		Use:               "wwctl COMMAND [OPTIONS]",
 		Short:             "Warewulf Control",
-		Long:              "Control interface to the Cluster Warewulf Provisioning System.",
+		Long:              "Control interface to the Warewulf Cluster Provisioning System.",
 		PersistentPreRunE: rootPersistentPreRunE,
 		SilenceUsage:      true,
 		SilenceErrors:     true,
@@ -32,6 +34,9 @@ var (
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&verboseArg, "verbose", "v", false, "Run with increased verbosity.")
 	rootCmd.PersistentFlags().BoolVarP(&DebugFlag, "debug", "d", false, "Run with debugging messages enabled.")
+
+        rootCmd.SetUsageTemplate(help.UsageTemplate)
+        rootCmd.SetHelpTemplate(help.HelpTemplate)
 
 	rootCmd.AddCommand(overlay.GetCommand())
 	rootCmd.AddCommand(container.GetCommand())
@@ -60,14 +65,17 @@ func rootPersistentPreRunE(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// GenBashCompletionFile
+// External functions not used by the wwctl command line
+
+// Generate Bash completion file
 func GenBashCompletion(w io.Writer) error {
 	return rootCmd.GenBashCompletion(w)
 }
 
+// Generate man pages
 func GenManTree(fileName string) error {
 	header := &doc.GenManHeader{
-		Title:   "MINE",
+		Title:   "WWCTL",
 		Section: "1",
 	}
 	return doc.GenManTree(rootCmd, header, fileName)

--- a/internal/app/wwctl/server/reload/root.go
+++ b/internal/app/wwctl/server/reload/root.go
@@ -4,7 +4,8 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "reload",
+		DisableFlagsInUseLine: true,
+		Use:   "reload [OPTIONS]",
 		Short: "Reload the Warewulf server configuration",
 		RunE:  CobraRunE,
 	}

--- a/internal/app/wwctl/server/restart/root.go
+++ b/internal/app/wwctl/server/restart/root.go
@@ -4,7 +4,8 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "restart",
+		DisableFlagsInUseLine: true,
+		Use:   "restart [OPTIONS]",
 		Short: "Restart the Warewulf server",
 		RunE:  CobraRunE,
 	}

--- a/internal/app/wwctl/server/root.go
+++ b/internal/app/wwctl/server/root.go
@@ -11,7 +11,8 @@ import (
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "server",
+		DisableFlagsInUseLine: true,
+		Use:   "server COMMAND [OPTIONS]",
 		Short: "Warewulf server process commands",
 		Long:  "This command will allow you to control the Warewulf daemon process.",
 	}

--- a/internal/app/wwctl/server/start/root.go
+++ b/internal/app/wwctl/server/start/root.go
@@ -4,7 +4,8 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "start",
+		DisableFlagsInUseLine: true,
+		Use:   "start [OPTIONS]",
 		Short: "Start Warewulf server",
 		RunE:  CobraRunE,
 	}

--- a/internal/app/wwctl/server/status/root.go
+++ b/internal/app/wwctl/server/status/root.go
@@ -4,7 +4,8 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "status",
+		DisableFlagsInUseLine: true,
+		Use:   "status [OPTIONS]",
 		Short: "Warewulf server status",
 		RunE:  CobraRunE,
 	}

--- a/internal/app/wwctl/server/stop/root.go
+++ b/internal/app/wwctl/server/stop/root.go
@@ -4,7 +4,8 @@ import "github.com/spf13/cobra"
 
 var (
 	baseCmd = &cobra.Command{
-		Use:   "stop",
+		DisableFlagsInUseLine: true,
+		Use:   "stop [OPTIONS]",
 		Short: "Stop Warewulf server",
 		RunE:  CobraRunE,
 	}

--- a/internal/pkg/help/help.go
+++ b/internal/pkg/help/help.go
@@ -1,0 +1,35 @@
+package help
+
+// UsageTemplate replaces the default usage template from cobra
+const UsageTemplate string = `Usage:
+{{if .Runnable}}  {{.UseLine}}
+{{end}}{{if .HasAvailableSubCommands}}  {{.CommandPath}} COMMAND [OPTIONS]
+{{end}}{{if gt (len .Aliases) 0}}
+Aliases:
+  {{.NameAndAliases}}
+{{end}}{{if .HasExample}}
+Examples:
+  {{.Example}}
+{{end}}{{if .HasAvailableSubCommands}}
+Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}
+{{end}}{{if .HasAvailableLocalFlags}}
+Options:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}
+{{end}}{{if .HasAvailableInheritedFlags}}
+Global Options:
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}
+{{end}}{{if .HasHelpSubCommands}}
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}
+{{end}}{{if .HasAvailableSubCommands}}
+Use "{{.CommandPath}} COMMAND --help" for more information about a COMMAND.
+{{end}} 
+`
+// End UsageTemplate
+
+// HelpTemplate replaces the default help template from cobra
+const HelpTemplate string = `
+{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
+{{end}}
+{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`


### PR DESCRIPTION
Signed-off-by: jcsiadal <jeremy.c.siadal@intel.com>

Reformats help output to common format. Help output is updated to clean up spacing and indentation and to use common format conventions (tar --help is a good example). Because LT/GT signs cannot be used, replaceable text is referenced by capitalized text, with the same capitalized text used in the descriptions.

Some updates to content to reduce filler words.
