### PR TITLE
Support for relocatable Warewulf server file share

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@
 # other created files
 /man_pages
 /bash_completion.d
+/usr/share/man/man1/
+/etc/bash_completion.d/
+/etc/warewulf.conf
+warewulf.spec

--- a/Makefile
+++ b/Makefile
@@ -105,23 +105,14 @@ files: all
 	test -f $(DESTDIR)/etc/warewulf/nodes.conf || install -m 644 etc/nodes.conf $(DESTDIR)/etc/warewulf/
 	cp -r etc/dhcp $(DESTDIR)/etc/warewulf/
 	cp -r etc/ipxe $(DESTDIR)/etc/warewulf/
-	cp -r overlays $(DESTDIR)/var/warewulf/
-	mkdir -p $(DESTDIR)$(OVERLAYIR)/wwinit/bin/
-	mkdir -p $(DESTDIR)$(OVERLAYIR)/wwinit/warewulf/bin/
-	chmod +x $(DESTDIR)$(OVERLAYIR)/wwinit/init
-	chmod 600 $(DESTDIR)$(OVERLAYIR)/wwinit/etc/ssh/ssh*
-	chmod 644 $(DESTDIR)$(OVERLAYIR)/wwinit/etc/ssh/ssh*.pub.ww
-	mkdir -p $(DESTDIR)$(OVERLAYIR)/wwinit/warewulf/bin/
-	install -m 0755 wwctl $(DESTDIR)/usr/bin/
-	mkdir -p $(DESTDIR)/usr/lib/firewalld/services
-	install -c -m 0644 include/firewalld/warewulf.xml $(DESTDIR)/usr/lib/firewalld/services
-	cp -r overlays $(DESTDIR)$(WWROOT)/warewulf/
-	mkdir -p $(DESTDIR)$(OVERLAYIR)/wwinit/bin/
-	mkdir -p $(DESTDIR)$(OVERLAYIR)/wwinit/warewulf/bin/
-	chmod +x $(DESTDIR)$(OVERLAYIR)/wwinit/init
-	chmod 600 $(DESTDIR)$(OVERLAYIR)/wwinit/etc/ssh/ssh*
-	chmod 644 $(DESTDIR)$(OVERLAYIR)/wwinit/etc/ssh/ssh*.pub.ww
-	mkdir -p $(DESTDIR)$(OVERLAYIR)/wwinit/warewulf/bin/
+	mkdir -p $(DESTDIR)$(OVERLAYDIR)
+	cp -r overlays/* $(DESTDIR)$(OVERLAYDIR)/
+	mkdir -p $(DESTDIR)$(OVERLAYDIR)/wwinit/bin/
+	mkdir -p $(DESTDIR)$(OVERLAYDIR)/wwinit/warewulf/bin/
+	chmod +x $(DESTDIR)$(OVERLAYDIR)/wwinit/init
+	chmod 600 $(DESTDIR)$(OVERLAYDIR)/wwinit/etc/ssh/ssh*
+	chmod 644 $(DESTDIR)$(OVERLAYDIR)/wwinit/etc/ssh/ssh*.pub.ww
+	mkdir -p $(DESTDIR)$(OVERLAYDIR)/wwinit/warewulf/bin/
 	install -m 0755 wwctl $(DESTDIR)/usr/bin/
 	mkdir -p $(DESTDIR)$(FIREWALLDIR)
 	install -c -m 0644 include/firewalld/warewulf.xml $(DESTDIR)$(FIREWALLDIR)
@@ -152,7 +143,7 @@ wwclient:
 	cd cmd/wwclient; CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -ldflags '-extldflags -static' -o ../../wwclient
 
 install_wwclient: wwclient
-	install -m 0755 wwclient $(DESSTDIR)/var/warewulf/overlays/wwinit/bin/wwclient
+	install -m 0755 wwclient $(DESTDIR)$(WWROOT)/warewulf/overlays/wwinit/bin/wwclient
 
 bash_completion:
 	cd cmd/bash_completion && go build -ldflags="-X 'github.com/hpcng/warewulf/internal/pkg/warewulfconf.ConfigFile=$(CONFIG)/etc/warewulf.conf'\
@@ -176,7 +167,7 @@ man_pages: man_page
 config_defaults:
 	cd cmd/config_defaults && go build -ldflags="-X 'github.com/hpcng/warewulf/internal/pkg/warewulfconf.ConfigFile=$(CONFIG)/etc/warewulf.conf' \
 	 -X 'github.com/hpcng/warewulf/internal/pkg/node.ConfigFile=$(CONFIG)/etc/nodes.conf' \
-	 -X 'github.com/hpcng/warewulf/internal/pkg/warewulfconf.defaultDataStore=/srv/warewulf'" \
+	 -X 'github.com/hpcng/warewulf/internal/pkg/warewulfconf.defaultDataStore=$(WWROOT)/warewulf'" \
 	 -mod vendor -tags "$(WW_BUILD_GO_BUILD_TAGS)" -o ../../config_defaults
 
 dist: vendor

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,10 @@ debfiles: debian
 	cp wwclient $(DESTDIR)$(WWROOT)/warewulf/overlays/system/debian/warewulf/bin/
 
 wwctl:
-	cd cmd/wwctl; GOOS=linux go build -ldflags="-X 'github.com/hpcng/warewulf/internal/pkg/version.Version=$(VERSION_FULL)'" -mod vendor -tags "$(WW_BUILD_GO_BUILD_TAGS)" -o ../../wwctl
+	cd cmd/wwctl; GOOS=linux go build \
+	-ldflags="-X 'github.com/hpcng/warewulf/internal/pkg/version.Version=$(VERSION_FULL)' \
+	-X 'github.com/hpcng/warewulf/internal/pkg/warewulfconf.defaultDataStore=$(WWROOT)/warewulf'" \
+	-mod vendor -tags "$(WW_BUILD_GO_BUILD_TAGS)" -o ../../wwctl
 
 wwclient:
 	cd cmd/wwclient; CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -ldflags '-extldflags -static' -o ../../wwclient
@@ -171,8 +174,9 @@ man_pages: man_page
 	cd man_pages; for i in wwctl*1; do echo "Compressing manpage: $$i"; gzip --force $$i; done
 
 config_defaults:
-	cd cmd/config_defaults && go build -ldflags="-X 'github.com/hpcng/warewulf/internal/pkg/warewulfconf.ConfigFile=$(CONFIG)/etc/warewulf.conf'\
-	 -X 'github.com/hpcng/warewulf/internal/pkg/node.ConfigFile=$(CONFIG)/etc/nodes.conf'"\
+	cd cmd/config_defaults && go build -ldflags="-X 'github.com/hpcng/warewulf/internal/pkg/warewulfconf.ConfigFile=$(CONFIG)/etc/warewulf.conf' \
+	 -X 'github.com/hpcng/warewulf/internal/pkg/node.ConfigFile=$(CONFIG)/etc/nodes.conf' \
+	 -X 'github.com/hpcng/warewulf/internal/pkg/warewulfconf.defaultDataStore=/srv/warewulf'" \
 	 -mod vendor -tags "$(WW_BUILD_GO_BUILD_TAGS)" -o ../../config_defaults
 
 dist: vendor

--- a/cmd/config_defaults/config_defaults.go
+++ b/cmd/config_defaults/config_defaults.go
@@ -1,0 +1,26 @@
+package main
+
+// Regenerates the default configuration files
+// Keeps the current content and adds missing default values
+// Won't create a new file, but will update a blank file
+
+//TODO: Add nodes.conf
+
+import (
+	"fmt"
+	"github.com/hpcng/warewulf/internal/pkg/warewulfconf"
+)
+
+func main() {
+	tmpConf, err := warewulfconf.New()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	err = tmpConf.Persist()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+}

--- a/etc/warewulf.conf.in
+++ b/etc/warewulf.conf.in
@@ -6,6 +6,7 @@ warewulf:
   autobuild overlays: true
   update interval: 60
   syslog: false
+  datastore: @WWROOT@/warewulf
 dhcp:
   enabled: true
   range start: 192.168.200.50
@@ -14,7 +15,7 @@ dhcp:
   systemd name: dhcpd
 tftp:
   enabled: true
-  tftproot: /var/lib/tftpboot
+  tftproot: @TFTPROOT@
   systemd name: tftp
 nfs:
   systemd name: nfs-server

--- a/internal/app/wwctl/configure/nfs/main.go
+++ b/internal/app/wwctl/configure/nfs/main.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hpcng/warewulf/internal/pkg/util"
 	"github.com/hpcng/warewulf/internal/pkg/warewulfconf"
 	"github.com/hpcng/warewulf/internal/pkg/wwlog"
+	"github.com/hpcng/warewulf/internal/pkg/overlay"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )

--- a/internal/app/wwctl/configure/nfs/main.go
+++ b/internal/app/wwctl/configure/nfs/main.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hpcng/warewulf/internal/pkg/util"
 	"github.com/hpcng/warewulf/internal/pkg/warewulfconf"
 	"github.com/hpcng/warewulf/internal/pkg/wwlog"
-	"github.com/hpcng/warewulf/internal/pkg/overlay"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/internal/app/wwctl/node/ready/main.go
+++ b/internal/app/wwctl/node/ready/main.go
@@ -81,18 +81,6 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 			wwlog.Printf(wwlog.VERBOSE, "System Overlay not defined: %s\n", node.Id.Get())
 		}
 
-		if node.RuntimeOverlay.Get() != "" {
-			if util.IsFile(overlay.RuntimeOverlayImage(node.Id.Get())) {
-				runtimeo_good = true
-			} else {
-				status = false
-				wwlog.Printf(wwlog.VERBOSE, "Runtime Overlay not found: %s\n", overlay.RuntimeOverlaySource(node.Id.Get()))
-			}
-		} else {
-			status = false
-			wwlog.Printf(wwlog.VERBOSE, "Runtime Overlay not defined: %s\n", node.Id.Get())
-		}
-
 		fmt.Printf("%-25s %-10t %-6t %-6t %-6t %-6t %-6t\n", node.Id.Get(), status, vnfs_good, kernel_good, kmods_good, systemo_good, runtimeo_good)
 	}
 

--- a/internal/app/wwctl/node/ready/main.go
+++ b/internal/app/wwctl/node/ready/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/hpcng/warewulf/internal/pkg/config"
+	"github.com/hpcng/warewulf/internal/pkg/overlay"
 	"github.com/hpcng/warewulf/internal/pkg/container"
 	"github.com/hpcng/warewulf/internal/pkg/kernel"
 	"github.com/hpcng/warewulf/internal/pkg/node"
@@ -70,11 +70,11 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		}
 
 		if node.SystemOverlay.Get() != "" {
-			if util.IsFile(config.SystemOverlayImage(node.Id.Get())) {
+			if util.IsFile(overlay.SystemOverlayImage(node.Id.Get())) {
 				systemo_good = true
 			} else {
 				status = false
-				wwlog.Printf(wwlog.VERBOSE, "System Overlay not found: %s\n", config.SystemOverlayImage(node.Id.Get()))
+				wwlog.Printf(wwlog.VERBOSE, "System Overlay not found: %s\n", overlay.SystemOverlayImage(node.Id.Get()))
 			}
 		} else {
 			status = false
@@ -82,11 +82,11 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		}
 
 		if node.RuntimeOverlay.Get() != "" {
-			if util.IsFile(config.RuntimeOverlayImage(node.Id.Get())) {
+			if util.IsFile(overlay.RuntimeOverlayImage(node.Id.Get())) {
 				runtimeo_good = true
 			} else {
 				status = false
-				wwlog.Printf(wwlog.VERBOSE, "Runtime Overlay not found: %s\n", config.RuntimeOverlaySource(node.Id.Get()))
+				wwlog.Printf(wwlog.VERBOSE, "Runtime Overlay not found: %s\n", overlay.RuntimeOverlaySource(node.Id.Get()))
 			}
 		} else {
 			status = false

--- a/internal/app/wwctl/overlay/list/main.go
+++ b/internal/app/wwctl/overlay/list/main.go
@@ -31,9 +31,25 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		fmt.Printf("%-30s %-12s\n", "OVERLAY NAME", "FILES/DIRS")
 	}
 
+<<<<<<< HEAD
 	for o := range overlays {
 		name := overlays[o]
 		path := overlay.OverlaySourceDir(name)
+=======
+	for o := range overlayList {
+		var path string
+		name := overlayList[o]
+
+		if overlayName != "" && overlayName != name {
+			continue
+		}
+
+		if overlayKind == "system" {
+			path = overlay.SystemOverlaySource(overlayList[o])
+		} else if overlayKind == "runtime" {
+			path = overlay.RuntimeOverlaySource(overlayList[o])
+		}
+>>>>>>> eb32d41... Add config option for shared state dir
 
 		if util.IsDir(path) {
 			files := util.FindFiles(path)
@@ -60,7 +76,11 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 					sys := s.Sys()
 
+<<<<<<< HEAD
 					fmt.Printf("%v %5d %-5d %-18s /%s\n", perms, sys.(*syscall.Stat_t).Uid, sys.(*syscall.Stat_t).Gid, overlays[o], files[file])
+=======
+					fmt.Printf("%v %5d %-5d %-18s /%s\n", perms, sys.(*syscall.Stat_t).Uid, sys.(*syscall.Stat_t).Gid, overlayList[o], files[file])
+>>>>>>> eb32d41... Add config option for shared state dir
 
 				}
 			} else {
@@ -68,7 +88,11 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 			}
 
 		} else {
+<<<<<<< HEAD
 			wwlog.Printf(wwlog.ERROR, "system/%s (path not found:%s)\n", overlays[o], path)
+=======
+			wwlog.Printf(wwlog.ERROR, "system/%s (path not found:%s)\n", overlayList[o], path)
+>>>>>>> eb32d41... Add config option for shared state dir
 		}
 	}
 

--- a/internal/app/wwctl/overlay/list/main.go
+++ b/internal/app/wwctl/overlay/list/main.go
@@ -31,25 +31,9 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		fmt.Printf("%-30s %-12s\n", "OVERLAY NAME", "FILES/DIRS")
 	}
 
-<<<<<<< HEAD
 	for o := range overlays {
 		name := overlays[o]
 		path := overlay.OverlaySourceDir(name)
-=======
-	for o := range overlayList {
-		var path string
-		name := overlayList[o]
-
-		if overlayName != "" && overlayName != name {
-			continue
-		}
-
-		if overlayKind == "system" {
-			path = overlay.SystemOverlaySource(overlayList[o])
-		} else if overlayKind == "runtime" {
-			path = overlay.RuntimeOverlaySource(overlayList[o])
-		}
->>>>>>> eb32d41... Add config option for shared state dir
 
 		if util.IsDir(path) {
 			files := util.FindFiles(path)
@@ -76,11 +60,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 					sys := s.Sys()
 
-<<<<<<< HEAD
 					fmt.Printf("%v %5d %-5d %-18s /%s\n", perms, sys.(*syscall.Stat_t).Uid, sys.(*syscall.Stat_t).Gid, overlays[o], files[file])
-=======
-					fmt.Printf("%v %5d %-5d %-18s /%s\n", perms, sys.(*syscall.Stat_t).Uid, sys.(*syscall.Stat_t).Gid, overlayList[o], files[file])
->>>>>>> eb32d41... Add config option for shared state dir
 
 				}
 			} else {
@@ -88,11 +68,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 			}
 
 		} else {
-<<<<<<< HEAD
 			wwlog.Printf(wwlog.ERROR, "system/%s (path not found:%s)\n", overlays[o], path)
-=======
-			wwlog.Printf(wwlog.ERROR, "system/%s (path not found:%s)\n", overlayList[o], path)
->>>>>>> eb32d41... Add config option for shared state dir
 		}
 	}
 

--- a/internal/pkg/container/imprt.go
+++ b/internal/pkg/container/imprt.go
@@ -15,7 +15,7 @@ import (
 )
 
 func ImportDocker(uri string, name string, sCtx *types.SystemContext) error {
-	OciBlobCacheDir := 	warewulfconf.DataStore() + "/oci/blobs"
+	OciBlobCacheDir := 	warewulfconf.DataStore() + "/oci"
 
 	err := os.MkdirAll(OciBlobCacheDir, 0755)
 	if err != nil {

--- a/internal/pkg/container/imprt.go
+++ b/internal/pkg/container/imprt.go
@@ -9,13 +9,13 @@ import (
 	"github.com/containers/storage/drivers/copy"
 	"github.com/pkg/errors"
 
-	"github.com/hpcng/warewulf/internal/pkg/config"
+	"github.com/hpcng/warewulf/internal/pkg/warewulfconf"
 	"github.com/hpcng/warewulf/internal/pkg/oci"
 	"github.com/hpcng/warewulf/internal/pkg/util"
 )
 
 func ImportDocker(uri string, name string, sCtx *types.SystemContext) error {
-	OciBlobCacheDir := config.LocalStateDir + "/oci/blobs"
+	OciBlobCacheDir := 	warewulfconf.DataStore() + "/oci/blobs"
 
 	err := os.MkdirAll(OciBlobCacheDir, 0755)
 	if err != nil {

--- a/internal/pkg/container/util.go
+++ b/internal/pkg/container/util.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/hpcng/warewulf/internal/pkg/config"
+	"github.com/hpcng/warewulf/internal/pkg/warewulfconf"
 	"github.com/hpcng/warewulf/internal/pkg/util"
 	"github.com/hpcng/warewulf/internal/pkg/wwlog"
 )
@@ -21,7 +21,7 @@ func ValidName(name string) bool {
 }
 
 func SourceParentDir() string {
-	return path.Join(config.LocalStateDir, "chroots")
+	return path.Join(warewulfconf.DataStore(), "chroots")
 }
 
 func SourceDir(name string) string {
@@ -33,7 +33,7 @@ func RootFsDir(name string) string {
 }
 
 func ImageParentDir() string {
-	return path.Join(config.LocalStateDir, "provision/container/")
+	return path.Join(warewulfconf.DataStore(), "provision/container/")
 }
 
 func ImageFile(name string) string {

--- a/internal/pkg/kernel/kernel.go
+++ b/internal/pkg/kernel/kernel.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/hpcng/warewulf/internal/pkg/config"
+	"github.com/hpcng/warewulf/internal/pkg/warewulfconf"
 	"github.com/hpcng/warewulf/internal/pkg/util"
 	"github.com/hpcng/warewulf/internal/pkg/wwlog"
 )
@@ -27,7 +27,7 @@ var (
 )
 
 func ParentDir() string {
-	return path.Join(config.LocalStateDir, "provision/kernel")
+	return path.Join(warewulfconf.DataStore(), "provision/kernel")
 }
 
 func KernelImage(kernelName string) string {
@@ -111,7 +111,7 @@ func ListKernels() ([]string, error) {
 
 func Build(kernelVersion string, kernelName string, root string) (string, error) {
 	kernelDrivers := path.Join(root, "/lib/modules/"+kernelVersion)
-  kernelDriversRelative := path.Join("/lib/modules/"+kernelVersion)
+    kernelDriversRelative := path.Join("/lib/modules/"+kernelVersion)
 	kernelDestination := KernelImage(kernelName)
 	driversDestination := KmodsImage(kernelName)
 	versionDestination := KernelVersion(kernelName)

--- a/internal/pkg/oci/cache.go
+++ b/internal/pkg/oci/cache.go
@@ -9,12 +9,6 @@ import (
 	"github.com/containers/image/v5/types"
 )
 
-const (
-	defaultCachePath = "/var/warewulf/container-cache/oci/"
-	blobPrefix       = "blobs"
-	rootfsPrefix     = "rootfs"
-)
-
 type CacheOpt func(*Cache) error
 
 func OptSetCachePath(path string) CacheOpt {

--- a/internal/pkg/oci/defaults.go
+++ b/internal/pkg/oci/defaults.go
@@ -1,0 +1,11 @@
+package oci
+
+import 	"github.com/hpcng/warewulf/internal/pkg/warewulfconf"
+import  "path/filepath"
+
+var defaultCachePath = filepath.Join(warewulfconf.DataStore(), "/container-cache/oci/")
+
+const (
+	blobPrefix       = "blobs"
+	rootfsPrefix     = "rootfs"
+)

--- a/internal/pkg/overlay/config.go
+++ b/internal/pkg/overlay/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 func OverlayDir() string {
-	return path.Join(warewulfconf.DataStore(), "provision/overlays")
+	return path.Join(warewulfconf.DataStore(), "/overlays")
 }
 
 func SystemOverlayDir() string {

--- a/internal/pkg/overlay/config.go
+++ b/internal/pkg/overlay/config.go
@@ -1,19 +1,15 @@
-package config
+package overlay
 
 import (
-	"fmt"
 	"path"
 
 	"github.com/hpcng/warewulf/internal/pkg/util"
 	"github.com/hpcng/warewulf/internal/pkg/wwlog"
-)
-
-const (
-	LocalStateDir = "/var/warewulf"
+	"github.com/hpcng/warewulf/internal/pkg/warewulfconf"
 )
 
 func OverlayDir() string {
-	return fmt.Sprintf("%s/overlays/", LocalStateDir)
+	return path.Join(warewulfconf.DataStore(), "provision/overlays")
 }
 
 func SystemOverlayDir() string {
@@ -63,7 +59,7 @@ func SystemOverlayImage(nodeName string) string {
 		return ""
 	}
 
-	return fmt.Sprintf("%s/provision/overlays/system/%s.img", LocalStateDir, nodeName)
+	return path.Join(SystemOverlayDir(), nodeName+".img")
 }
 
 func RuntimeOverlayImage(nodeName string) string {
@@ -77,5 +73,5 @@ func RuntimeOverlayImage(nodeName string) string {
 		return ""
 	}
 
-	return fmt.Sprintf("%s/provision/overlays/runtime/%s.img", LocalStateDir, nodeName)
+	return path.Join(RuntimeOverlayDir(), nodeName+".img")
 }

--- a/internal/pkg/overlay/config.go
+++ b/internal/pkg/overlay/config.go
@@ -3,21 +3,28 @@ package overlay
 import (
 	"path"
 
-	"github.com/hpcng/warewulf/internal/pkg/util"
-	"github.com/hpcng/warewulf/internal/pkg/wwlog"
 	"github.com/hpcng/warewulf/internal/pkg/warewulfconf"
+	"github.com/hpcng/warewulf/internal/pkg/wwlog"
+	"github.com/hpcng/warewulf/internal/pkg/util"
 )
 
-func OverlayDir() string {
-	return path.Join(warewulfconf.DataStore(), "/overlays")
+func OverlaySourceTopDir() string {
+	return path.Join(warewulfconf.DataStore(), "overlays/")
 }
 
+func OverlaySourceDir(overlayName string) string {
+	return path.Join(OverlaySourceTopDir(), overlayName)
+}
+
+func OverlayImage(nodeName string, overlayName string) string {
+	return path.Join(warewulfconf.DataStore(), "/provision/overlays/", nodeName, overlayName + ".img")
+}
 func SystemOverlayDir() string {
-	return path.Join(OverlayDir(), "/system")
+	return path.Join(OverlaySourceTopDir(), "/system")
 }
 
 func RuntimeOverlayDir() string {
-	return path.Join(OverlayDir(), "/runtime")
+	return path.Join(OverlaySourceTopDir(), "/runtime")
 }
 
 func SystemOverlaySource(overlayName string) string {
@@ -59,7 +66,7 @@ func SystemOverlayImage(nodeName string) string {
 		return ""
 	}
 
-	return path.Join(SystemOverlayDir(), nodeName+".img")
+	return path.Join(warewulfconf.DataStore(), "/provision/overlays/runtime/", nodeName + ".img")
 }
 
 func RuntimeOverlayImage(nodeName string) string {
@@ -73,5 +80,5 @@ func RuntimeOverlayImage(nodeName string) string {
 		return ""
 	}
 
-	return path.Join(RuntimeOverlayDir(), nodeName+".img")
+	return path.Join(warewulfconf.DataStore(), "/provision/overlays/system/", nodeName + ".img")
 }

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -57,18 +57,6 @@ func FindRuntimeOverlays() ([]string, error) {
 }
 */
 
