### PR TITLE
Missing hyphen in dhcp template path. Unit tests.

### DIFF
--- a/internal/app/wwctl/configure/dhcp/dhcp_main_test.go
+++ b/internal/app/wwctl/configure/dhcp/dhcp_main_test.go
@@ -1,0 +1,25 @@
+package dhcp
+
+import (
+	"testing"
+)
+
+func TestDhcpTemplateFile(t *testing.T) {
+	tests := []struct{
+		parameter string
+		expected string
+	}{
+		{"", "/usr/local/etc/warewulf/dhcp/default-dhcpd.conf"},
+		{"default", "/usr/local/etc/warewulf/dhcp/default-dhcpd.conf"},
+		{"static", "/usr/local/etc/warewulf/dhcp/static-dhcpd.conf"},
+		{"/test/absolute/path.conf", "/test/absolute/path.conf"},
+	}
+	for _, tt := range tests {
+		actual := dhcpTemplateFile(tt.parameter)
+		if actual != tt.expected {
+			t.Errorf("dhcpTemplateFile(%v) expected: %v, actual: %v",
+				tt.parameter, tt.expected, actual)
+		}
+	}
+}
+

--- a/internal/app/wwctl/configure/dhcp/main.go
+++ b/internal/app/wwctl/configure/dhcp/main.go
@@ -84,16 +84,7 @@ func Configure(show bool) error {
 
 	d.Nodes = append(d.Nodes, nodes...)
 
-	if controller.Dhcp.Template == "" {
-		templateFile = path.Join(buildconfig.SYSCONFDIR(), "warewulf/dhcp/default-dhcpd.conf")
-	} else {
-		if strings.HasPrefix(controller.Dhcp.Template, "/") {
-			templateFile = controller.Dhcp.Template
-		} else {
-			templateFile = path.Join(buildconfig.SYSCONFDIR(), "warewulf/dhcp/"+controller.Dhcp.Template+"dhcpd.conf")
-		}
-	}
-
+	templateFile = dhcpTemplateFile(controller.Dhcp.Template)
 	tmpl, err := template.New(path.Base(templateFile)).ParseFiles(templateFile)
 	if err != nil {
 		wwlog.Printf(wwlog.ERROR, "%s\n", err)
@@ -136,4 +127,18 @@ func Configure(show bool) error {
 	}
 
 	return nil
+}
+
+// dhcpTemplateFile returns the path of the warewulf dhcp template given controller.Dhcp.Template.
+func dhcpTemplateFile(controllerDhcpTemplate string) (templateFile string) {
+	if controllerDhcpTemplate == "" {
+		templateFile = path.Join(buildconfig.SYSCONFDIR(), "warewulf/dhcp/default-dhcpd.conf")
+	} else {
+		if strings.HasPrefix(controllerDhcpTemplate, "/") {
+			templateFile = controllerDhcpTemplate
+		} else {
+			templateFile = path.Join(buildconfig.SYSCONFDIR(), "warewulf/dhcp/"+controllerDhcpTemplate+"-dhcpd.conf")
+		}
+	}
+	return
 }


### PR DESCRIPTION
This is a single character bug fix.
Broke this out into a function for testing.