### PR TITLE
will exec /usr/bin/bash if no cmd is provided

### DIFF
--- a/internal/app/wwctl/container/exec/main.go
+++ b/internal/app/wwctl/container/exec/main.go
@@ -18,6 +18,9 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	containerName := args[0]
 	var allargs []string
+	if len(args) == 1 {
+		allargs = append(allargs, "/usr/bin/bash")
+	}
 
 	if !container.ValidSource(containerName) {
 		wwlog.Printf(wwlog.ERROR, "Unknown Warewulf container: %s\n", containerName)

--- a/internal/app/wwctl/container/exec/root.go
+++ b/internal/app/wwctl/container/exec/root.go
@@ -9,13 +9,13 @@ import (
 var (
 	baseCmd = &cobra.Command{
 		DisableFlagsInUseLine: true,
-		Use:   "exec [OPTIONS] CONTAINER COMMAND",
-		Short: "Run a command inside of a Warewulf container",
+		Use:                   "exec [OPTIONS] CONTAINER COMMAND",
+		Short:                 "Run a command inside of a Warewulf container",
 		Long: "Run a COMMAND inside of a warewulf CONTAINER.\n" +
-		      "This is commonly used with an interactive shell such as /bin/bash\n" +
+			"This is commonly used with an interactive shell such as /bin/bash\n" +
 			"to run a virtual environment within the container.",
 		RunE: CobraRunE,
-		Args: cobra.MinimumNArgs(2),
+		Args: cobra.MinimumNArgs(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) != 0 {
 				return nil, cobra.ShellCompDirectiveNoFileComp


### PR DESCRIPTION
Adds `/usr/bin/bash` as default argument for
`wwctl container exec foo` 
