### PR TITLE
heck if ./.ww4/exludes exist and use if its exists

### DIFF
--- a/internal/pkg/container/build.go
+++ b/internal/pkg/container/build.go
@@ -48,10 +48,15 @@ func Build(name string, buildForce bool) error {
 	} else {
 		wwlog.Printf(wwlog.VERBOSE, "Using PIGZ to compress the container: %s\n", compressor)
 	}
-
-	wwlog.Printf(wwlog.DEBUG, "Building VNFS image: '%s' -> '%s'\n", rootfsPath, imagePath)
-	cmd := fmt.Sprintf("cd %s; find . | cpio --quiet -o -H newc | %s -c > \"%s\"", rootfsPath, compressor, imagePath)
-
+	var cmd string
+	_, err = os.Stat(path.Join(rootfsPath, "./.ww4/exclude"))
+	if os.IsNotExist(err) {
+		wwlog.Printf(wwlog.DEBUG, "Building VNFS image: '%s' -> '%s'\n", rootfsPath, imagePath)
+		cmd = fmt.Sprintf("cd %s; find . | cpio --quiet -o -H newc | %s -c > \"%s\"", rootfsPath, compressor, imagePath)
+	} else {
+		wwlog.Printf(wwlog.DEBUG, "Building VNFS image with excludes: '%s' -> '%s'\n", rootfsPath, imagePath)
+		cmd = fmt.Sprintf("cd %s; find . | grep -v -f .ww4/exclude | cpio --quiet -o -H newc | %s -c > \"%s\"", rootfsPath, compressor, imagePath)
+	}
 	wwlog.Printf(wwlog.DEBUG, "RUNNING: %s\n", cmd)
 	err = exec.Command("/bin/sh", "-c", cmd).Run()
 	if err != nil {


### PR DESCRIPTION
Usage of this feature is very basic, but an example exlucde file would be
```
/boot/
./var/cache
./usr/src
```
with `./FOO` refering to FOO in the rootfs of the container.
As `wwctld -dv container build FOO` will show the exact command, the 'source' of exclude 
is exhibited to the admin.
