### PR TITLE
Change how booleans operate (and network config simplification)

### DIFF
--- a/internal/app/wwctl/node/set/root.go
+++ b/internal/app/wwctl/node/set/root.go
@@ -132,9 +132,8 @@ func init() {
 	}); err != nil {
 		log.Println(err)
 	}
-	baseCmd.PersistentFlags().StringVarP(&SetNetName, "netname", "n", "", "Define the network name to configure")
-	baseCmd.PersistentFlags().StringVarP(&SetNetName, "netdev", "N", "", "Alias to --netname")
-	baseCmd.PersistentFlags().StringVarP(&SetNetDev, "netdevice", "D", "", "Define the network device")
+	baseCmd.PersistentFlags().StringVarP(&SetNetName, "netname", "n", "default", "Define the network name to configure")
+	baseCmd.PersistentFlags().StringVarP(&SetNetDev, "netdev", "N", "", "Alias to --netname")
 	baseCmd.PersistentFlags().StringVarP(&SetIpaddr, "ipaddr", "I", "", "Set the node's network device IP address")
 	baseCmd.PersistentFlags().StringVarP(&SetNetmask, "netmask", "M", "", "Set the node's network device netmask")
 	baseCmd.PersistentFlags().StringVarP(&SetGateway, "gateway", "G", "", "Set the node's network device gateway")

