### PR TITLE
warewulf.conf option disable host overlays

### DIFF
--- a/internal/app/wwctl/overlay/build/main.go
+++ b/internal/app/wwctl/overlay/build/main.go
@@ -7,12 +7,18 @@ import (
 
 	"github.com/hpcng/warewulf/internal/pkg/node"
 	"github.com/hpcng/warewulf/internal/pkg/overlay"
+	"github.com/hpcng/warewulf/internal/pkg/warewulfconf"
 	"github.com/hpcng/warewulf/internal/pkg/wwlog"
 	"github.com/hpcng/warewulf/pkg/hostlist"
 	"github.com/spf13/cobra"
 )
 
 func CobraRunE(cmd *cobra.Command, args []string) error {
+	controller, err := warewulfconf.New()
+	if err != nil {
+		wwlog.Printf(wwlog.ERROR, "%s\n", err)
+		os.Exit(1)
+	}
 	nodeDB, err := node.New()
 	if err != nil {
 		wwlog.Printf(wwlog.ERROR, "Could not open node configuration: %s\n", err)
@@ -45,7 +51,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		}
 
 	}
-	if BuildHost || (!BuildHost && !BuildNodes && len(args) == 0) {
+	if BuildHost || (!BuildHost && !BuildNodes && len(args) == 0 && controller.Warewulf.EnableHostOverlay) {
 		err := overlay.BuildHostOverlay()
 		if err != nil {
 			wwlog.Printf(wwlog.WARN, "host overlay could not be built: %s\n", err)

--- a/internal/pkg/configure/dhcp.go
+++ b/internal/pkg/configure/dhcp.go
@@ -37,10 +37,11 @@ func Dhcp() error {
 		wwlog.Printf(wwlog.ERROR, "Configuration is not defined: `dhcpd range end`\n")
 		os.Exit(1)
 	}
-
-	err = overlay.BuildHostOverlay()
-	if err != nil {
-		wwlog.Printf(wwlog.WARN, "host overlay could not be built: %s\n", err)
+	if controller.Warewulf.EnableHostOverlay {
+		err = overlay.BuildHostOverlay()
+		if err != nil {
+			wwlog.Printf(wwlog.WARN, "host overlay could not be built: %s\n", err)
+		}
 	}
 	fmt.Printf("Enabling and restarting the DHCP services\n")
 	err = util.SystemdStart(controller.Dhcp.SystemdName)

--- a/internal/pkg/configure/nfs.go
+++ b/internal/pkg/configure/nfs.go
@@ -27,9 +27,11 @@ func NFS() error {
 		if err != nil {
 			fmt.Println(err)
 		}
-		err = overlay.BuildHostOverlay()
-		if err != nil {
-			wwlog.Printf(wwlog.WARN, "host overlay could not be built: %s\n", err)
+		if controller.Warewulf.EnableHostOverlay {
+			err = overlay.BuildHostOverlay()
+			if err != nil {
+				wwlog.Printf(wwlog.WARN, "host overlay could not be built: %s\n", err)
+			}
 		}
 		fmt.Printf("Enabling and restarting the NFS services\n")
 		if controller.Nfs.SystemdName == "" {

--- a/internal/pkg/warewulfconf/datastructure.go
+++ b/internal/pkg/warewulfconf/datastructure.go
@@ -26,7 +26,7 @@ type WarewulfConf struct {
 	Secure            bool   `yaml:"secure"`
 	UpdateInterval    int    `yaml:"update interval"`
 	AutobuildOverlays bool   `yaml:"autobuild overlays"`
-	EnableHostOverlay bool   `yaml:"enable host overlay"`
+	EnableHostOverlay bool   `yaml:"host overlay"`
 	Syslog            bool   `yaml:"syslog"`
 	DataStore         string `yaml:"datastore"`
 }

--- a/internal/pkg/warewulfconf/datastructure.go
+++ b/internal/pkg/warewulfconf/datastructure.go
@@ -26,6 +26,7 @@ type WarewulfConf struct {
 	Secure            bool   `yaml:"secure"`
 	UpdateInterval    int    `yaml:"update interval"`
 	AutobuildOverlays bool   `yaml:"autobuild overlays"`
+	EnableHostOverlay bool   `yaml:"enable host overlay"`
 	Syslog            bool   `yaml:"syslog"`
 	DataStore         string `yaml:"datastore"`
 }

--- a/internal/pkg/warewulfconf/defaults.go
+++ b/internal/pkg/warewulfconf/defaults.go
@@ -10,6 +10,7 @@ func defaultConfig() *ControllerConf {
 		Secure:            true,
 		UpdateInterval:    60,
 		AutobuildOverlays: true,
+		EnableHostOverlay: true,
 		Syslog:            false,
 		DataStore:         defaultDataStore,
 	}


### PR DESCRIPTION
Adds the bool option 
warewulf:
  host overlay: true
so that host overlays can be disabled. The command 
`wwctl build overlay -H` will still build the host overlay, as
this may be explicitly wanted.
