### PR TITLE
container info

### DIFF
--- a/internal/app/wwctl/container/root.go
+++ b/internal/app/wwctl/container/root.go
@@ -6,14 +6,15 @@ import (
 	"github.com/hpcng/warewulf/internal/app/wwctl/container/exec"
 	"github.com/hpcng/warewulf/internal/app/wwctl/container/imprt"
 	"github.com/hpcng/warewulf/internal/app/wwctl/container/list"
+	"github.com/hpcng/warewulf/internal/app/wwctl/container/show"
 	"github.com/spf13/cobra"
 )
 
 var (
 	baseCmd = &cobra.Command{
 		DisableFlagsInUseLine: true,
-		Use:   "container COMMAND [OPTIONS]",
-		Short: "Container / VNFS image management",
+		Use:                   "container COMMAND [OPTIONS]",
+		Short:                 "Container / VNFS image management",
 		Long: "Starting with version 4, Warewulf uses containers to build the bootable VNFS\n" +
 			"node images. These commands will help you import, manage, and transform\n" +
 			"containers into bootable Warewulf VNFS images.",
@@ -27,6 +28,8 @@ func init() {
 	baseCmd.AddCommand(imprt.GetCommand())
 	baseCmd.AddCommand(exec.GetCommand())
 	baseCmd.AddCommand(delete.GetCommand())
+	baseCmd.AddCommand(show.GetCommand())
+
 }
 
 // GetRootCommand returns the root cobra.Command for the application.

--- a/internal/app/wwctl/container/show/main.go
+++ b/internal/app/wwctl/container/show/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func CobraRunE(cmd *cobra.Command, args []string) error {
-	containerName := args[1]
+	containerName := args[0]
 	if !container.ValidName(containerName) {
 		return fmt.Errorf("%s is not a valid container", containerName)
 	}
@@ -17,7 +17,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		fmt.Printf("%s\n", container.RootFsDir(containerName))
 	} else {
 		fmt.Printf("Name: %s\n", containerName)
-		fmt.Printf("Rootsfs: %s\n", container.RootFsDir(containerName))
+		fmt.Printf("Rootfs: %s\n", container.RootFsDir(containerName))
 		nodeDB, _ := node.New()
 
 		nodes, _ := nodeDB.FindAllNodes()

--- a/internal/app/wwctl/container/show/main.go
+++ b/internal/app/wwctl/container/show/main.go
@@ -1,0 +1,36 @@
+package list
+
+import (
+	"fmt"
+
+	"github.com/hpcng/warewulf/internal/pkg/container"
+	"github.com/hpcng/warewulf/internal/pkg/node"
+	"github.com/spf13/cobra"
+)
+
+func CobraRunE(cmd *cobra.Command, args []string) error {
+	containerName := args[1]
+	if !container.ValidName(containerName) {
+		return fmt.Errorf("%s is not a valid container", containerName)
+	}
+	if !ShowAll {
+		fmt.Printf("%s\n", container.RootFsDir(containerName))
+	} else {
+		fmt.Printf("Name: %s\n", containerName)
+		fmt.Printf("Rootsfs: %s\n", container.RootFsDir(containerName))
+		nodeDB, _ := node.New()
+
+		nodes, _ := nodeDB.FindAllNodes()
+		var nodeList []string
+		for _, n := range nodes {
+			if n.ContainerName.Get() == containerName {
+
+				nodeList = append(nodeList, n.Id.Get())
+			}
+		}
+		fmt.Printf("Nr nodes: %d\n", len(nodeList))
+		fmt.Printf("Nodes: %s\n", nodeList)
+
+	}
+	return nil
+}

--- a/internal/app/wwctl/container/show/main.go
+++ b/internal/app/wwctl/container/show/main.go
@@ -1,4 +1,4 @@
-package list
+package show
 
 import (
 	"fmt"

--- a/internal/app/wwctl/container/show/root.go
+++ b/internal/app/wwctl/container/show/root.go
@@ -1,4 +1,4 @@
-package list
+package show
 
 import (
 	"github.com/hpcng/warewulf/internal/pkg/container"

--- a/internal/app/wwctl/container/show/root.go
+++ b/internal/app/wwctl/container/show/root.go
@@ -1,0 +1,38 @@
+package list
+
+import (
+	"github.com/hpcng/warewulf/internal/pkg/container"
+	"github.com/spf13/cobra"
+)
+
+var (
+	baseCmd = &cobra.Command{
+		DisableFlagsInUseLine: true,
+		Use:                   "show [OPTIONS] CONTAINER",
+		Short:                 "Show root fs dir for container",
+		Long: `Shows the base directory for the chroot of the given container. 
+		More information about the conainer can be hosw with -a option.`,
+		RunE: CobraRunE,
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) != 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			list, _ := container.ListSources()
+			return list, cobra.ShellCompDirectiveNoFileComp
+		},
+
+		Aliases: []string{"sh", "chroot"},
+		Args:    cobra.MinimumNArgs(1),
+	}
+	ShowAll bool
+)
+
+func Init() {
+	baseCmd.PersistentFlags().BoolVarP(&ShowAll, "all", "a", false, "Show all information about a container")
+
+}
+
+// GetRootCommand returns the root cobra.Command for the application.
+func GetCommand() *cobra.Command {
+	return baseCmd
+}

--- a/internal/app/wwctl/container/show/root.go
+++ b/internal/app/wwctl/container/show/root.go
@@ -11,7 +11,7 @@ var (
 		Use:                   "show [OPTIONS] CONTAINER",
 		Short:                 "Show root fs dir for container",
 		Long: `Shows the base directory for the chroot of the given container. 
-		More information about the conainer can be hosw with -a option.`,
+More information about the conainer can be shown with the '-a' option.`,
 		RunE: CobraRunE,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) != 0 {
@@ -27,7 +27,7 @@ var (
 	ShowAll bool
 )
 
-func Init() {
+func init() {
 	baseCmd.PersistentFlags().BoolVarP(&ShowAll, "all", "a", false, "Show all information about a container")
 
 }


### PR DESCRIPTION
Adds the command `wwctl container show $FOO` what will show the 
rootfs for the container $FOO. The `-a` option is also provided
to give more info.
