### PR TITLE
Fix wwctl chmod arg parsing.

### DIFF
--- a/internal/app/wwctl/overlay/chmod/chmod_test.go
+++ b/internal/app/wwctl/overlay/chmod/chmod_test.go
@@ -1,0 +1,21 @@
+package chmod
+
+import (
+	"testing"
+)
+
+// TestArgsOverlayChmod is a regression test for 260.
+// Two arguments should fail, three should succeed.
+func TestArgsOverlayChmod(t *testing.T) {
+	command := GetCommand()
+
+	err := command.Args(command, []string{"overlay_name", "file_name"})
+	if err == nil {
+		t.Errorf("two arguments to overlay chmod should fail")
+	}
+
+	err = command.Args(command, []string{"overlay_name", "file_name", "0755"})
+	if err != nil {
+		t.Errorf("three arguments to overlay chmod should succeed")
+	}
+}

--- a/internal/app/wwctl/overlay/chmod/main.go
+++ b/internal/app/wwctl/overlay/chmod/main.go
@@ -17,7 +17,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	overlayName := args[0]
 	fileName := args[1]
 
-	permissionMode, err := strconv.ParseInt(args[3], 8, 32)
+	permissionMode, err := strconv.ParseUint(args[2], 8, 32)
 	if err != nil {
 		wwlog.Printf(wwlog.ERROR, "Could not convert requested mode: %s\n", err)
 		os.Exit(1)


### PR DESCRIPTION
Tested manually by: sudo wwctl overlay chmod wwinit /warewulf/wwinit 755
Considering how to automate such testing. It may require a make install on the build machine, and I need to find out more about how that works.