### PR TITLE
RFE: retry unconfigured instead of reboot

### DIFF
--- a/etc/ipxe/unconfigured.ipxe
+++ b/etc/ipxe/unconfigured.ipxe
@@ -7,6 +7,6 @@ echo
 echo MESSAGE: This node is unconfigured. Please have your system administrator add a
 echo          configuration for this node with HW address: {{$.Hwaddr}}
 echo
-echo Rebooting in 1 minute...
-sleep 60
-reboot
+echo Retrying provisioning in 15s...
+sleep 15
+autoboot


### PR DESCRIPTION
Use autoboot instead of reboot to just retry without going through POST again.

Although I'm using this now and it works, this is not intended to be merged as-is, just a feature request disguised as a PR. 