### PR TITLE
use secure overlay dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,7 @@ files: all
 	chmod 755 $(DESTDIR)$(WWOVERLAYDIR)/wwinit/$(WWCLIENTDIR)/wwinit
 	chmod 600 $(DESTDIR)$(WWOVERLAYDIR)/wwinit/etc/ssh/ssh*
 	chmod 644 $(DESTDIR)$(WWOVERLAYDIR)/wwinit/etc/ssh/ssh*.pub.ww
+	chmod 750 $(DESTDIR)$(WWOVERLAYDIR)/host
 	install -m 0755 wwctl $(DESTDIR)$(BINDIR)
 	install -m 0644 include/firewalld/warewulf.xml $(DESTDIR)$(FIREWALLDDIR)
 	install -m 0644 include/systemd/warewulfd.service $(DESTDIR)$(SYSTEMDDIR)

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -98,7 +98,7 @@ func BuildHostOverlay() error {
 		return errors.Wrap(err, "could not build host overlay ")
 	}
 	if !(stats.Mode() == os.FileMode(0750|os.ModeDir) || stats.Mode() == os.FileMode(0700|os.ModeDir)) {
-		wwlog.Printf(wwlog.WARN, "Permissions of host overlay dir %s are %s (750 is considered as secure)\n", hostdir, stats.Mode())
+		wwlog.Printf(wwlog.SECWARN, "Permissions of host overlay dir %s are %s (750 is considered as secure)\n", hostdir, stats.Mode())
 	}
 	return BuildOverlayIndir(host, []string{"host"}, "/")
 }

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -92,6 +92,14 @@ func BuildHostOverlay() error {
 	wwlog.Printf(wwlog.INFO, "Building overlay for %s: host\n", hostname)
 	idEntry.Set(hostname)
 	host.Id = idEntry
+	hostdir := OverlaySourceDir("host")
+	stats, err := os.Stat(hostdir)
+	if err != nil {
+		return errors.Wrap(err, "could not build host overlay ")
+	}
+	if !(stats.Mode() == os.FileMode(0750|os.ModeDir) || stats.Mode() == os.FileMode(0700|os.ModeDir)) {
+		wwlog.Printf(wwlog.WARN, "Permissions of host overlay dir %s are %s (750 is considered as secure)\n", hostdir, stats.Mode())
+	}
 	return BuildOverlayIndir(host, []string{"host"}, "/")
 }
 

--- a/internal/pkg/wwlog/wwlog.go
+++ b/internal/pkg/wwlog/wwlog.go
@@ -6,38 +6,63 @@ import (
 )
 
 const (
-	CRITICAL = 0
-	ERROR    = 1
-	WARN     = 2
-	INFO     = 3
-	VERBOSE  = 4
-	DEBUG    = 5
+	CRITICAL    = 0
+	SECCRITICAL = 1
+	ERROR       = 2
+	SECERROR    = 3
+	WARN        = 4
+	SECWARN     = 5
+	INFO        = 6
+	SECINFO     = 7
+	VERBOSE     = 8
+	SECVERBOSE  = 9
+	DEBUG       = 10
+	SECDEBUG    = 11
 )
 
 var (
 	logLevel = INFO
 )
 
+/*
+Set the central log level. Uneven values are security related
+lof entries.
+*/
 func SetLevel(level int) {
 	logLevel = level
 
 	Printf(DEBUG, "Set log level to: %d\n", logLevel)
 }
 
+/*
+generate the prefix for log level
+*/
 func prefixGen(level int) string {
 	switch level {
 	case DEBUG:
-		return "[DEBUG]   : "
+		return "[DEBUG]      : "
+	case SECDEBUG:
+		return "[SECDEBUG]   : "
 	case VERBOSE:
-		return "[VERBOSE] : "
+		return "[VERBOSE]    : "
+	case SECVERBOSE:
+		return "[SECVERBOSE] : "
 	case INFO:
-		return "[INFO]    : "
+		return "[INFO]       : "
+	case SECINFO:
+		return "[SECINFO]    : "
 	case WARN:
-		return "[WARNING] : "
+		return "[WARNING]    : "
+	case SECWARN:
+		return "[SECWARNING] : "
 	case ERROR:
-		return "[ERROR]   : "
+		return "[ERROR]      : "
+	case SECERROR:
+		return "[SECERROR]   : "
 	case CRITICAL:
-		return "[CRITICAL]: "
+		return "[CRITICAL]   : "
+	case SECCRITICAL:
+		return "[SECCRITICAL]: "
 	}
 	return "[UNDEF]   : "
 }


### PR DESCRIPTION
If there is a user writeable file in the host overlay, a user can
create arbitrary files on the host root file system. Although these
files will belong to this user, this might allow users to modify
any files.
So this patch restricts the access to the host overlay to root and
produces a warning if this was changed.