### PR TITLE
moved fstab creation for nodes to template

### DIFF
--- a/overlays/wwinit/etc/fstab.ww
+++ b/overlays/wwinit/etc/fstab.ww
@@ -1,0 +1,8 @@
+rootfs / tmpfs defaults 0 0
+devpts /dev/pts devpts gid=5,mode=620 0 0
+tmpfs /run/shm tmpfs defaults 0 0
+sysfs /sys sysfs defaults 0 0
+proc /proc proc defaults 0 0
+{{range .NFSMounts}}
+        {{.}}
+{{end}}


### PR DESCRIPTION
the file `/etc/fstab` created with `wwctl configure nfs` takes bits which are baked into wwctl. Having the file as a template `fstab.ww` allows some flexibilty for other mounts.