-func OverlaySourceTopDir() string {
-	return path.Join(config.LocalStateDir, "overlays/")
-}
-
-func OverlaySourceDir(overlayName string) string {
-	return path.Join(OverlaySourceTopDir(), overlayName)
-}
-
-func OverlayImage(nodename string, overlayname string) string {
-	return fmt.Sprintf("%s/provision/overlays/%s/%s.img", config.LocalStateDir, nodename, overlayname)
-}
-
 func BuildAllOverlays(nodes []node.NodeInfo) error {
 	for _, n := range nodes {
 		var overlays []string

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hpcng/warewulf/internal/pkg/config"
 	"github.com/hpcng/warewulf/internal/pkg/node"
 	"github.com/hpcng/warewulf/internal/pkg/util"
 	"github.com/hpcng/warewulf/internal/pkg/wwlog"

--- a/internal/pkg/warewulfconf/constructors.go
+++ b/internal/pkg/warewulfconf/constructors.go
@@ -4,22 +4,25 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"errors"
 
 	"github.com/brotherpowers/ipsubnet"
 	"github.com/hpcng/warewulf/internal/pkg/wwlog"
+
 	"gopkg.in/yaml.v2"
 )
 
-var singleton ControllerConf
+var cachedConf ControllerConf
 
 func New() (ControllerConf, error) {
-	var ret ControllerConf
+	var ret ControllerConf = *defaultConfig()
 
-	if (ControllerConf{}) == singleton {
+	// Check if cached config is old before re-reading config file
+	if !cachedConf.current {
 		wwlog.Printf(wwlog.DEBUG, "Opening Warewulf configuration file: %s\n", ConfigFile)
 		data, err := ioutil.ReadFile(ConfigFile)
 		if err != nil {
-			fmt.Printf("error reading Warewulf configuration file\n")
+			fmt.Printf("Error reading Warewulf configuration file\n")
 			return ret, err
 		}
 
@@ -29,11 +32,16 @@ func New() (ControllerConf, error) {
 			return ret, err
 		}
 
+// TODO: Need to add comprehensive config file validator
+// TODO: Change function to guess default IP address and/or mask from local system
 		if ret.Ipaddr == "" {
-			wwlog.Printf(wwlog.WARN, "IP address is not configured in warewulfd.conf\n")
+			wwlog.Printf(wwlog.ERROR, "IP address is not configured in warewulfd.conf\n")
+			return ret, errors.New("no IP Address")
 		}
+
 		if ret.Netmask == "" {
-			wwlog.Printf(wwlog.WARN, "Netmask is not configured in warewulfd.conf\n")
+			wwlog.Printf(wwlog.ERROR, "Netmask is not configured in warewulfd.conf\n")
+			return ret, errors.New("no netmask")
 		}
 
 		if ret.Network == "" {
@@ -46,16 +54,17 @@ func New() (ControllerConf, error) {
 		}
 
 		if ret.Warewulf.Port == 0 {
-			ret.Warewulf.Port = 9873
+			ret.Warewulf.Port = defaultPort
 		}
 
 		wwlog.Printf(wwlog.DEBUG, "Returning warewulf config object\n")
-		singleton = ret
+		cachedConf = ret
+		cachedConf.current = true
 
 	} else {
 		wwlog.Printf(wwlog.DEBUG, "Returning cached warewulf config object\n")
-
-		ret = singleton
+		// If cached struct isn't empty, use it as the return value 
+		ret = cachedConf
 	}
 
 	return ret, nil

--- a/internal/pkg/warewulfconf/datastructure.go
+++ b/internal/pkg/warewulfconf/datastructure.go
@@ -6,10 +6,8 @@ import (
 	"github.com/hpcng/warewulf/internal/pkg/wwlog"
 )
 
-var ConfigFile = "/etc/warewulf/warewulf.conf"
-
 type ControllerConf struct {
-	Comment  string        `yaml:"comment"`
+	Comment  string        `yaml:"comment,omitempty"`
 	Ipaddr   string        `yaml:"ipaddr"`
 	Netmask  string        `yaml:"netmask"`
 	Network  string        `yaml:"network,omitempty"`
@@ -18,14 +16,16 @@ type ControllerConf struct {
 	Dhcp     *DhcpConf     `yaml:"dhcp"`
 	Tftp     *TftpConf     `yaml:"tftp"`
 	Nfs      *NfsConf      `yaml:"nfs"`
+	current  bool
 }
 
 type WarewulfConf struct {
-	Port              int  `yaml:"port"`
-	Secure            bool `yaml:"secure"`
-	UpdateInterval    int  `yaml:"update interval"`
-	AutobuildOverlays bool `yaml:"autobuild overlays"`
-	Syslog            bool `yaml:"syslog"`
+	Port              int    `yaml:"port"`
+	Secure            bool   `yaml:"secure"`
+	UpdateInterval    int    `yaml:"update interval"`
+	AutobuildOverlays bool   `yaml:"autobuild overlays"`
+	Syslog            bool   `yaml:"syslog"`
+	DataStore         string `yaml:"datastore"`
 }
 
 type DhcpConf struct {
@@ -34,7 +34,7 @@ type DhcpConf struct {
 	RangeStart  string `yaml:"range start"`
 	RangeEnd    string `yaml:"range end"`
 	SystemdName string `yaml:"systemd name"`
-	ConfigFile  string `yaml:"config file"`
+	ConfigFile  string `yaml:"config file,omitempty"`
 }
 
 type TftpConf struct {
@@ -70,11 +70,20 @@ func (s *NfsConf) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+
 func init() {
-	//TODO: Check to make sure nodes.conf is found
 	if !util.IsFile(ConfigFile) {
 		wwlog.Printf(wwlog.ERROR, "Configuration file not found: %s\n", ConfigFile)
 		// fail silently as this also called by bash_completion
-		return
 	}
+	_, err := New()
+	if err != nil {
+		wwlog.Printf(wwlog.ERROR, "Could not read Warewulf configuration file: %s\n", err)
+	}
+}
+
+// Waste processor cycles to make code more readable
+
+func DataStore() string {
+	return cachedConf.Warewulf.DataStore
 }

--- a/internal/pkg/warewulfconf/defaults.go
+++ b/internal/pkg/warewulfconf/defaults.go
@@ -2,46 +2,46 @@ package warewulfconf
 
 const (
 	defaultDataStore string = "/srv/warewulf"
-	defaultPort int = 9983
+	defaultPort      int    = 9983
 )
 
 var ConfigFile string = "/etc/warewulf/warewulf.conf"
 
 func defaultConfig() *ControllerConf {
 	Warewulf := &WarewulfConf{
-		Port: defaultPort,
-		Secure: true,
-		UpdateInterval: 60,
+		Port:              defaultPort,
+		Secure:            true,
+		UpdateInterval:    60,
 		AutobuildOverlays: true,
-		Syslog: false,
-		DataStore: defaultDataStore,
+		Syslog:            false,
+		DataStore:         defaultDataStore,
 	}
 	Dhcp := &DhcpConf{
-			Enabled: true,
-			Template: "default",
-			RangeStart: "192.168.200.50",
-			RangeEnd: "192.168.200.99",
-			SystemdName: "dhcpd",
-			ConfigFile: "/etc/dhcp/dhcpd.conf",
-		}
+		Enabled:     true,
+		Template:    "default",
+		RangeStart:  "192.168.200.50",
+		RangeEnd:    "192.168.200.99",
+		SystemdName: "dhcpd",
+		ConfigFile:  "/etc/dhcp/dhcpd.conf",
+	}
 	Tftp := &TftpConf{
-			Enabled: true,
-			TftpRoot: "/var/lib/tftpboot",
-			SystemdName: "tftp",
-		}
+		Enabled:     true,
+		TftpRoot:    "/var/lib/tftpboot",
+		SystemdName: "tftp",
+	}
 	Nfs := &NfsConf{
-		    Enabled: true,
-			Exports: []string{"/home",
-				defaultDataStore,
-			},
-			SystemdName: "nfs-server",
-		}
+		Enabled: true,
+		Exports: []string{"/home",
+			defaultDataStore,
+		},
+		SystemdName: "nfs-server",
+	}
 
 	return &ControllerConf{
 		Warewulf: Warewulf,
-        Dhcp: Dhcp,
-		Tftp: Tftp,
-		Nfs: Nfs,
-		current: false,
+		Dhcp:     Dhcp,
+		Tftp:     Tftp,
+		Nfs:      Nfs,
+		current:  false,
 	}
 }

--- a/internal/pkg/warewulfconf/defaults.go
+++ b/internal/pkg/warewulfconf/defaults.go
@@ -1,11 +1,11 @@
 package warewulfconf
 
-const (
-	defaultDataStore string = "/srv/warewulf"
-	defaultPort      int    = 9983
-)
+const defaultPort      int    = 9983
 
-var ConfigFile string = "/etc/warewulf/warewulf.conf"
+var (
+	ConfigFile string = "/etc/warewulf/warewulf.conf"
+	defaultDataStore string = "/var/lib/warewulf"
+)
 
 func defaultConfig() *ControllerConf {
 	Warewulf := &WarewulfConf{

--- a/internal/pkg/warewulfconf/defaults.go
+++ b/internal/pkg/warewulfconf/defaults.go
@@ -1,0 +1,47 @@
+package warewulfconf
+
+const (
+	defaultDataStore string = "/srv/warewulf"
+	defaultPort int = 9983
+)
+
+var ConfigFile string = "/etc/warewulf/warewulf.conf"
+
+func defaultConfig() *ControllerConf {
+	Warewulf := &WarewulfConf{
+		Port: defaultPort,
+		Secure: true,
+		UpdateInterval: 60,
+		AutobuildOverlays: true,
+		Syslog: false,
+		DataStore: defaultDataStore,
+	}
+	Dhcp := &DhcpConf{
+			Enabled: true,
+			Template: "default",
+			RangeStart: "192.168.200.50",
+			RangeEnd: "192.168.200.99",
+			SystemdName: "dhcpd",
+			ConfigFile: "/etc/dhcp/dhcpd.conf",
+		}
+	Tftp := &TftpConf{
+			Enabled: true,
+			TftpRoot: "/var/lib/tftpboot",
+			SystemdName: "tftp",
+		}
+	Nfs := &NfsConf{
+		    Enabled: true,
+			Exports: []string{"/home",
+				defaultDataStore,
+			},
+			SystemdName: "nfs-server",
+		}
+
+	return &ControllerConf{
+		Warewulf: Warewulf,
+        Dhcp: Dhcp,
+		Tftp: Tftp,
+		Nfs: Nfs,
+		current: false,
+	}
+}

--- a/internal/pkg/warewulfconf/defaults.go
+++ b/internal/pkg/warewulfconf/defaults.go
@@ -31,9 +31,7 @@ func defaultConfig() *ControllerConf {
 	}
 	Nfs := &NfsConf{
 		Enabled: true,
-		Exports: []string{"/home",
-			defaultDataStore,
-		},
+		Exports: []string{"/home",},
 		SystemdName: "nfs-server",
 	}
 

--- a/internal/pkg/warewulfconf/modifiers.go
+++ b/internal/pkg/warewulfconf/modifiers.go
@@ -22,8 +22,9 @@ func (controller *ControllerConf) Persist() error {
 
 	defer file.Close()
 
-	_, err = file.WriteString(string(out))
+	_, err = file.WriteString(string(out)+"\n")
 	if err != nil {
+		wwlog.Printf(wwlog.ERROR, "Unable to write to warewulf.conf\n")
 		return err
 	}
 

--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -1,5 +1,5 @@
 %global wwgroup warewulf
-%{!?wwshared: %global wwshared %{_localstatedir}}
+%global wwshared @WWROOT@/warewulf
 %define debug_package %{nil}
 
 Name: warewulf
@@ -51,6 +51,9 @@ system for large clusters of bare metal and/or virtual systems.
 
 
 %build
+%if 0%{?sle_version}
+make all TFTPROOT="/srv/tftpboot"
+%else
 make all
 
 
@@ -86,16 +89,15 @@ getent group %{wwgroup} >/dev/null || groupadd -r %{wwgroup}
 %{wwshared}/%{name}/overlays/system/*
 
 %attr(-, root, root) %{_bindir}/wwctl
-%if 0%{?rhel}
 %attr(-, root, root) %{_prefix}/lib/firewalld/services/warewulf.xml
-%else
-# sle_version
-%attr(-, root, root) %{_libexecdir}/firewalld/services/warewulf.xml
-%endif
 %attr(-, root, root) %{_unitdir}/warewulfd.service
 %attr(-, root, root) %{_mandir}/man1/wwctl*
 
 %changelog
+* Wed Dec 15 2021 Jeremy Siadal <jeremy.c.siadal@intel.com> - 4.2.0-1
+- Relocate tftpboot for OpenSUSE
+- Remove libexecdir macro; changing in OpenSUSE 15.4
+
 * Mon Nov 1 2021 Jeremy Siadal <jeremy.c.siadal@intel.com> - 4.2.0-1
 - Add support for OpenSUSE
 - Update file attribs

--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -87,8 +87,7 @@ getent group %{wwgroup} >/dev/null || groupadd -r %{wwgroup}
 %{_sysconfdir}/bash_completion.d/warewulf
 
 %dir %{wwshared}/%{name}
-%{wwshared}/%{name}/overlays/runtime/*
-%{wwshared}/%{name}/overlays/system/*
+%{wwshared}/%{name}/overlays/*
 
 %attr(-, root, root) %{_bindir}/wwctl
 %attr(-, root, root) %{_prefix}/lib/firewalld/services/warewulf.xml
@@ -96,7 +95,8 @@ getent group %{wwgroup} >/dev/null || groupadd -r %{wwgroup}
 %attr(-, root, root) %{_mandir}/man1/wwctl*
 
 %changelog
-* Wed Dec 22 2021 Jeremy Siadal <jeremy.c.siadal@intel.com> - 4.2.0-1
+* Tue Jan 11 2022 Jeremy Siadal <jeremy.c.siadal@intel.com> - 4.2.0-1
+- Merge overlay subdirectories
 - Add configuration options to make
 - Relocate tftpboot for OpenSUSE
 - Remove libexecdir macro; changing in OpenSUSE 15.4

--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -1,5 +1,10 @@
 %global wwgroup warewulf
 %global wwshared @WWROOT@
+%if 0%{?sle_version}
+%global tftpdir "/srv/tftpboot"
+%else
+%global tftpdir "/var/lib/tftpboot"
+%endif
 %define debug_package %{nil}
 
 Name: warewulf
@@ -51,15 +56,11 @@ system for large clusters of bare metal and/or virtual systems.
 
 
 %build
-%if 0%{?sle_version}
-make all TFTPROOT="/srv/tftpboot"
-%else
-make all
-%endif
+make TFTPROOT="%{tftpdir}" WWROOT="%{wwshared}"
 
 
 %install
-%make_install DESTDIR=%{buildroot} %{?mflags_install}
+%make_install DESTDIR=%{buildroot} TFTPROOT="%{tftpdir}" WWROOT="%{wwshared}" %{?mflags_install}
 
 
 %pre
@@ -95,7 +96,8 @@ getent group %{wwgroup} >/dev/null || groupadd -r %{wwgroup}
 %attr(-, root, root) %{_mandir}/man1/wwctl*
 
 %changelog
-* Wed Dec 15 2021 Jeremy Siadal <jeremy.c.siadal@intel.com> - 4.2.0-1
+* Wed Dec 22 2021 Jeremy Siadal <jeremy.c.siadal@intel.com> - 4.2.0-1
+- Add configuration options to make
 - Relocate tftpboot for OpenSUSE
 - Remove libexecdir macro; changing in OpenSUSE 15.4
 

--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -1,5 +1,5 @@
 %global wwgroup warewulf
-%global wwshared @WWROOT@/warewulf
+%global wwshared @WWROOT@
 %define debug_package %{nil}
 
 Name: warewulf
@@ -55,6 +55,7 @@ system for large clusters of bare metal and/or virtual systems.
 make all TFTPROOT="/srv/tftpboot"
 %else
 make all
+%endif
 
 
 %install


### PR DESCRIPTION
This change provides the ability to set the default directory for server files, in addition to changing the active location using the warewulf.conf file. In addition, the default location is moved from /var/warewulf to /srv/warewulf, to strictly adhere to the Linux FHS which generally prohibits new directories directly under /var.

The default locations for both Warewulf server files and TFTP IPXE files are set during make through variables. The currently hardcoded "/warewulf" subdirectory name has not been made configurable in this update.

One nice result is that any missing fields in warewulf.conf now use default values. The IP and netmask are still needed. If those are missing, the warning was changed to an error, because without these fields wwctl will crash.

My understanding of Golang standards is that global variables should be avoided, with a variable owned by the package that creates it. So, the server directory variable, called DataStore, is now owned by warewulfconf. After this change, the config package becomes just more overlay package routines. Those routines have been moved to the overlay package and all imports and references in other packages have been updated.

I renamed some variables that were confusing. Golang style guide recommends variable names be self-descriptive and single-letter variables should be limited to throw-aways, such as loop counters.

There's a new binary called config_defaults, but it does not get installed. It's a developer tool to check round-tripping and changing defaults in warewolf.conf.

Spec file is updated and tested on Rocky 8.5. I did the final test of this PR by building a Rocky 8.5 cluster.
