### PR TITLE
ipmi: Fix log output, set IMPI port on profile and settings for console

### DIFF
--- a/internal/app/wwctl/node/console/power.go
+++ b/internal/app/wwctl/node/console/power.go
@@ -49,11 +49,13 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		}
 
 		ipmiCmd := power.IPMI{
-			NodeName: node.Id.Get(),
-			HostName: node.IpmiIpaddr.Get(),
-			User:     node.IpmiUserName.Get(),
-			Password: node.IpmiPassword.Get(),
-			AuthType: "MD5",
+			NodeName:  node.Id.Get(),
+			HostName:  node.IpmiIpaddr.Get(),
+			Port:      node.IpmiPort.Get(),
+			User:      node.IpmiUserName.Get(),
+			Password:  node.IpmiPassword.Get(),
+			AuthType:  "MD5",
+			Interface: node.IpmiInterface.Get(),
 		}
 
 		err := ipmiCmd.Console()

--- a/internal/app/wwctl/node/list/main.go
+++ b/internal/app/wwctl/node/list/main.go
@@ -84,11 +84,11 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		}
 
 	} else if ShowIpmi {
-		fmt.Printf("%-22s %-16s %-5s %-20s %-20s %-20s\n", "NODE NAME", "IPMI IPADDR", "IPMI PORT", "IPMI USERNAME", "IPMI PASSWORD", "IPMI INTERFACE")
-		fmt.Println(strings.Repeat("=", 80))
+		fmt.Printf("%-22s %-16s %-10s %-20s %-20s %-14s\n", "NODE NAME", "IPMI IPADDR", "IPMI PORT", "IPMI USERNAME", "IPMI PASSWORD", "IPMI INTERFACE")
+		fmt.Println(strings.Repeat("=", 108))
 
 		for _, node := range node.FilterByName(nodes, args) {
-			fmt.Printf("%-22s %-16s %-5s %-20s %-20s %-20s\n", node.Id.Get(), node.IpmiIpaddr.Print(), node.IpmiPort.Print(), node.IpmiUserName.Print(), node.IpmiPassword.Print(), node.IpmiInterface.Print())
+			fmt.Printf("%-22s %-16s %-10s %-20s %-20s %-14s\n", node.Id.Get(), node.IpmiIpaddr.Print(), node.IpmiPort.Print(), node.IpmiUserName.Print(), node.IpmiPassword.Print(), node.IpmiInterface.Print())
 		}
 
 	} else if ShowLong {

--- a/internal/app/wwctl/profile/list/main.go
+++ b/internal/app/wwctl/profile/list/main.go
@@ -41,7 +41,6 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 			fmt.Printf("%-20s %-18s %s\n", profile.Id.Get(), "RuntimeOverlay", profile.RuntimeOverlay.Print())
 			fmt.Printf("%-20s %-18s %s\n", profile.Id.Get(), "SystemOverlay", profile.SystemOverlay.Print())
 			fmt.Printf("%-20s %-18s %s\n", profile.Id.Get(), "Ipxe", profile.Ipxe.Print())
-			fmt.Printf("%-20s %-18s %s\n", profile.Id.Get(), "IpmiIpaddr", profile.IpmiIpaddr.Print())
 			fmt.Printf("%-20s %-18s %s\n", profile.Id.Get(), "IpmiNetmask", profile.IpmiNetmask.Print())
 			fmt.Printf("%-20s %-18s %s\n", profile.Id.Get(), "IpmiPort", profile.IpmiPort.Print())
 			fmt.Printf("%-20s %-18s %s\n", profile.Id.Get(), "IpmiGateway", profile.IpmiGateway.Print())

--- a/internal/app/wwctl/profile/set/main.go
+++ b/internal/app/wwctl/profile/set/main.go
@@ -96,12 +96,17 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		}
 
 		if SetIpmiNetmask != "" {
-			wwlog.Printf(wwlog.VERBOSE, "Profile: %s, Setting IPMI username to: %s\n", p.Id.Get(), SetIpmiNetmask)
+			wwlog.Printf(wwlog.VERBOSE, "Profile: %s, Setting IPMI netmask to: %s\n", p.Id.Get(), SetIpmiNetmask)
 			p.IpmiNetmask.Set(SetIpmiNetmask)
 		}
 
