### PR TITLE
updated overlay includes more vars and split func

### DIFF
--- a/internal/pkg/overlay/datastructure.go
+++ b/internal/pkg/overlay/datastructure.go
@@ -37,4 +37,8 @@ type TemplateStruct struct {
 	Dhcp           warewulfconf.DhcpConf
 	Nfs            warewulfconf.NfsConf
 	Warewulf       warewulfconf.WarewulfConf
+	Overlays       []string
+	Containers     []string
+	Kernels        []string
+	Profiles       []string
 }

--- a/internal/pkg/overlay/datastructure.go
+++ b/internal/pkg/overlay/datastructure.go
@@ -26,6 +26,7 @@ type TemplateStruct struct {
 	AllNodes       []node.NodeInfo
 	BuildHost      string
 	BuildTime      string
+	BuildTimeUnix  string
 	BuildSource    string
 	Ipaddr         string
 	Ipaddr6        string

--- a/internal/pkg/overlay/datastructure.go
+++ b/internal/pkg/overlay/datastructure.go
@@ -26,7 +26,6 @@ type TemplateStruct struct {
 	AllNodes       []node.NodeInfo
 	BuildHost      string
 	BuildTime      string
-	BuildTimeUnix  string
 	BuildSource    string
 	Ipaddr         string
 	Ipaddr6        string
@@ -37,8 +36,4 @@ type TemplateStruct struct {
 	Dhcp           warewulfconf.DhcpConf
 	Nfs            warewulfconf.NfsConf
 	Warewulf       warewulfconf.WarewulfConf
-	Overlays       []string
-	Containers     []string
-	Kernels        []string
-	Profiles       []string
 }

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -17,8 +17,6 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/hpcng/warewulf/internal/pkg/container"
-	"github.com/hpcng/warewulf/internal/pkg/kernel"
 	"github.com/hpcng/warewulf/internal/pkg/node"
 	"github.com/hpcng/warewulf/internal/pkg/util"
 	"github.com/hpcng/warewulf/internal/pkg/warewulfconf"
@@ -302,16 +300,6 @@ func BuildOverlayIndir(nodeInfo node.NodeInfo, overlayNames []string, outputDir 
 	tstruct.BuildHost = hostname
 	dt := time.Now()
 	tstruct.BuildTime = dt.Format("01-02-2006 15:04:05 MST")
-	tstruct.BuildTimeUnix = strconv.FormatInt(dt.Unix(), 10)
-	tstruct.Containers, _ = container.ListSources()
-	profiles, _ := nodeDB.FindAllProfiles()
-	var profileList []string
-	for _, profile := range profiles {
-		profileList = append(profileList, profile.Id.Get())
-	}
-	tstruct.Profiles = profileList
-	tstruct.Overlays, _ = FindOverlays()
-	tstruct.Kernels, _ = kernel.ListKernels()
 	for _, overlayName := range overlayNames {
 		wwlog.Printf(wwlog.VERBOSE, "Building overlay %s for node %s in %s\n", overlayName, nodeInfo.Id.Get(), outputDir)
 		overlaySourceDir := OverlaySourceDir(overlayName)

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -300,6 +300,7 @@ func BuildOverlayIndir(nodeInfo node.NodeInfo, overlayNames []string, outputDir 
 	tstruct.BuildHost = hostname
 	dt := time.Now()
 	tstruct.BuildTime = dt.Format("01-02-2006 15:04:05 MST")
+	tstruct.BuildTimeUnix = strconv.FormatInt(dt.Unix(), 10)
 	for _, overlayName := range overlayNames {
 		wwlog.Printf(wwlog.VERBOSE, "Building overlay %s for node %s in %s\n", overlayName, nodeInfo.Id.Get(), outputDir)
 		overlaySourceDir := OverlaySourceDir(overlayName)


### PR DESCRIPTION
The split function allows the creation of string slices in templates out of a string. This is extremly useful, as the `range` expression in tempaltes only works with slices and maps. With this function following is possible:
```
{{ $devices := split .Tags.devices ";" -}}
{{ range $dev := $devices -}}
Do stuff with {{ $dev }}
{{  end }}
```
and store the devices in the central configuration as `;` seperated list.
Simple full disk deployments can so be enabled without the need if having addiotnal variables in the configuration.