### PR TITLE
removed leading /etc for key location

### DIFF
--- a/internal/app/wwctl/configure/ssh/main.go
+++ b/internal/app/wwctl/configure/ssh/main.go
@@ -20,7 +20,7 @@ func Configure(show bool) error {
 	if os.Getuid() == 0 {
 		fmt.Printf("Updating system keys\n")
 
-		wwkeydir := path.Join(buildconfig.SYSCONFDIR(), "/etc/warewulf/keys") + "/"
+		wwkeydir := path.Join(buildconfig.SYSCONFDIR(), "warewulf/keys") + "/"
 
 		err := os.MkdirAll(path.Join(buildconfig.SYSCONFDIR(), "warewulf/keys"), 0755)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Christian Goll <cgoll@suse.de>
