### PR TITLE
container show prints kernel version

### DIFF
--- a/internal/app/wwctl/container/show/main.go
+++ b/internal/app/wwctl/container/show/main.go
@@ -18,6 +18,11 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	} else {
 		fmt.Printf("Name: %s\n", containerName)
 		fmt.Printf("Rootfs: %s\n", container.RootFsDir(containerName))
+		kernelVersion := container.KernelVersion(containerName)
+		if kernelVersion != "" {
+			kernelVersion = "not found"
+			fmt.Printf("Kernelversion: %s\n", kernelVersion)
+		}
 		nodeDB, _ := node.New()
 
 		nodes, _ := nodeDB.FindAllNodes()


### PR DESCRIPTION
The `wwctl container show -a` command should also list the actual kernel of a container.
