### PR TITLE
Fix wwctl bug deleting networks and ability to set default network

### DIFF
--- a/internal/app/wwctl/node/set/main.go
+++ b/internal/app/wwctl/node/set/main.go
@@ -289,10 +289,10 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 					n.Default.SetB(false)
 				}
 
-				wwlog.Printf(wwlog.VERBOSE, "Node: %s:%s, Setting DEFAULT\n", n.Id.Get(), SetNetName)
+				wwlog.Printf(wwlog.VERBOSE, "Node: %s:%s, Setting PRIMARY\n", n.Id.Get(), SetNetName)
 				n.NetDevs[SetNetName].Default.SetB(true)
 			} else {
-				wwlog.Printf(wwlog.VERBOSE, "Node: %s:%s, Unsetting DEFAULT\n", n.Id.Get(), SetNetName)
+				wwlog.Printf(wwlog.VERBOSE, "Node: %s:%s, Unsetting PRIMARY\n", n.Id.Get(), SetNetName)
 				n.NetDevs[SetNetName].Default.SetB(false)
 			}
 		}

--- a/internal/app/wwctl/node/set/root.go
+++ b/internal/app/wwctl/node/set/root.go
@@ -143,7 +143,7 @@ func init() {
 	baseCmd.PersistentFlags().StringVarP(&SetHwaddr, "hwaddr", "H", "", "Set the node's network device HW address")
 	baseCmd.PersistentFlags().StringVarP(&SetType, "type", "T", "", "Set the node's network device type")
 	baseCmd.PersistentFlags().StringVar(&SetNetOnBoot, "onboot", "", "Enable/disable device (yes/no)")
-	baseCmd.PersistentFlags().StringVar(&SetNetDefault, "default", "", "Enable/disable device as default (yes/no)")
+	baseCmd.PersistentFlags().StringVar(&SetNetDefault, "primary", "", "Enable/disable device as primary (yes/no)")
 
 	baseCmd.PersistentFlags().BoolVar(&SetNetDevDel, "netdel", false, "Delete the node's network device")
 	baseCmd.PersistentFlags().StringSliceVar(&SetNetTags, "nettag", []string{}, "Define custom tag to network device (key=value)")

--- a/internal/app/wwctl/profile/set/main.go
+++ b/internal/app/wwctl/profile/set/main.go
@@ -219,32 +219,32 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 			if SetNetDefault == "yes" || SetNetDefault == "y" || SetNetDefault == "1" || SetNetDefault == "true" {
 
-				// Set all other devices to non-default
+				// Set all other networks to non-default
 				for _, n := range p.NetDevs {
 					n.Default.SetB(false)
 				}
 
-				wwlog.Printf(wwlog.VERBOSE, "Profile: %s:%s, Setting DEFAULT\n", p.Id.Get(), SetNetName)
+				wwlog.Printf(wwlog.VERBOSE, "Profile: %s:%s, Setting PRIMARY\n", p.Id.Get(), SetNetName)
 				p.NetDevs[SetNetName].Default.SetB(true)
 			} else {
-				wwlog.Printf(wwlog.VERBOSE, "Profile: %s:%s, Unsetting DEFAULT\n", p.Id.Get(), SetNetName)
+				wwlog.Printf(wwlog.VERBOSE, "Profile: %s:%s, Unsetting PRIMARY\n", p.Id.Get(), SetNetName)
 				p.NetDevs[SetNetName].Default.SetB(false)
 			}
 		}
 
 		if SetNetDevDel {
-			if SetNetDev == "" {
+			if SetNetName == "" {
 				wwlog.Printf(wwlog.ERROR, "You must include the '--netname' option\n")
 				os.Exit(1)
 			}
 
-			if _, ok := p.NetDevs[SetNetDev]; !ok {
-				wwlog.Printf(wwlog.ERROR, "Profile '%s': network Device doesn't exist: %s\n", p.Id.Get(), SetNetDev)
+			if _, ok := p.NetDevs[SetNetName]; !ok {
+				wwlog.Printf(wwlog.ERROR, "Profile '%s': network name doesn't exist: %s\n", p.Id.Get(), SetNetName)
 				os.Exit(1)
 			}
 
-			wwlog.Printf(wwlog.VERBOSE, "Profile %s: Deleting network device: %s\n", p.Id.Get(), SetNetDev)
-			delete(p.NetDevs, SetNetDev)
+			wwlog.Printf(wwlog.VERBOSE, "Profile %s: Deleting network: %s\n", p.Id.Get(), SetNetName)
+			delete(p.NetDevs, SetNetName)
 		}
 
 		if len(SetTags) > 0 {

--- a/internal/app/wwctl/profile/set/root.go
+++ b/internal/app/wwctl/profile/set/root.go
@@ -118,6 +118,7 @@ func init() {
 
 	baseCmd.PersistentFlags().StringVarP(&SetNetName, "netname", "n", "default", "Define the network name to configure")
 	baseCmd.PersistentFlags().StringVarP(&SetNetDev, "netdev", "N", "", "Set the node's network device")
+	baseCmd.PersistentFlags().StringVar(&SetNetDefault, "primary", "", "Enable/disable device as primary (yes/no)")
 	baseCmd.PersistentFlags().StringVarP(&SetNetmask, "netmask", "M", "", "Set the node's network device netmask")
 	baseCmd.PersistentFlags().StringVarP(&SetGateway, "gateway", "G", "", "Set the node's network device gateway")
 	baseCmd.PersistentFlags().StringVarP(&SetType, "type", "T", "", "Set the node's network device type")

--- a/internal/pkg/node/datastructure.go
+++ b/internal/pkg/node/datastructure.go
@@ -75,7 +75,7 @@ type NetDevs struct {
 	Prefix  string            `yaml:"prefix,omitempty"`
 	Netmask string            `yaml:"netmask,omitempty"`
 	Gateway string            `yaml:"gateway,omitempty"`
-	Default string            `yaml:"default,omitempty"`
+	Default string            `yaml:"primary,omitempty"`
 	Tags    map[string]string `yaml:"tags,omitempty"`
 }
 

--- a/internal/pkg/node/methods.go
+++ b/internal/pkg/node/methods.go
@@ -68,6 +68,8 @@ Set bool
 func (ent *Entry) SetB(val bool) {
 	if val {
 		ent.value = []string{"true"}
+	} else {
+		ent.value = []string{"false"}
 	}
 }
 
@@ -99,6 +101,9 @@ Sets alternative bool
 func (ent *Entry) SetAltB(val bool, from string) {
 	if val {
 		ent.altvalue = []string{"true"}
+		ent.from = from
+	} else {
+		ent.altvalue = []string{"false"}
 		ent.from = from
 	}
 }


### PR DESCRIPTION
Signed-off-by: jcsiadal <jeremy.c.siadal@intel.com>

Fixes issues #395, #391, and #392 

- Updates the netdel argument to use the network name instead of the network device, which caused the command to fail.
- Enables an option to set the default network in a profile.
- Fixes the boolean set method in the node datastructure. Previously, a false value would do nothing, so a "true" value couldn't be unset
- Changes the main network device identifier from "default" to "primary". Default is defined as fallback or failover, so term was used incorrectly here (in addition to being overloaded). 