### PR TITLE
Container exit script runner

### DIFF
--- a/internal/app/wwctl/container/exec/child/main.go
+++ b/internal/app/wwctl/container/exec/child/main.go
@@ -85,17 +85,6 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		wwlog.Printf(wwlog.ERROR, "%s\n", err)
 		os.Exit(1)
 	}
-	_, err = os.Stat("./etc/warewulf/runExit")
-	if os.IsNotExist(err) {
-		wwlog.Printf(wwlog.DEBUG, "no exit script")
-		return nil
-	}
-	wwlog.Printf(wwlog.INFO, "Running exit script %s\n", path.Join(container.RootFsDir(containerName), "./etc/warewulf/runExit"))
-	err = syscall.Exec("./etc/warewulf/runExit", []string{""}, os.Environ())
-	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "%s\n", err)
-		os.Exit(1)
-	}
 
 	return nil
 }

--- a/internal/app/wwctl/container/exec/main.go
+++ b/internal/app/wwctl/container/exec/main.go
@@ -7,12 +7,32 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"syscall"
 
 	"github.com/hpcng/warewulf/internal/pkg/container"
+	"github.com/hpcng/warewulf/internal/pkg/util"
 	"github.com/hpcng/warewulf/internal/pkg/wwlog"
 	"github.com/spf13/cobra"
 )
+
+func runContainedCmd(args []string) error {
+	wwlog.Printf(wwlog.VERBOSE, "Running contained command: %s\n", args[1:])
+	c := exec.Command("/proc/self/exe", append([]string{"container", "exec", "__child"}, args...)...)
+
+	c.SysProcAttr = &syscall.SysProcAttr{
+		Cloneflags: syscall.CLONE_NEWUTS | syscall.CLONE_NEWPID | syscall.CLONE_NEWNS,
+	}
+	c.Stdin = os.Stdin
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+
+	if err := c.Run(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	return nil
+}
 
 func CobraRunE(cmd *cobra.Command, args []string) error {
 
@@ -29,23 +49,23 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	}
 	allargs = append(allargs, args...)
 
-	c := exec.Command("/proc/self/exe", append([]string{"container", "exec", "__child"}, allargs...)...)
-
-	//c := exec.Command("/bin/sh")
-	c.SysProcAttr = &syscall.SysProcAttr{
-		Cloneflags: syscall.CLONE_NEWUTS | syscall.CLONE_NEWPID | syscall.CLONE_NEWNS,
-	}
-	c.Stdin = os.Stdin
-	c.Stdout = os.Stdout
-	c.Stderr = os.Stderr
-
-	if err := c.Run(); err != nil {
-		fmt.Println(err)
+	err := runContainedCmd(allargs)
+	if err != nil {
+		wwlog.Printf(wwlog.ERROR, "Failed executing container command: %s\n", err)
 		os.Exit(1)
 	}
 
+	if util.IsFile(path.Join(container.RootFsDir(allargs[0]), "/etc/warewulf/container_exit.sh")) {
+		wwlog.Printf(wwlog.VERBOSE, "Found clean script: /etc/warewulf/container_exit.sh\n")
+		err = runContainedCmd([]string{allargs[0], "/bin/sh", "/etc/warewulf/container_exit.sh"})
+		if err != nil {
+			wwlog.Printf(wwlog.ERROR, "Failed executing exit script: %s\n", err)
+			os.Exit(1)
+		}
+	}
+
 	fmt.Printf("Rebuilding container...\n")
-	err := container.Build(containerName, false)
+	err = container.Build(containerName, false)
 	if err != nil {
 		wwlog.Printf(wwlog.ERROR, "Could not build container %s: %s\n", containerName, err)
 		os.Exit(1)


### PR DESCRIPTION
This is a different implementation for the runner in #271 that executes the `container_exit.sh` script when the container exits.