### PR TITLE
Setting sane defaults for node and profile selection

### DIFF
--- a/internal/app/wwctl/node/set/main.go
+++ b/internal/app/wwctl/node/set/main.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hpcng/warewulf/internal/pkg/util"
 	"github.com/hpcng/warewulf/internal/pkg/warewulfd"
 	"github.com/hpcng/warewulf/internal/pkg/wwlog"
-	"github.com/hpcng/warewulf/pkg/hostlist"
 	"github.com/manifoldco/promptui"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -32,14 +31,10 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 
-	if !SetNodeAll {
-		if len(args) > 0 {
-			nodes = node.FilterByName(nodes, hostlist.Expand(args))
-		} else {
-			//nolint:errcheck
-			cmd.Usage()
-			os.Exit(1)
-		}
+	if SetNodeAll || (len(args) == 0 && len(nodes) > 0) {
+		fmt.Printf("\n*** WARNING: This command will modify all nodes! ***\n\n")
+	} else {
+		nodes = node.FilterByName(nodes, args)
 	}
 
 	if len(nodes) == 0 {

--- a/internal/app/wwctl/node/set/root.go
+++ b/internal/app/wwctl/node/set/root.go
@@ -16,7 +16,7 @@ var (
 		Use:                   "set [OPTIONS] PATTERN [PATTERN ...]",
 		Short:                 "Configure node properties",
 		Long:                  "This command sets configuration properties for nodes matching PATTERN.\n\nNote: use the string 'UNSET' to remove a configuration",
-		Args:                  cobra.MinimumNArgs(1),
+		Args:                  cobra.MinimumNArgs(0),
 		RunE:                  CobraRunE,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) != 0 {

--- a/internal/app/wwctl/profile/set/main.go
+++ b/internal/app/wwctl/profile/set/main.go
@@ -28,14 +28,13 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 
-	if !SetAll {
-		if len(args) > 0 {
-			profiles = node.FilterByName(profiles, args)
-		} else {
-			//nolint:errcheck
-			cmd.Usage()
-			os.Exit(1)
-		}
+	if SetAll {
+		fmt.Printf("\n*** WARNING: This command will modify all profiles! ***\n\n")
+	} else if len(args) > 0 {
+		profiles = node.FilterByName(profiles, args)
+	} else {
+		wwlog.Printf(wwlog.INFO, "No profile specified, selecting the 'default' profile\n")
+		profiles = node.FilterByName(profiles, []string{"default"})
 	}
 
 	if len(profiles) == 0 {

--- a/internal/app/wwctl/profile/set/root.go
+++ b/internal/app/wwctl/profile/set/root.go
@@ -16,7 +16,7 @@ var (
 		Short: "Configure node profile properties",
 		Long: "This command sets configuration properties for the node PROFILE(s).\n\n" +
 			"Note: use the string 'UNSET' to remove a configuration",
-		Args: cobra.MinimumNArgs(1),
+		Args: cobra.MinimumNArgs(0),
 		RunE: CobraRunE,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) != 0 {


### PR DESCRIPTION
When no profile is selected, assume `default`, and when node nodes are selected, assume all, but also emit a giant warning.