### PR TITLE
Add dereference option when importing the kernel.

### DIFF
--- a/internal/pkg/kernel/kernel.go
+++ b/internal/pkg/kernel/kernel.go
@@ -198,7 +198,7 @@ func Build(kernelVersion, kernelName, root string) (string, error) {
 			wwlog.Printf(wwlog.VERBOSE, "Using PIGZ to compress the container: %s\n", compressor)
 		}
 
-		cmd := fmt.Sprintf("cd %s; find .%s | cpio --quiet -o -H newc | %s -c > \"%s\"", root, kernelDriversRelative, compressor, driversDestination)
+		cmd := fmt.Sprintf("cd %s; find .%s | cpio --quiet -o -L -H newc | %s -c > \"%s\"", root, kernelDriversRelative, compressor, driversDestination)
 
 		wwlog.Printf(wwlog.DEBUG, "RUNNING: %s\n", cmd)
 		err = exec.Command("/bin/sh", "-c", cmd).Run()


### PR DESCRIPTION
Due to the nature of provisioning nodes when there are symbolic
links involved we want to copy the file that they point to instead
of copying the link.

Backporting change from 4.2.x branch
Issue #281 