### PR TITLE
nfs fix

### DIFF
--- a/internal/app/wwctl/configure/nfs/main.go
+++ b/internal/app/wwctl/configure/nfs/main.go
@@ -61,11 +61,6 @@ func Configure(show bool) error {
 
 			fmt.Fprintf(exports, "# This file was written by Warewulf (wwctl configure nfs)\n")
 
-			for _, export := range controller.Nfs.Exports {
-				fmt.Fprintf(exports, "%s %s/%s(sync)\n", export, controller.Network, controller.Netmask)
-				fmt.Fprintf(fstab, "%s:%s %s nfs defaults 0 0\n", controller.Ipaddr, export, export)
-			}
-
 			for _, export := range controller.Nfs.ExportsExtended {
 				fmt.Fprintf(exports, "%s %s/%s(%s)\n", export.Path, controller.Network, controller.Netmask, export.ExportOptions)
 				if export.Mount {
@@ -102,9 +97,6 @@ func Configure(show bool) error {
 		}
 		fmt.Printf("\n")
 		fmt.Printf("SYSTEM OVERLAY: wwinit/etc/fstab:\n")
-		for _, export := range controller.Nfs.Exports {
-			fmt.Printf("%s:%s %s nfs defaults 0 0\n", controller.Ipaddr, export, export)
-		}
 		for _, export := range controller.Nfs.ExportsExtended {
 			fmt.Printf("%s:%s %s nfs defaults 0 0\n", controller.Ipaddr, export.Path, export.Path)
 		}

--- a/internal/pkg/warewulfconf/defaults.go
+++ b/internal/pkg/warewulfconf/defaults.go
@@ -26,17 +26,11 @@ func defaultConfig() *ControllerConf {
 		TftpRoot:    "/var/lib/tftpboot",
 		SystemdName: "tftp",
 	}
-	Nfs := &NfsConf{
-		Enabled:     true,
-		Exports:     []string{"/home"},
-		SystemdName: "nfs-server",
-	}
 
 	return &ControllerConf{
 		Warewulf: Warewulf,
 		Dhcp:     Dhcp,
 		Tftp:     Tftp,
-		Nfs:      Nfs,
 		current:  false,
 	}
 }


### PR DESCRIPTION
Even if `/home/` is defined in `warewulf.conf` a second mount will show up
in `fstab` and `exports` as this line is filed via the default settings

- nfs mount option must be defaults
- remove default home mount
