### PR TITLE
`wwctl version` writes current version as a semver to stdout.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ debfiles: debian
 	cp wwclient $(DESTDIR)/var/warewulf/overlays/system/debian/warewulf/bin/
 
 wwctl:
-	cd cmd/wwctl; GOOS=linux go build -mod vendor -tags "$(WW_BUILD_GO_BUILD_TAGS)" -o ../../wwctl
+	cd cmd/wwctl; GOOS=linux go build -mod vendor -tags "$(WW_BUILD_GO_BUILD_TAGS)" -ldflags '-X github.com/hpcng/warewulf/internal/app/wwctl/version.version=$(VERSION) -X github.com/hpcng/warewulf/internal/app/wwctl/version.release=$(RELEASE)' -o ../../wwctl
 
 wwclient:
 	cd cmd/wwclient; CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -ldflags '-extldflags -static' -o ../../wwclient
@@ -158,4 +158,3 @@ clean:
 install: files install_wwclient
 
 debinstall: files debfiles
-

--- a/internal/app/wwctl/root.go
+++ b/internal/app/wwctl/root.go
@@ -9,8 +9,9 @@ import (
 	"github.com/hpcng/warewulf/internal/app/wwctl/power"
 	"github.com/hpcng/warewulf/internal/app/wwctl/profile"
 	"github.com/hpcng/warewulf/internal/app/wwctl/server"
-	"github.com/hpcng/warewulf/internal/pkg/wwlog"
+	"github.com/hpcng/warewulf/internal/app/wwctl/version"
 	"github.com/hpcng/warewulf/internal/pkg/help"
+	"github.com/hpcng/warewulf/internal/pkg/wwlog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 
@@ -20,12 +21,12 @@ import (
 var (
 	rootCmd = &cobra.Command{
 		DisableFlagsInUseLine: true,
-		Use:               "wwctl COMMAND [OPTIONS]",
-		Short:             "Warewulf Control",
-		Long:              "Control interface to the Warewulf Cluster Provisioning System.",
-		PersistentPreRunE: rootPersistentPreRunE,
-		SilenceUsage:      true,
-		SilenceErrors:     true,
+		Use:                   "wwctl COMMAND [OPTIONS]",
+		Short:                 "Warewulf Control",
+		Long:                  "Control interface to the Warewulf Cluster Provisioning System.",
+		PersistentPreRunE:     rootPersistentPreRunE,
+		SilenceUsage:          true,
+		SilenceErrors:         true,
 	}
 	verboseArg bool
 	DebugFlag  bool
@@ -35,9 +36,10 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&verboseArg, "verbose", "v", false, "Run with increased verbosity.")
 	rootCmd.PersistentFlags().BoolVarP(&DebugFlag, "debug", "d", false, "Run with debugging messages enabled.")
 
-        rootCmd.SetUsageTemplate(help.UsageTemplate)
-        rootCmd.SetHelpTemplate(help.HelpTemplate)
+	rootCmd.SetUsageTemplate(help.UsageTemplate)
+	rootCmd.SetHelpTemplate(help.HelpTemplate)
 
+	rootCmd.AddCommand(version.GetCommand())
 	rootCmd.AddCommand(overlay.GetCommand())
 	rootCmd.AddCommand(container.GetCommand())
 	rootCmd.AddCommand(node.GetCommand())

--- a/internal/app/wwctl/version/main.go
+++ b/internal/app/wwctl/version/main.go
@@ -1,0 +1,18 @@
+package version
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+)
+
+// Makefile modifies version and release during build using VERSION and RELEASE.
+// @see https://polyverse.com/blog/how-to-embed-versioning-information-in-go-applications-f76e2579b572/
+var (
+	version = "tbs"
+	release = "tbs"
+)
+
+func CobraRunE(cmd *cobra.Command, args []string) error {
+	fmt.Printf("v%s.%s\n", version, release)
+	return nil
+}

--- a/internal/app/wwctl/version/root.go
+++ b/internal/app/wwctl/version/root.go
@@ -1,0 +1,17 @@
+package version
+
+import "github.com/spf13/cobra"
+
+var (
+	baseCmd = &cobra.Command{
+		DisableFlagsInUseLine: true,
+		Use:                   "version [OPTIONS]",
+		Short:                 "Warewulf version",
+		RunE:                  CobraRunE,
+	}
+)
+
+// GetRootCommand returns the root cobra.Command for the application.
+func GetCommand() *cobra.Command {
+	return baseCmd
+}


### PR DESCRIPTION
I was surprised to find there was no `wwctl version` so I created one, learning some go and wwctl along the way. 