+		if SetIpmiPort != "" {
+			wwlog.Printf(wwlog.VERBOSE, "Profile: %s, Setting IPMI port to: %s\n", p.Id.Get(), SetIpmiPort)
+			p.IpmiPort.Set(SetIpmiPort)
+		}
+
 		if SetIpmiGateway != "" {
-			wwlog.Printf(wwlog.VERBOSE, "Profile: %s, Setting IPMI username to: %s\n", p.Id.Get(), SetIpmiGateway)
+			wwlog.Printf(wwlog.VERBOSE, "Profile: %s, Setting IPMI gateway to: %s\n", p.Id.Get(), SetIpmiGateway)
 			p.IpmiGateway.Set(SetIpmiGateway)
 		}
 
@@ -111,12 +116,12 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		}
 
 		if SetIpmiPassword != "" {
-			wwlog.Printf(wwlog.VERBOSE, "Profile: %s, Setting IPMI username to: %s\n", p.Id.Get(), SetIpmiPassword)
+			wwlog.Printf(wwlog.VERBOSE, "Profile: %s, Setting IPMI password to: %s\n", p.Id.Get(), SetIpmiPassword)
 			p.IpmiPassword.Set(SetIpmiPassword)
 		}
 
 		if SetIpmiInterface != "" {
-			wwlog.Printf(wwlog.VERBOSE, "Profile: %s, Setting IPMI username to: %s\n", p.Id.Get(), SetIpmiInterface)
+			wwlog.Printf(wwlog.VERBOSE, "Profile: %s, Setting IPMI interface to: %s\n", p.Id.Get(), SetIpmiInterface)
 			p.IpmiInterface.Set(SetIpmiInterface)
 		}
 

--- a/internal/app/wwctl/profile/set/root.go
+++ b/internal/app/wwctl/profile/set/root.go
@@ -44,6 +44,7 @@ var (
 	SetRuntimeOverlay string
 	SetSystemOverlay  string
 	SetIpmiNetmask    string
+	SetIpmiPort       string
 	SetIpmiGateway    string
 	SetIpmiUsername   string
 	SetIpmiPassword   string
@@ -103,10 +104,11 @@ func init() {
 		log.Println(err)
 	}
 	baseCmd.PersistentFlags().StringVar(&SetIpmiNetmask, "ipminetmask", "", "Set the node's IPMI netmask")
+	baseCmd.PersistentFlags().StringVar(&SetIpmiPort, "ipmiport", "", "Set the node's IPMI port")
 	baseCmd.PersistentFlags().StringVar(&SetIpmiGateway, "ipmigateway", "", "Set the node's IPMI gateway")
 	baseCmd.PersistentFlags().StringVar(&SetIpmiUsername, "ipmiuser", "", "Set the node's IPMI username")
 	baseCmd.PersistentFlags().StringVar(&SetIpmiPassword, "ipmipass", "", "Set the node's IPMI password")
-	baseCmd.PersistentFlags().StringVar(&SetIpmiInterface, "ipmiinterface", "", "Set the node's IPMI interface (defaults to 'lan' if empty)")
+	baseCmd.PersistentFlags().StringVar(&SetIpmiInterface, "ipmiinterface", "", "Set the node's IPMI interface (defaults to 'lan')")
 
 	baseCmd.PersistentFlags().StringVarP(&SetNetDev, "netdev", "N", "", "Define the network device to configure")
 	baseCmd.PersistentFlags().StringVarP(&SetIpaddr, "ipaddr", "I", "", "Set the node's network device IP address")


### PR DESCRIPTION
- Fix the logs to reference the correct IPMI setting that is being set.

- Add setting the IPMI port at a profile level.

- Apply all IPMI settings when preparing to us the console.

Closes #225