### PR TITLE
make location of buildconf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ SRVDIR ?= $(PREFIX)/srv
 DATADIR ?= $(PREFIX)/share
 MANDIR ?= $(DATADIR)/man
 LOCALSTATEDIR ?= $(PREFIX)/var
+WWCLIENTLOC ?= /warewulf/bin
 
 TFTPDIR ?= /var/lib/tftpboot
 FIREWALLDDIR ?= /usr/lib/firewalld/services
@@ -98,6 +99,7 @@ config:
 			-e 's,@WWCHROOTDIR@,$(WWCHROOTDIR),g' \
 			-e 's,@WWPROVISIONDIR@,$(WWPROVISIONDIR),g' \
 			-e 's,@VERSION@,$(VERSION),g' \
+			-e 's,@WWCLIENTLOC@,$(WWCLIENTLOC),g' \
 			-e 's,@RELEASE@,$(RELEASE),g' $$i > $$NAME; \
 	done
 	touch config
@@ -181,7 +183,7 @@ wwclient:
 	 -X 'github.com/hpcng/warewulf/internal/pkg/warewulfconf.ConfigFile=/etc/warewulf/warewulf.conf'" -o ../../wwclient
 
 install_wwclient: wwclient
-	install -m 0755 wwclient $(DESTDIR)$(WWOVERLAYDIR)/wwinit/warewulf/bin/wwclient
+	install -m 0755 wwclient $(DESTDIR)$(WWOVERLAYDIR)/wwinit/$(WWCLIENTLOC)/wwclient
 
 
 bash_completion:

--- a/internal/app/wwclient/root.go
+++ b/internal/app/wwclient/root.go
@@ -14,13 +14,14 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/google/uuid"
-	"github.com/talos-systems/go-smbios/smbios"
 	"github.com/coreos/go-systemd/daemon"
+	"github.com/google/uuid"
+	"github.com/hpcng/warewulf/internal/pkg/buildconfig"
 	"github.com/hpcng/warewulf/internal/pkg/pidfile"
 	"github.com/hpcng/warewulf/internal/pkg/warewulfconf"
 	"github.com/hpcng/warewulf/internal/pkg/wwlog"
 	"github.com/spf13/cobra"
+	"github.com/talos-systems/go-smbios/smbios"
 )
 
 var (
@@ -61,7 +62,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		return errors.New("found pidfile " + PIDFile + " not starting")
 	}
 
-	if os.Args[0] == "/warewulf/bin/wwclient" {
+	if os.Args[0] == buildconfig.WWCLIENTLOC() {
 		err := os.Chdir("/")
 		if err != nil {
 			wwlog.Printf(wwlog.ERROR, "failed to change dir: %s", err)
@@ -132,7 +133,6 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	wwid := strings.Split(wwid_tmp[1], " ")[0]
-
 
 	duration := 300
 	if conf.Warewulf.UpdateInterval > 0 {

--- a/internal/pkg/buildconfig/defaults.go
+++ b/internal/pkg/buildconfig/defaults.go
@@ -15,6 +15,7 @@ var (
 	wwprovisiondir string = "UNDEF"
 	version        string = "UNDEF"
 	release        string = "UNDEF"
+	wwclientloc    string = "UNDEF"
 )
 
 func BINDIR() string {
@@ -75,4 +76,9 @@ func VERSION() string {
 func RELEASE() string {
 	wwlog.Printf(wwlog.DEBUG, "RELEASE = '%s'\n", release)
 	return release
+}
+
+func WWCLIENTLOC() string {
+	wwlog.Printf(wwlog.DEBUG, "WWCLIENTLOC = '%s'\n", wwclientloc)
+	return wwclientloc
 }

--- a/internal/pkg/buildconfig/setconfigs.go.in
+++ b/internal/pkg/buildconfig/setconfigs.go.in
@@ -13,4 +13,5 @@ func init() {
     wwprovisiondir = "@WWPROVISIONDIR@"
     version = "@VERSION@"
     release = "@RELEASE@"
+    wwclientloc = "@WWCLIENTLOC"
 }


### PR DESCRIPTION
`wwclient` checks in what location the binaries it is, and won't 
execute correctly if it is the wrong. This was introduced, to have a
`wwctl` and `wwclient` to be same the binary, but is quite a good 'security` 
againts fat fingered admins, not to accidently overwrite the '/'-dir 
of the ww4 master node. 
So this patch makes the location of `wwclient` configureable with a 
single source of truth.
Should fix #284.
