### PR TITLE
more verbose wwctl version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ VARLIST := OS
 VARLIST += WAREWULF VERSION RELEASE
 WAREWULF ?= warewulf
 VERSION ?= 4.3.0rc2
-GIT_TAG := $(shell test -e .git && git describe --tags --long --first-parent --always)
+GIT_TAG := $(shell test -e .git && git log -1 --format="%h")
 
 ifdef GIT_TAG
   ifdef $(filter $(OS),ubuntu debian)

--- a/internal/app/wwctl/version/main.go
+++ b/internal/app/wwctl/version/main.go
@@ -10,20 +10,20 @@ import (
 
 func CobraRunE(cmd *cobra.Command, args []string) error {
 	if ListFull {
-		fmt.Printf("%-20s %-18s\n", "VERSION:", version.GetVersion())
-		fmt.Printf("%-20s %-18s\n", "BINDIR:", buildconfig.BINDIR())
-		fmt.Printf("%-20s %-18s\n", "DATADIR:", buildconfig.DATADIR())
-		fmt.Printf("%-20s %-18s\n", "SYSCONFDIR:", buildconfig.SYSCONFDIR())
-		fmt.Printf("%-20s %-18s\n", "LOCALSTATEDIR:", buildconfig.LOCALSTATEDIR())
-		fmt.Printf("%-20s %-18s\n", "SRVDIR:", buildconfig.SRVDIR())
-		fmt.Printf("%-20s %-18s\n", "TFTPDIR:", buildconfig.TFTPDIR())
-		fmt.Printf("%-20s %-18s\n", "SYSTEMDDIR:", buildconfig.SYSTEMDDIR())
-		fmt.Printf("%-20s %-18s\n", "WWOVERLAYDIR:", buildconfig.WWOVERLAYDIR())
-		fmt.Printf("%-20s %-18s\n", "WWCHROOTDIR:", buildconfig.WWCHROOTDIR())
-		fmt.Printf("%-20s %-18s\n", "WWPROVISIONDIR:", buildconfig.WWPROVISIONDIR())
-		fmt.Printf("%-20s %-18s\n", "BASEVERSION:", buildconfig.VERSION())
-		fmt.Printf("%-20s %-18s\n", "RELEASE:", buildconfig.RELEASE())
-		fmt.Printf("%-20s %-18s\n", "WWCLIENTDIR:", buildconfig.WWCLIENTDIR())
+		fmt.Printf("%s=%s\n", "VERSION", version.GetVersion())
+		fmt.Printf("%s=%s\n", "BINDIR", buildconfig.BINDIR())
+		fmt.Printf("%s=%s\n", "DATADIR", buildconfig.DATADIR())
+		fmt.Printf("%s=%s\n", "SYSCONFDIR", buildconfig.SYSCONFDIR())
+		fmt.Printf("%s=%s\n", "LOCALSTATEDIR", buildconfig.LOCALSTATEDIR())
+		fmt.Printf("%s=%s\n", "SRVDIR", buildconfig.SRVDIR())
+		fmt.Printf("%s=%s\n", "TFTPDIR", buildconfig.TFTPDIR())
+		fmt.Printf("%s=%s\n", "SYSTEMDDIR", buildconfig.SYSTEMDDIR())
+		fmt.Printf("%s=%s\n", "WWOVERLAYDIR", buildconfig.WWOVERLAYDIR())
+		fmt.Printf("%s=%s\n", "WWCHROOTDIR", buildconfig.WWCHROOTDIR())
+		fmt.Printf("%s=%s\n", "WWPROVISIONDIR", buildconfig.WWPROVISIONDIR())
+		fmt.Printf("%s=%s\n", "BASEVERSION", buildconfig.VERSION())
+		fmt.Printf("%s=%s\n", "RELEASE", buildconfig.RELEASE())
+		fmt.Printf("%s=%s\n", "WWCLIENTDIR", buildconfig.WWCLIENTDIR())o
 	} else {
 		fmt.Println(version.GetVersion())
 	}

--- a/internal/app/wwctl/version/main.go
+++ b/internal/app/wwctl/version/main.go
@@ -10,18 +10,20 @@ import (
 
 func CobraRunE(cmd *cobra.Command, args []string) error {
 
-	fmt.Println("VERSION:\t", version.GetVersion())
-	fmt.Println("BINDIR:\t", buildconfig.BINDIR())
-	fmt.Println("DATADIR:\t", buildconfig.DATADIR())
-	fmt.Println("SYSCONFDIR:\t", buildconfig.SYSCONFDIR())
-	fmt.Println("LOCALSTATEDIR:\t", buildconfig.LOCALSTATEDIR())
-	fmt.Println("SRVDIR:\t", buildconfig.SRVDIR())
-	fmt.Println("TFTPDIR:\t", buildconfig.TFTPDIR())
-	fmt.Println("SYSTEMDDIR:\t", buildconfig.SYSTEMDDIR())
-	fmt.Println("WWOVERLAYDIR:\t", buildconfig.WWOVERLAYDIR())
-	fmt.Println("WWCHROOTDIR:\t", buildconfig.WWCHROOTDIR())
-	fmt.Println("WWPROVISIONDIR:\t", buildconfig.WWPROVISIONDIR())
-	fmt.Println("WWCLIENTDIR:\t", buildconfig.WWCLIENTDIR())
+	fmt.Printf("%-20s %-18s\n", "VERSION:", version.GetVersion())
+	fmt.Printf("%-20s %-18s\n", "BINDIR:", buildconfig.BINDIR())
+	fmt.Printf("%-20s %-18s\n", "DATADIR:", buildconfig.DATADIR())
+	fmt.Printf("%-20s %-18s\n", "SYSCONFDIR:", buildconfig.SYSCONFDIR())
+	fmt.Printf("%-20s %-18s\n", "LOCALSTATEDIR:", buildconfig.LOCALSTATEDIR())
+	fmt.Printf("%-20s %-18s\n", "SRVDIR:", buildconfig.SRVDIR())
+	fmt.Printf("%-20s %-18s\n", "TFTPDIR:", buildconfig.TFTPDIR())
+	fmt.Printf("%-20s %-18s\n", "SYSTEMDDIR:", buildconfig.SYSTEMDDIR())
+	fmt.Printf("%-20s %-18s\n", "WWOVERLAYDIR:", buildconfig.WWOVERLAYDIR())
+	fmt.Printf("%-20s %-18s\n", "WWCHROOTDIR:", buildconfig.WWCHROOTDIR())
+	fmt.Printf("%-20s %-18s\n", "WWPROVISIONDIR:", buildconfig.WWPROVISIONDIR())
+	fmt.Printf("%-20s %-18s\n", "BASEVERSION:", buildconfig.VERSION())
+	fmt.Printf("%-20s %-18s\n", "RELEASE:", buildconfig.RELEASE())
+	fmt.Printf("%-20s %-18s\n", "WWCLIENTDIR:", buildconfig.WWCLIENTDIR())
 
 	return nil
 }

--- a/internal/app/wwctl/version/main.go
+++ b/internal/app/wwctl/version/main.go
@@ -9,21 +9,23 @@ import (
 )
 
 func CobraRunE(cmd *cobra.Command, args []string) error {
-
-	fmt.Printf("%-20s %-18s\n", "VERSION:", version.GetVersion())
-	fmt.Printf("%-20s %-18s\n", "BINDIR:", buildconfig.BINDIR())
-	fmt.Printf("%-20s %-18s\n", "DATADIR:", buildconfig.DATADIR())
-	fmt.Printf("%-20s %-18s\n", "SYSCONFDIR:", buildconfig.SYSCONFDIR())
-	fmt.Printf("%-20s %-18s\n", "LOCALSTATEDIR:", buildconfig.LOCALSTATEDIR())
-	fmt.Printf("%-20s %-18s\n", "SRVDIR:", buildconfig.SRVDIR())
-	fmt.Printf("%-20s %-18s\n", "TFTPDIR:", buildconfig.TFTPDIR())
-	fmt.Printf("%-20s %-18s\n", "SYSTEMDDIR:", buildconfig.SYSTEMDDIR())
-	fmt.Printf("%-20s %-18s\n", "WWOVERLAYDIR:", buildconfig.WWOVERLAYDIR())
-	fmt.Printf("%-20s %-18s\n", "WWCHROOTDIR:", buildconfig.WWCHROOTDIR())
-	fmt.Printf("%-20s %-18s\n", "WWPROVISIONDIR:", buildconfig.WWPROVISIONDIR())
-	fmt.Printf("%-20s %-18s\n", "BASEVERSION:", buildconfig.VERSION())
-	fmt.Printf("%-20s %-18s\n", "RELEASE:", buildconfig.RELEASE())
-	fmt.Printf("%-20s %-18s\n", "WWCLIENTDIR:", buildconfig.WWCLIENTDIR())
-
+	if ListFull {
+		fmt.Printf("%-20s %-18s\n", "VERSION:", version.GetVersion())
+		fmt.Printf("%-20s %-18s\n", "BINDIR:", buildconfig.BINDIR())
+		fmt.Printf("%-20s %-18s\n", "DATADIR:", buildconfig.DATADIR())
+		fmt.Printf("%-20s %-18s\n", "SYSCONFDIR:", buildconfig.SYSCONFDIR())
+		fmt.Printf("%-20s %-18s\n", "LOCALSTATEDIR:", buildconfig.LOCALSTATEDIR())
+		fmt.Printf("%-20s %-18s\n", "SRVDIR:", buildconfig.SRVDIR())
+		fmt.Printf("%-20s %-18s\n", "TFTPDIR:", buildconfig.TFTPDIR())
+		fmt.Printf("%-20s %-18s\n", "SYSTEMDDIR:", buildconfig.SYSTEMDDIR())
+		fmt.Printf("%-20s %-18s\n", "WWOVERLAYDIR:", buildconfig.WWOVERLAYDIR())
+		fmt.Printf("%-20s %-18s\n", "WWCHROOTDIR:", buildconfig.WWCHROOTDIR())
+		fmt.Printf("%-20s %-18s\n", "WWPROVISIONDIR:", buildconfig.WWPROVISIONDIR())
+		fmt.Printf("%-20s %-18s\n", "BASEVERSION:", buildconfig.VERSION())
+		fmt.Printf("%-20s %-18s\n", "RELEASE:", buildconfig.RELEASE())
+		fmt.Printf("%-20s %-18s\n", "WWCLIENTDIR:", buildconfig.WWCLIENTDIR())
+	} else {
+		fmt.Println(version.GetVersion())
+	}
 	return nil
 }

--- a/internal/app/wwctl/version/main.go
+++ b/internal/app/wwctl/version/main.go
@@ -3,13 +3,25 @@ package version
 import (
 	"fmt"
 
+	"github.com/hpcng/warewulf/internal/pkg/buildconfig"
 	"github.com/hpcng/warewulf/internal/pkg/version"
 	"github.com/spf13/cobra"
 )
 
 func CobraRunE(cmd *cobra.Command, args []string) error {
 
-	fmt.Println("Version:\t", version.GetVersion())
+	fmt.Println("VERSION:\t", version.GetVersion())
+	fmt.Println("BINDIR:\t", buildconfig.BINDIR())
+	fmt.Println("DATADIR:\t", buildconfig.DATADIR())
+	fmt.Println("SYSCONFDIR:\t", buildconfig.SYSCONFDIR())
+	fmt.Println("LOCALSTATEDIR:\t", buildconfig.LOCALSTATEDIR())
+	fmt.Println("SRVDIR:\t", buildconfig.SRVDIR())
+	fmt.Println("TFTPDIR:\t", buildconfig.TFTPDIR())
+	fmt.Println("SYSTEMDDIR:\t", buildconfig.SYSTEMDDIR())
+	fmt.Println("WWOVERLAYDIR:\t", buildconfig.WWOVERLAYDIR())
+	fmt.Println("WWCHROOTDIR:\t", buildconfig.WWCHROOTDIR())
+	fmt.Println("WWPROVISIONDIR:\t", buildconfig.WWPROVISIONDIR())
+	fmt.Println("WWCLIENTDIR:\t", buildconfig.WWCLIENTDIR())
 
 	return nil
 }

--- a/internal/app/wwctl/version/main.go
+++ b/internal/app/wwctl/version/main.go
@@ -23,7 +23,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		fmt.Printf("%s=%s\n", "WWPROVISIONDIR", buildconfig.WWPROVISIONDIR())
 		fmt.Printf("%s=%s\n", "BASEVERSION", buildconfig.VERSION())
 		fmt.Printf("%s=%s\n", "RELEASE", buildconfig.RELEASE())
-		fmt.Printf("%s=%s\n", "WWCLIENTDIR", buildconfig.WWCLIENTDIR())o
+		fmt.Printf("%s=%s\n", "WWCLIENTDIR", buildconfig.WWCLIENTDIR())
 	} else {
 		fmt.Println(version.GetVersion())
 	}

--- a/internal/app/wwctl/version/root.go
+++ b/internal/app/wwctl/version/root.go
@@ -11,9 +11,11 @@ var (
 		Args:    cobra.ExactArgs(0),
 		Aliases: []string{"vers"},
 	}
+	ListFull bool
 )
 
 func init() {
+	baseCmd.PersistentFlags().BoolVarP(&ListFull, "full", "f", false, "List all compiled in variables.")
 }
 
 // GetRootCommand returns the root cobra.Command for the application.


### PR DESCRIPTION
`wwctl version` will print out all complied in vars. This will make debugging for users much easier, e.g #394 