### PR TITLE
Fix network name in /etc/hosts. Fixes #247.

### DIFF
--- a/etc/hosts.tmpl
+++ b/etc/hosts.tmpl
@@ -1,15 +1,15 @@
 {{$.PrevHostFile}}# Do not edit after this line - these host entries are maintained by warewulf
 
-{{range $node := $.AllNodes}}
+{{range $node := $.AllNodes}}                  {{/* for each node */}}
 # Entry for {{$node.Id.Get}}
-{{- range $devname, $netdev := $node.NetDevs}}
-{{- if $netdev.Ipaddr.Defined}}
-{{- if $netdev.Default.GetB}}
-{{$netdev.Ipaddr.Get}} {{$node.Id.Get}}
+{{- range $devname, $netdev := $node.NetDevs}} {{/* for each network device on the node */}}
+{{- if $netdev.Ipaddr.Defined}}                {{/* if we have an ip address on this network device */}}
+{{- if $netdev.Default.GetB}}                  {{/* emit the node name as hostname if this is the default */}}
+{{$netdev.Ipaddr.Get}} {{$node.Id.Get}} {{$node.Id.Get}}-{{$devname}} {{$node.Id.Get}}-{{$netdev.Device.Get}}
 {{- else}}
-{{$netdev.Ipaddr.Get}} {{$node.Id.Get}}-{{$devname}}
-{{- end}}
-{{- end}}
-{{- end}}
-{{end}}
+{{$netdev.Ipaddr.Get}} {{$node.Id.Get}}-{{$devname}} {{$node.Id.Get}}-{{$netdev.Device.Get}}
+{{- end}} {{/* end if default */}}
+{{- end}} {{/* end if ip */}}
+{{- end}} {{/* end for each network device */}}
+{{end}}   {{/* end for each node */}}
 


### PR DESCRIPTION
For hosts with ip addresses, the hosts file entry should be:
```
<ip> <node_name> <node_name>-<network_device>
```
I have a fix for this here. Manual testing with the command below gives me the result below. I'm not immediately sure of a great way to test this because it would modify /etc/hosts. Sounds like I need to understand CI more.

I had to manually copy in the template file because the makefile install does not clobber it. 
Installation:
```
[mhink@localhost warewulf]$ pwd
/home/mhink/go/src/github.com/hpcng/warewulf
sudo cp etc/hosts.tmpl /usr/local/etc/warewulf/hosts.tmpl
sudo chmod 644 /usr/local/etc/warewulf/hosts.tmpl
```
Configuration:
```
[mhink@localhost warewulf]$ sudo wwctl configure hosts
[mhink@localhost warewulf]$ cat /etc/hosts
127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
# Do not edit after this line - these host entries are maintained by warewulf


# Entry for n0000
10.0.8.150 n0000 n0000-eth0
```

