### PR TITLE
execute './.ww4/runExit` on exit of container exec

### DIFF
--- a/internal/app/wwctl/container/exec/child/main.go
+++ b/internal/app/wwctl/container/exec/child/main.go
@@ -85,6 +85,16 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		wwlog.Printf(wwlog.ERROR, "%s\n", err)
 		os.Exit(1)
 	}
+	_, err = os.Stat("./.ww4/runExit")
+	if os.IsNotExist(err) {
+		wwlog.Printf(wwlog.DEBUG, "no exit script")
+		return nil
+	}
+	err = syscall.Exec("./.ww4/runExit", []string{""}, os.Environ())
+	if err != nil {
+		wwlog.Printf(wwlog.ERROR, "%s\n", err)
+		os.Exit(1)
+	}
 
 	return nil
 }

--- a/internal/app/wwctl/container/exec/child/main.go
+++ b/internal/app/wwctl/container/exec/child/main.go
@@ -85,12 +85,13 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		wwlog.Printf(wwlog.ERROR, "%s\n", err)
 		os.Exit(1)
 	}
-	_, err = os.Stat("./.ww4/runExit")
+	_, err = os.Stat("./etc/warewulf/runExit")
 	if os.IsNotExist(err) {
 		wwlog.Printf(wwlog.DEBUG, "no exit script")
 		return nil
 	}
-	err = syscall.Exec("./.ww4/runExit", []string{""}, os.Environ())
+	wwlog.Printf(wwlog.INFO, "Running exit script %s\n", path.Join(container.RootFsDir(containerName), "./etc/warewulf/runExit"))
+	err = syscall.Exec("./etc/warewulf/runExit", []string{""}, os.Environ())
 	if err != nil {
 		wwlog.Printf(wwlog.ERROR, "%s\n", err)
 		os.Exit(1)


### PR DESCRIPTION
After exiting a shell with `wwctl container exec` a script/executeable `./.ww4/runExit`
will be executed.
