### PR TITLE
Fix container build --all. #215.

### DIFF
--- a/internal/app/wwctl/container/build/build_test.go
+++ b/internal/app/wwctl/container/build/build_test.go
@@ -1,0 +1,20 @@
+package build
+
+import (
+	"testing"
+)
+
+// TestArgsContainerBuild is a regression test for 215.
+func TestArgsContainerBuild(t *testing.T) {
+	command := GetCommand()
+
+	err := command.Args(command, []string{})
+	if err != nil {
+		t.Errorf("no arguments to container build should succeed.")
+	}
+
+	err = command.Args(command, []string{"container1", "container2"})
+	if err != nil {
+		t.Errorf("multiple arguments to container build should succeed.")
+	}
+}

--- a/internal/app/wwctl/container/build/root.go
+++ b/internal/app/wwctl/container/build/root.go
@@ -12,7 +12,7 @@ var (
 		Short: "(Re)build a bootable VNFS image",
 		Long:  "This command will build a bootable VNFS image from imported CONTAINER image(s).",
 		RunE:  CobraRunE,
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.ArbitraryArgs,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) != 0 {
 				return nil, cobra.ShellCompDirectiveNoFileComp


### PR DESCRIPTION
We didn't need to add an arg check here because it's already there.