### PR TITLE
set default kernel.version to container name

### DIFF
--- a/internal/app/wwctl/container/imprt/main.go
+++ b/internal/app/wwctl/container/imprt/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/containers/image/v5/types"
 	"github.com/hpcng/warewulf/internal/pkg/container"
+	"github.com/hpcng/warewulf/internal/pkg/kernel"
 	"github.com/hpcng/warewulf/internal/pkg/node"
 	"github.com/hpcng/warewulf/internal/pkg/util"
 	"github.com/hpcng/warewulf/internal/pkg/warewulfd"
@@ -173,6 +174,17 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 			return errors.Wrap(err, "failed to reload warewulf daemon")
 		}
 	}
-
+	if FindKernel {
+		kernelVersion, err := kernel.FindKernelVersion(name)
+		if err != nil {
+			wwlog.Printf(wwlog.ERROR, "could not detect kernel under %s\n", path.Join(container.RootFsDir(name)))
+			os.Exit(1)
+		}
+		_, err = kernel.Build(kernelVersion, name, path.Join(container.RootFsDir(name)))
+		if err != nil {
+			wwlog.Printf(wwlog.ERROR, "Failed building kernel: %s\n", err)
+			os.Exit(1)
+		}
+	}
 	return nil
 }

--- a/internal/app/wwctl/container/imprt/root.go
+++ b/internal/app/wwctl/container/imprt/root.go
@@ -19,6 +19,7 @@ Imported containers are used to create bootable VNFS images.`,
 	SetBuild   bool
 	SetDefault bool
 	NoSyncUser bool
+	FindKernel bool
 )
 
 func init() {
@@ -27,6 +28,7 @@ func init() {
 	baseCmd.PersistentFlags().BoolVarP(&SetBuild, "build", "b", false, "Build container when after pulling")
 	baseCmd.PersistentFlags().BoolVar(&SetDefault, "setdefault", false, "Set this container for the default profile")
 	baseCmd.PersistentFlags().BoolVar(&NoSyncUser, "nosyncuser", false, "Don't synchronize uis/gods from host to container")
+	baseCmd.PersistentFlags().BoolVar(&FindKernel, "nokernel", true, "Don't try to find a kernel in the imported container")
 }
 
 // GetRootCommand returns the root cobra.Command for the application.

--- a/internal/pkg/container/util.go
+++ b/internal/pkg/container/util.go
@@ -10,6 +10,9 @@ import (
 	"github.com/hpcng/warewulf/internal/pkg/wwlog"
 )
 
+/*
+check if its possible to have this containername.
+*/
 func ValidName(name string) bool {
 	if !util.ValidString(name, "^[\\w\\-\\.\\:]+$") {
 		wwlog.Printf(wwlog.WARN, "VNFS name has illegal characters: %s\n", name)
@@ -18,6 +21,10 @@ func ValidName(name string) bool {
 	return true
 }
 
+/*
+List all dirs in the container directory which is subsequently the list of all
+available containers.
+*/
 func ListSources() ([]string, error) {
 	var ret []string
 
@@ -49,6 +56,9 @@ func ListSources() ([]string, error) {
 	return ret, nil
 }
 
+/*
+Check if name ends up in a valid container directory.
+*/
 func ValidSource(name string) bool {
 	fullPath := RootFsDir(name)
 
@@ -64,6 +74,9 @@ func ValidSource(name string) bool {
 	return true
 }
 
+/*
+Remove the rootfs of container but not the images.
+*/
 func DeleteSource(name string) error {
 	fullPath := SourceDir(name)
 

--- a/internal/pkg/node/constructors.go
+++ b/internal/pkg/node/constructors.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/hpcng/warewulf/internal/pkg/buildconfig"
+	"github.com/hpcng/warewulf/internal/pkg/kernel"
 	"github.com/hpcng/warewulf/internal/pkg/warewulfconf"
 	"github.com/hpcng/warewulf/internal/pkg/wwlog"
 
@@ -263,7 +264,17 @@ func (config *nodeYaml) FindAllNodes() ([]NodeInfo, error) {
 				n.Tags[keyname].SetAlt(key, p)
 			}
 		}
-
+		// set default name of kernel to the kernelname of the container
+		if n.ContainerName.Get() != "" {
+			listKernel, err := kernel.ListKernels()
+			if err != nil {
+				for _, kern := range listKernel {
+					if kern == n.ContainerName.Get() {
+						n.Kernel.Override.SetDefault(n.ContainerName.Get())
+					}
+				}
+			}
+		}
 		ret = append(ret, n)
 
 	}


### PR DESCRIPTION
Always set the default value of kernel.versionoverride to the name of the container, if this is a valid kernel. Also try to automatically import a kernel on container import.

In a normal workflow this will endup in just one single command which will import the container and its kernel. The kernel will be dereived from the container name, if this there is a kernel with the same name as the container.

