### PR TITLE
Optimized FilterByName() to weed out redundant queries

### DIFF
--- a/internal/pkg/node/methods.go
+++ b/internal/pkg/node/methods.go
@@ -10,15 +10,19 @@ import "regexp"
 
 func FilterByName(set []NodeInfo, searchList []string) []NodeInfo {
 	var ret []NodeInfo
+	unique := make(map[string]NodeInfo)
 
 	if len(searchList) > 0 {
 		for _, search := range searchList {
 			for _, entry := range set {
 				b, _ := regexp.MatchString("^"+search+"$", entry.Id.Get())
 				if b {
-					ret = append(ret, entry)
+					unique[entry.Id.Get()] = entry
 				}
 			}
+		}
+		for _, n := range unique {
+			ret = append(ret, n)
 		}
 	} else {
 		ret = set


### PR DESCRIPTION
Minor fix-up to cleanup search query so duplicate node entries don't show up multiple times:

```
$ sudo wwctl node list n0000 n0000
NODE NAME              PROFILES                   NETWORK
================================================================================
n0000                  default                    eth0:192.168.1.1
n0000                  default                    eth0:192.168.1.1
```

Vs.

```
$ sudo ./wwctl node list n0000 n0000
NODE NAME              PROFILES                   NETWORK
================================================================================
n0000                  default                    eth0:192.168.1.1
```