### PR TITLE
only build assigned overlays

### DIFF
--- a/internal/app/wwctl/overlay/build/main.go
+++ b/internal/app/wwctl/overlay/build/main.go
@@ -74,7 +74,12 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 			}
 		} else {
 			if OverlayName != "" {
-				err = overlay.BuildSpecificOverlays(nodes, OverlayName)
+				for _, n := range nodes {
+					if util.InSlice(n.RuntimeOverlay.GetSlice(), OverlayName) ||
+						util.InSlice(n.SystemOverlay.GetSlice(), OverlayName) {
+						err = overlay.BuildSpecificOverlays([]node.NodeInfo{n}, OverlayName)
+					}
+				}
 			} else {
 				err = overlay.BuildAllOverlays(nodes)
 			}

--- a/internal/app/wwctl/overlay/build/main.go
+++ b/internal/app/wwctl/overlay/build/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hpcng/warewulf/internal/pkg/node"
 	"github.com/hpcng/warewulf/internal/pkg/overlay"
+	"github.com/hpcng/warewulf/internal/pkg/util"
 	"github.com/hpcng/warewulf/internal/pkg/warewulfconf"
 	"github.com/hpcng/warewulf/internal/pkg/wwlog"
 	"github.com/hpcng/warewulf/pkg/hostlist"
@@ -37,7 +38,12 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		if len(args) > 0 {
 			args = hostlist.Expand(args)
 			for _, node := range nodes {
-				return overlay.BuildOverlayIndir(node, strings.Split(OverlayName, ","), OverlayDir)
+				if util.InSlice(node.RuntimeOverlay.GetSlice(), OverlayName) ||
+					util.InSlice(node.SystemOverlay.GetSlice(), OverlayName) {
+					return overlay.BuildOverlayIndir(node, strings.Split(OverlayName, ","), OverlayDir)
+				} else {
+					return errors.New("no node uses the given overlay")
+				}
 			}
 		} else {
 			var host node.NodeInfo

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -72,6 +72,33 @@ func RandomString(n int) string {
 	return string(b)
 }
 
+/*
+Checks if given string is in slice. I yes returns true, false otherwise.
+*/
+func InSlice(slice []string, match string) bool {
+	for _, val := range slice {
+		if val == match {
+			return true
+		}
+	}
+	return false
+}
+
+/*
+Checks if one or more elements of a slice A are a part of slice B. Returns true
+as soon as one element matches.\
+*/
+func SliceInSlice(A []string, B []string) bool {
+	for _, a := range A {
+		for _, b := range B {
+			if a == b {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func IsDir(path string) bool {
 	wwlog.Printf(wwlog.DEBUG, "Checking if path exists as a directory: %s\n", path)
 


### PR DESCRIPTION
If a overlay should be build, check if the overlay is assigned to
a node, and return error if otherwise.

Adresses #399
