### PR TITLE
Add fields for use in iPxe templates

### DIFF
--- a/internal/pkg/warewulfd/ipxe.go
+++ b/internal/pkg/warewulfd/ipxe.go
@@ -18,6 +18,8 @@ type iPxeTemplate struct {
 	WaitTime      string
 	Hostname      string
 	Fqdn          string
+	Id            string
+	Cluster       string
 	ContainerName string
 	Hwaddr        string
 	Ipaddr        string
@@ -129,6 +131,8 @@ func IpxeSend(w http.ResponseWriter, req *http.Request) {
 
 		var replace iPxeTemplate
 
+		replace.Id = nodeobj.Id.Get()
+		replace.Cluster = nodeobj.Cluster.Get()
 		replace.Fqdn = nodeobj.Id.Get()
 		replace.Ipaddr = conf.Ipaddr
 		replace.Port = strconv.Itoa(conf.Warewulf.Port)

--- a/internal/pkg/warewulfd/ipxe.go
+++ b/internal/pkg/warewulfd/ipxe.go
@@ -132,7 +132,7 @@ func IpxeSend(w http.ResponseWriter, req *http.Request) {
 		var replace iPxeTemplate
 
 		replace.Id = nodeobj.Id.Get()
-		replace.Cluster = nodeobj.Cluster.Get()
+		replace.Cluster = nodeobj.ClusterName.Get()
 		replace.Fqdn = nodeobj.Id.Get()
 		replace.Ipaddr = conf.Ipaddr
 		replace.Port = strconv.Itoa(conf.Warewulf.Port)


### PR DESCRIPTION
Adding two fields to make available to iPxe templates.

- Id : Already there as hostname and fqdn, adding ID to be consistent with node field naming. 
- Cluster: Adding for consistency

The motivation here is to pass values in as kernel params to avoid the need to write files into the image via overlays for trivial node/asset information and to make all values available to the iPxe templates that are available to overlay templates.

These two commits could be folded together, but I didn't know how to do that offhand. 