--- a/internal/app/wwctl/profile/set/root.go
+++ b/internal/app/wwctl/profile/set/root.go
@@ -115,9 +115,8 @@ func init() {
 	baseCmd.PersistentFlags().StringVar(&SetIpmiPassword, "ipmipass", "", "Set the node's IPMI password")
 	baseCmd.PersistentFlags().StringVar(&SetIpmiInterface, "ipmiinterface", "", "Set the node's IPMI interface (defaults to 'lan')")
 
-	baseCmd.PersistentFlags().StringVarP(&SetNetName, "netname", "n", "", "Define the network name to configure")
-	baseCmd.PersistentFlags().StringVarP(&SetNetName, "netdev", "N", "", "Alias to --netname")
-	baseCmd.PersistentFlags().StringVarP(&SetNetDev, "netdevice", "D", "", "Define the network device")
+	baseCmd.PersistentFlags().StringVarP(&SetNetName, "netname", "n", "default", "Define the network name to configure")
+	baseCmd.PersistentFlags().StringVarP(&SetNetDev, "netdev", "N", "", "Alias to --netname")
 	baseCmd.PersistentFlags().StringVarP(&SetIpaddr, "ipaddr", "I", "", "Set the node's network device IP address")
 	baseCmd.PersistentFlags().StringVarP(&SetNetmask, "netmask", "M", "", "Set the node's network device netmask")
 	baseCmd.PersistentFlags().StringVarP(&SetGateway, "gateway", "G", "", "Set the node's network device gateway")

--- a/internal/pkg/node/constructors.go
+++ b/internal/pkg/node/constructors.go
@@ -89,7 +89,7 @@ func (config *nodeYaml) FindAllNodes() ([]NodeInfo, error) {
 		n.Root.Set(node.Root)
 		n.AssetKey.Set(node.AssetKey)
 
-		n.Discoverable.SetB(node.Discoverable)
+		n.Discoverable.Set(node.Discoverable)
 
 		for devname, netdev := range node.NetDevs {
 			if _, ok := n.NetDevs[devname]; !ok {
@@ -97,18 +97,14 @@ func (config *nodeYaml) FindAllNodes() ([]NodeInfo, error) {
 				n.NetDevs[devname] = &netdev
 			}
 
-			if netdev.Device != "" {
-				n.NetDevs[devname].Device.Set(netdev.Device)
-			} else {
-				n.NetDevs[devname].Device.Set(devname)
-			}
+			n.NetDevs[devname].Device.Set(netdev.Device)
 			n.NetDevs[devname].Ipaddr.Set(netdev.Ipaddr)
 			n.NetDevs[devname].Netmask.Set(netdev.Netmask)
 			n.NetDevs[devname].Hwaddr.Set(netdev.Hwaddr)
 			n.NetDevs[devname].Gateway.Set(netdev.Gateway)
 			n.NetDevs[devname].Type.Set(netdev.Type)
-			n.NetDevs[devname].OnBoot.SetB(netdev.OnBoot)
-			n.NetDevs[devname].Default.SetB(netdev.Default)
+			n.NetDevs[devname].OnBoot.Set(netdev.OnBoot)
+			n.NetDevs[devname].Default.Set(netdev.Default)
 		}
 
 		for keyname, key := range node.Keys {
@@ -146,7 +142,7 @@ func (config *nodeYaml) FindAllNodes() ([]NodeInfo, error) {
 			n.Root.SetAlt(config.NodeProfiles[p].Root, p)
 			n.AssetKey.SetAlt(config.NodeProfiles[p].AssetKey, p)
 
-			n.Discoverable.SetAltB(config.NodeProfiles[p].Discoverable, p)
+			n.Discoverable.SetAlt(config.NodeProfiles[p].Discoverable, p)
 
 			for devname, netdev := range config.NodeProfiles[p].NetDevs {
 				if _, ok := n.NetDevs[devname]; !ok {
@@ -161,8 +157,8 @@ func (config *nodeYaml) FindAllNodes() ([]NodeInfo, error) {
 				n.NetDevs[devname].Hwaddr.SetAlt(netdev.Hwaddr, p)
 				n.NetDevs[devname].Gateway.SetAlt(netdev.Gateway, p)
 				n.NetDevs[devname].Type.SetAlt(netdev.Type, p)
-				n.NetDevs[devname].OnBoot.SetAltB(netdev.OnBoot, p)
-				n.NetDevs[devname].Default.SetAltB(netdev.Default, p)
+				n.NetDevs[devname].OnBoot.SetAlt(netdev.OnBoot, p)
+				n.NetDevs[devname].Default.SetAlt(netdev.Default, p)
 			}
 
 			for keyname, key := range config.NodeProfiles[p].Keys {
@@ -219,7 +215,7 @@ func (config *nodeYaml) FindAllProfiles() ([]NodeInfo, error) {
 		p.Root.Set(profile.Root)
 		p.AssetKey.Set(profile.AssetKey)
 
-		p.Discoverable.SetB(profile.Discoverable)
+		p.Discoverable.Set(profile.Discoverable)
 
 		for devname, netdev := range profile.NetDevs {
 			if _, ok := p.NetDevs[devname]; !ok {
@@ -235,8 +231,8 @@ func (config *nodeYaml) FindAllProfiles() ([]NodeInfo, error) {
 			p.NetDevs[devname].Hwaddr.Set(netdev.Hwaddr)
 			p.NetDevs[devname].Gateway.Set(netdev.Gateway)
 			p.NetDevs[devname].Type.Set(netdev.Type)
-			p.NetDevs[devname].OnBoot.SetB(netdev.OnBoot)
-			p.NetDevs[devname].Default.SetB(netdev.Default)
+			p.NetDevs[devname].OnBoot.Set(netdev.OnBoot)
+			p.NetDevs[devname].Default.Set(netdev.Default)
 		}
 
 		for keyname, key := range profile.Keys {

--- a/internal/pkg/node/datastructure.go
+++ b/internal/pkg/node/datastructure.go
@@ -33,7 +33,7 @@ type NodeConf struct {
 	Init           string              `yaml:"init,omitempty"`
 	Root           string              `yaml:"root,omitempty"`
 	AssetKey       string              `yaml:"asset key,omitempty"`
-	Discoverable   bool                `yaml:"discoverable,omitempty"`
+	Discoverable   string              `yaml:"discoverable,omitempty"`
 	Profiles       []string            `yaml:"profiles,omitempty"`
 	NetDevs        map[string]*NetDevs `yaml:"network devices,omitempty"`
 	Keys           map[string]string   `yaml:"keys,omitempty"`
@@ -41,7 +41,7 @@ type NodeConf struct {
 
 type NetDevs struct {
 	Type    string
-	OnBoot  bool
+	OnBoot  string
 	Device  string
 	Hwaddr  string
 	Ipaddr  string
@@ -49,7 +49,7 @@ type NetDevs struct {
 	Prefix  string `yaml:"prefix,omitempty"`
 	Netmask string
 	Gateway string `yaml:"gateway"`
-	Default bool
+	Default string
 }
 
 /******
@@ -59,8 +59,6 @@ type NetDevs struct {
 type Entry struct {
 	value    string
 	altvalue string
-	bool     bool
-	altbool  bool
 	from     string
 	def      string
 }

--- a/internal/pkg/node/methods.go
+++ b/internal/pkg/node/methods.go
@@ -1,6 +1,8 @@
 package node
 
-import "regexp"
+import (
+	"regexp"
+)
 
 /**********
  *
@@ -51,7 +53,9 @@ func (ent *Entry) Set(val string) {
 }
 
 func (ent *Entry) SetB(val bool) {
-	ent.bool = val
+	if val {
+		ent.value = "true"
+	}
 }
 
 func (ent *Entry) SetAlt(val string, from string) {
@@ -66,10 +70,9 @@ func (ent *Entry) SetAlt(val string, from string) {
 
 func (ent *Entry) SetAltB(val bool, from string) {
 	if val {
-		ent.altbool = val
+		ent.altvalue = "true"
 		ent.from = from
 	}
-
 }
 
 func (ent *Entry) SetDefault(val string) {
@@ -101,15 +104,17 @@ func (ent *Entry) Get() string {
 }
 
 func (ent *Entry) GetB() bool {
-	return ent.bool
+	if ent.value == "false" || ent.value == "no" {
+		return false
+	}
+	if ent.altvalue == "false" || ent.altvalue == "no" || ent.altvalue == "" {
+		return false
+	}
+	return true
 }
 
 func (ent *Entry) GetReal() string {
 	return ent.value
-}
-
-func (ent *Entry) GetRealB() bool {
-	return ent.bool
 }
 
 /**********
@@ -132,10 +137,10 @@ func (ent *Entry) Print() string {
 }
 
 func (ent *Entry) PrintB() bool {
-	if ent.from == "" {
-		return ent.bool
+	if ent.GetB() {
+		return true
 	}
-	return ent.altbool
+	return false
 }
 
 func (ent *Entry) Source() string {

--- a/internal/pkg/node/modifiers.go
+++ b/internal/pkg/node/modifiers.go
@@ -74,7 +74,7 @@ func (config *nodeYaml) NodeUpdate(node NodeInfo) error {
 	config.Nodes[nodeID].Root = node.Root.GetReal()
 	config.Nodes[nodeID].AssetKey = node.AssetKey.GetReal()
 
-	config.Nodes[nodeID].Discoverable = node.Discoverable.GetRealB()
+	config.Nodes[nodeID].Discoverable = node.Discoverable.GetReal()
 
 	config.Nodes[nodeID].Profiles = node.Profiles
 	config.Nodes[nodeID].NetDevs = make(map[string]*NetDevs)
@@ -91,8 +91,8 @@ func (config *nodeYaml) NodeUpdate(node NodeInfo) error {
 		config.Nodes[nodeID].NetDevs[devname].Hwaddr = netdev.Hwaddr.GetReal()
 		config.Nodes[nodeID].NetDevs[devname].Gateway = netdev.Gateway.GetReal()
 		config.Nodes[nodeID].NetDevs[devname].Type = netdev.Type.GetReal()
-		config.Nodes[nodeID].NetDevs[devname].OnBoot = netdev.OnBoot.GetRealB()
-		config.Nodes[nodeID].NetDevs[devname].Default = netdev.Default.GetRealB()
+		config.Nodes[nodeID].NetDevs[devname].OnBoot = netdev.OnBoot.GetReal()
+		config.Nodes[nodeID].NetDevs[devname].Default = netdev.Default.GetReal()
 	}
 
 	for keyname, key := range node.Keys {
@@ -162,7 +162,7 @@ func (config *nodeYaml) ProfileUpdate(profile NodeInfo) error {
 	config.NodeProfiles[profileID].Root = profile.Root.GetReal()
 	config.NodeProfiles[profileID].AssetKey = profile.AssetKey.GetReal()
 
-	config.NodeProfiles[profileID].Discoverable = profile.Discoverable.GetRealB()
+	config.NodeProfiles[profileID].Discoverable = profile.Discoverable.GetReal()
 
 	config.NodeProfiles[profileID].Profiles = profile.Profiles
 	config.NodeProfiles[profileID].NetDevs = make(map[string]*NetDevs)
@@ -179,8 +179,8 @@ func (config *nodeYaml) ProfileUpdate(profile NodeInfo) error {
 		config.NodeProfiles[profileID].NetDevs[devname].Hwaddr = netdev.Hwaddr.GetReal()
 		config.NodeProfiles[profileID].NetDevs[devname].Gateway = netdev.Gateway.GetReal()
 		config.NodeProfiles[profileID].NetDevs[devname].Type = netdev.Type.GetReal()
-		config.NodeProfiles[profileID].NetDevs[devname].OnBoot = netdev.OnBoot.GetRealB()
-		config.NodeProfiles[profileID].NetDevs[devname].Default = netdev.Default.GetRealB()
+		config.NodeProfiles[profileID].NetDevs[devname].OnBoot = netdev.OnBoot.GetReal()
+		config.NodeProfiles[profileID].NetDevs[devname].Default = netdev.Default.GetReal()
 	}
 
 	for keyname, key := range profile.Keys {

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -197,8 +197,8 @@ func BuildOverlay(nodeInfo node.NodeInfo, overlayName string) error {
 		tstruct.NetDevs[devname].Netmask = netdev.Netmask.Get()
 		tstruct.NetDevs[devname].Gateway = netdev.Gateway.Get()
 		tstruct.NetDevs[devname].Type = netdev.Type.Get()
-		tstruct.NetDevs[devname].OnBoot = netdev.OnBoot.GetB()
-		tstruct.NetDevs[devname].Default = netdev.Default.GetB()
+		tstruct.NetDevs[devname].OnBoot = netdev.OnBoot.Get()
+		tstruct.NetDevs[devname].Default = netdev.Default.Get()
 
 		mask := net.IPMask(net.ParseIP(netdev.Netmask.Get()).To4())
 		ipaddr := net.ParseIP(netdev.Ipaddr.Get()).To4()


### PR DESCRIPTION
This PR changes how boolean values are handled within the node data structure.

In summary, we transform two and from of strings as needed.

This fixes booleans not being able to differentiate between undefined and false.