### PR TITLE
Adding '^' and '$' to serach string to avoid greedy regexp

### DIFF
--- a/internal/pkg/node/methods.go
+++ b/internal/pkg/node/methods.go
@@ -14,7 +14,7 @@ func FilterByName(set []NodeInfo, searchList []string) []NodeInfo {
 	if len(searchList) > 0 {
 		for _, search := range searchList {
 			for _, entry := range set {
-				b, _ := regexp.MatchString(search, entry.Id.Get())
+				b, _ := regexp.MatchString("^"+search+"$", entry.Id.Get())
 				if b {
 					ret = append(ret, entry)
 				}


### PR DESCRIPTION
regexp.MatchString will match also substrings, what means that 
```
wwctl node list node1
```
will not only match `node1` but also `node10`, so its impossible to target `node1` which is also described in #203.
With '^' at start of the search string and '$' at the end, its possible to target `node1`. The old behavior can be retained with
```
wwctl node list node1.
```
