### PR TITLE
Minor fix of path.Join() usage

### DIFF
--- a/internal/pkg/kernel/kernel.go
+++ b/internal/pkg/kernel/kernel.go
@@ -110,8 +110,8 @@ func ListKernels() ([]string, error) {
 }
 
 func Build(kernelVersion, kernelName, root string) (string, error) {
-	kernelDrivers := path.Join(root, "/lib/modules/"+kernelVersion)
-	kernelDriversRelative := path.Join("/lib/modules/" + kernelVersion)
+	kernelDrivers := path.Join(root, "/lib/modules/", kernelVersion)
+	kernelDriversRelative := path.Join("/lib/modules/", kernelVersion)
 	kernelDestination := KernelImage(kernelName)
 	driversDestination := KmodsImage(kernelName)
 	versionDestination := KernelVersionFile(kernelName)


### PR DESCRIPTION
Minor fix up of `path.Join()` syntax referring to comment in #241.