### PR TITLE
Renames instances of "Default" to "Primary" in netdev source code

### DIFF
--- a/cmd/update_configuration/update_configuration.go
+++ b/cmd/update_configuration/update_configuration.go
@@ -104,7 +104,7 @@ func update42to43(conf42 vers42.NodeConf) vers43.NodeConf {
 		var device vers43.NetDevs = vers43.NetDevs{
 			Type:    netdev.Type,
 			Device:  devn,
-			Default: printB(netdev.Default),
+			Primary: printB(netdev.Default),
 			Hwaddr:  netdev.Hwaddr,
 			Ipaddr:  netdev.Ipaddr,
 			IpCIDR:  netdev.IpCIDR,

--- a/cmd/update_configuration/vers43/datastructure.go
+++ b/cmd/update_configuration/vers43/datastructure.go
@@ -60,6 +60,6 @@ type NetDevs struct {
 	Prefix  string            `yaml:"prefix,omitempty"`
 	Netmask string            `yaml:"netmask,omitempty"`
 	Gateway string            `yaml:"gateway,omitempty"`
-	Default string            `yaml:"default,omitempty"`
+	Primary string            `yaml:"primary,omitempty"`
 	Tags    map[string]string `yaml:"tags,omitempty"`
 }

--- a/internal/app/wwctl/node/list/main.go
+++ b/internal/app/wwctl/node/list/main.go
@@ -71,7 +71,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 				fmt.Printf("%-20s %-18s %-12s %s\n", node.Id.Get(), name+":GATEWAY", netdev.Gateway.Source(), netdev.Gateway.Print())
 				fmt.Printf("%-20s %-18s %-12s %s\n", node.Id.Get(), name+":TYPE", netdev.Type.Source(), netdev.Type.Print())
 				fmt.Printf("%-20s %-18s %-12s %s\n", node.Id.Get(), name+":ONBOOT", netdev.OnBoot.Source(), netdev.OnBoot.PrintB())
-				fmt.Printf("%-20s %-18s %-12s %s\n", node.Id.Get(), name+":DEFAULT", netdev.Default.Source(), netdev.Default.PrintB())
+				fmt.Printf("%-20s %-18s %-12s %s\n", node.Id.Get(), name+":PRIMARY", netdev.Primary.Source(), netdev.Primary.PrintB())
 				for keyname, key := range netdev.Tags {
 					fmt.Printf("%-20s %-18s %-12s %s\n", node.Id.Get(), name+":TAG["+keyname+"]", key.Source(), key.Print())
 				}

--- a/internal/app/wwctl/node/set/main.go
+++ b/internal/app/wwctl/node/set/main.go
@@ -188,13 +188,13 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 			SetNetOnBoot = "yes"
 
 			for _, n := range n.NetDevs {
-				if n.Default.GetB() {
+				if n.Primary.GetB() {
 					def = false
 				}
 			}
 
 			if def {
-				SetNetDefault = "yes"
+				SetNetPrimary = "yes"
 			}
 
 		}
@@ -276,24 +276,24 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		if SetNetDefault != "" {
+		if SetNetPrimary != "" {
 			if SetNetName == "" {
 				wwlog.Printf(wwlog.ERROR, "You must include the '--netname' option\n")
 				os.Exit(1)
 			}
 
-			if SetNetDefault == "yes" || SetNetDefault == "y" || SetNetDefault == "1" || SetNetDefault == "true" {
+			if SetNetPrimary == "yes" || SetNetPrimary == "y" || SetNetPrimary == "1" || SetNetPrimary == "true" {
 
 				// Set all other devices to non-default
 				for _, n := range n.NetDevs {
-					n.Default.SetB(false)
+					n.Primary.SetB(false)
 				}
 
 				wwlog.Printf(wwlog.VERBOSE, "Node: %s:%s, Setting PRIMARY\n", n.Id.Get(), SetNetName)
-				n.NetDevs[SetNetName].Default.SetB(true)
+				n.NetDevs[SetNetName].Primary.SetB(true)
 			} else {
 				wwlog.Printf(wwlog.VERBOSE, "Node: %s:%s, Unsetting PRIMARY\n", n.Id.Get(), SetNetName)
-				n.NetDevs[SetNetName].Default.SetB(false)
+				n.NetDevs[SetNetName].Primary.SetB(false)
 			}
 		}
 

--- a/internal/app/wwctl/node/set/root.go
+++ b/internal/app/wwctl/node/set/root.go
@@ -44,7 +44,7 @@ var (
 	SetHwaddr         string
 	SetType           string
 	SetNetOnBoot      string
-	SetNetDefault     string
+	SetNetPrimary     string
 	SetNetDevDel      bool
 	SetClusterName    string
 	SetIpxe           string
@@ -143,7 +143,7 @@ func init() {
 	baseCmd.PersistentFlags().StringVarP(&SetHwaddr, "hwaddr", "H", "", "Set the node's network device HW address")
 	baseCmd.PersistentFlags().StringVarP(&SetType, "type", "T", "", "Set the node's network device type")
 	baseCmd.PersistentFlags().StringVar(&SetNetOnBoot, "onboot", "", "Enable/disable device (yes/no)")
-	baseCmd.PersistentFlags().StringVar(&SetNetDefault, "primary", "", "Enable/disable device as primary (yes/no)")
+	baseCmd.PersistentFlags().StringVar(&SetNetPrimary, "primary", "", "Enable/disable device as primary (yes/no)")
 
 	baseCmd.PersistentFlags().BoolVar(&SetNetDevDel, "netdel", false, "Delete the node's network device")
 	baseCmd.PersistentFlags().StringSliceVar(&SetNetTags, "nettag", []string{}, "Define custom tag to network device (key=value)")

--- a/internal/app/wwctl/profile/list/main.go
+++ b/internal/app/wwctl/profile/list/main.go
@@ -62,7 +62,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 				fmt.Printf("%-20s %-18s %s\n", profile.Id.Get(), name+":HWADDR", netdev.Hwaddr.Print())
 				fmt.Printf("%-20s %-18s %s\n", profile.Id.Get(), name+":TYPE", netdev.Hwaddr.Print())
 				fmt.Printf("%-20s %-18s %s\n", profile.Id.Get(), name+":ONBOOT", netdev.OnBoot.PrintB())
-				fmt.Printf("%-20s %-18s %s\n", profile.Id.Get(), name+":DEFAULT", netdev.Default.PrintB())
+				fmt.Printf("%-20s %-18s %s\n", profile.Id.Get(), name+":PRIMARY", netdev.Primary.PrintB())
 				for keyname, key := range netdev.Tags {
 					fmt.Printf("%-20s %-18s %-12s %s\n", profile.Id.Get(), name+":TAG["+keyname+"]", key.Source(), key.Print())
 				}

--- a/internal/app/wwctl/profile/set/main.go
+++ b/internal/app/wwctl/profile/set/main.go
@@ -211,24 +211,24 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		if SetNetDefault != "" {
+		if SetNetPrimary != "" {
 			if SetNetName == "" {
 				wwlog.Printf(wwlog.ERROR, "You must include the '--netname' option\n")
 				os.Exit(1)
 			}
 
-			if SetNetDefault == "yes" || SetNetDefault == "y" || SetNetDefault == "1" || SetNetDefault == "true" {
+			if SetNetPrimary == "yes" || SetNetPrimary == "y" || SetNetPrimary == "1" || SetNetPrimary == "true" {
 
 				// Set all other networks to non-default
 				for _, n := range p.NetDevs {
-					n.Default.SetB(false)
+					n.Primary.SetB(false)
 				}
 
 				wwlog.Printf(wwlog.VERBOSE, "Profile: %s:%s, Setting PRIMARY\n", p.Id.Get(), SetNetName)
-				p.NetDevs[SetNetName].Default.SetB(true)
+				p.NetDevs[SetNetName].Primary.SetB(true)
 			} else {
 				wwlog.Printf(wwlog.VERBOSE, "Profile: %s:%s, Unsetting PRIMARY\n", p.Id.Get(), SetNetName)
-				p.NetDevs[SetNetName].Default.SetB(false)
+				p.NetDevs[SetNetName].Primary.SetB(false)
 			}
 		}
 

--- a/internal/app/wwctl/profile/set/root.go
+++ b/internal/app/wwctl/profile/set/root.go
@@ -57,7 +57,7 @@ var (
 	SetGateway        string
 	SetType           string
 	SetNetOnBoot      string
-	SetNetDefault     string
+	SetNetPrimary     string
 	SetNetDevDel      bool
 	SetDiscoverable   bool
 	SetUndiscoverable bool
@@ -118,7 +118,7 @@ func init() {
 
 	baseCmd.PersistentFlags().StringVarP(&SetNetName, "netname", "n", "default", "Define the network name to configure")
 	baseCmd.PersistentFlags().StringVarP(&SetNetDev, "netdev", "N", "", "Set the node's network device")
-	baseCmd.PersistentFlags().StringVar(&SetNetDefault, "primary", "", "Enable/disable device as primary (yes/no)")
+	baseCmd.PersistentFlags().StringVar(&SetNetPrimary, "primary", "", "Enable/disable device as primary (yes/no)")
 	baseCmd.PersistentFlags().StringVarP(&SetNetmask, "netmask", "M", "", "Set the node's network device netmask")
 	baseCmd.PersistentFlags().StringVarP(&SetGateway, "gateway", "G", "", "Set the node's network device gateway")
 	baseCmd.PersistentFlags().StringVarP(&SetType, "type", "T", "", "Set the node's network device type")

--- a/internal/pkg/node/constructors.go
+++ b/internal/pkg/node/constructors.go
@@ -166,10 +166,10 @@ func (config *nodeYaml) FindAllNodes() ([]NodeInfo, error) {
 			n.NetDevs[devname].Gateway.Set(netdev.Gateway)
 			n.NetDevs[devname].Type.Set(netdev.Type)
 			n.NetDevs[devname].OnBoot.Set(netdev.OnBoot)
-			n.NetDevs[devname].Default.Set(netdev.Default)
+			n.NetDevs[devname].Primary.Set(netdev.Primary)
 			// for just one netdev, it is always the default
 			if len(node.NetDevs) == 1 {
-				n.NetDevs[devname].Default.Set("true")
+				n.NetDevs[devname].Primary.Set("true")
 			}
 			n.NetDevs[devname].Tags = make(map[string]*Entry)
 			for keyname, key := range netdev.Tags {
@@ -253,7 +253,7 @@ func (config *nodeYaml) FindAllNodes() ([]NodeInfo, error) {
 				n.NetDevs[devname].Gateway.SetAlt(netdev.Gateway, p)
 				n.NetDevs[devname].Type.SetAlt(netdev.Type, p)
 				n.NetDevs[devname].OnBoot.SetAlt(netdev.OnBoot, p)
-				n.NetDevs[devname].Default.SetAlt(netdev.Default, p)
+				n.NetDevs[devname].Primary.SetAlt(netdev.Primary, p)
 				if len(netdev.Tags) != 0 {
 					for keyname, key := range netdev.Tags {
 						if _, ok := n.NetDevs[devname].Tags[keyname]; !ok {
@@ -376,7 +376,7 @@ func (config *nodeYaml) FindAllProfiles() ([]NodeInfo, error) {
 			p.NetDevs[devname].Gateway.Set(netdev.Gateway)
 			p.NetDevs[devname].Type.Set(netdev.Type)
 			p.NetDevs[devname].OnBoot.Set(netdev.OnBoot)
-			p.NetDevs[devname].Default.Set(netdev.Default)
+			p.NetDevs[devname].Primary.Set(netdev.Primary)
 
 			// The following should not be set in a profile.
 			if netdev.Ipaddr != "" {

--- a/internal/pkg/node/constructors.go
+++ b/internal/pkg/node/constructors.go
@@ -167,7 +167,8 @@ func (config *nodeYaml) FindAllNodes() ([]NodeInfo, error) {
 			n.NetDevs[devname].Type.Set(netdev.Type)
 			n.NetDevs[devname].OnBoot.Set(netdev.OnBoot)
 			n.NetDevs[devname].Primary.Set(netdev.Primary)
-			// for just one netdev, it is always the default
+			n.NetDevs[devname].Primary.Set(netdev.Default) // backwards compatibility
+			// for just one netdev, it is always the primary
 			if len(node.NetDevs) == 1 {
 				n.NetDevs[devname].Primary.Set("true")
 			}
@@ -377,6 +378,7 @@ func (config *nodeYaml) FindAllProfiles() ([]NodeInfo, error) {
 			p.NetDevs[devname].Type.Set(netdev.Type)
 			p.NetDevs[devname].OnBoot.Set(netdev.OnBoot)
 			p.NetDevs[devname].Primary.Set(netdev.Primary)
+			p.NetDevs[devname].Primary.Set(netdev.Default) // backwards compatibility
 
 			// The following should not be set in a profile.
 			if netdev.Ipaddr != "" {

--- a/internal/pkg/node/datastructure.go
+++ b/internal/pkg/node/datastructure.go
@@ -75,7 +75,7 @@ type NetDevs struct {
 	Prefix  string            `yaml:"prefix,omitempty"`
 	Netmask string            `yaml:"netmask,omitempty"`
 	Gateway string            `yaml:"gateway,omitempty"`
-	Default string            `yaml:"primary,omitempty"`
+	Primary string            `yaml:"primary,omitempty"`
 	Tags    map[string]string `yaml:"tags,omitempty"`
 }
 
@@ -149,7 +149,7 @@ type NetDevEntry struct {
 	Prefix  Entry
 	Netmask Entry
 	Gateway Entry
-	Default Entry
+	Primary Entry
 	Tags    map[string]*Entry
 }
 

--- a/internal/pkg/node/datastructure.go
+++ b/internal/pkg/node/datastructure.go
@@ -76,6 +76,7 @@ type NetDevs struct {
 	Netmask string            `yaml:"netmask,omitempty"`
 	Gateway string            `yaml:"gateway,omitempty"`
 	Primary string            `yaml:"primary,omitempty"`
+	Default string            `yaml:"default,omitempty"` /* backward compatibility */
 	Tags    map[string]string `yaml:"tags,omitempty"`
 }
 

--- a/internal/pkg/node/modifiers.go
+++ b/internal/pkg/node/modifiers.go
@@ -101,7 +101,7 @@ func (config *nodeYaml) NodeUpdate(node NodeInfo) error {
 		config.Nodes[nodeID].NetDevs[devname].Gateway = netdev.Gateway.GetReal()
 		config.Nodes[nodeID].NetDevs[devname].Type = netdev.Type.GetReal()
 		config.Nodes[nodeID].NetDevs[devname].OnBoot = netdev.OnBoot.GetReal()
-		config.Nodes[nodeID].NetDevs[devname].Default = netdev.Default.GetReal()
+		config.Nodes[nodeID].NetDevs[devname].Primary = netdev.Primary.GetReal()
 		config.Nodes[nodeID].NetDevs[devname].Tags = make(map[string]string)
 		for keyname, key := range netdev.Tags {
 			if key.GetReal() != "" {
@@ -207,7 +207,7 @@ func (config *nodeYaml) ProfileUpdate(profile NodeInfo) error {
 		config.NodeProfiles[profileID].NetDevs[devname].Gateway = netdev.Gateway.GetReal()
 		config.NodeProfiles[profileID].NetDevs[devname].Type = netdev.Type.GetReal()
 		config.NodeProfiles[profileID].NetDevs[devname].OnBoot = netdev.OnBoot.GetReal()
-		config.NodeProfiles[profileID].NetDevs[devname].Default = netdev.Default.GetReal()
+		config.NodeProfiles[profileID].NetDevs[devname].Primary = netdev.Primary.GetReal()
 		config.NodeProfiles[profileID].NetDevs[devname].Tags = make(map[string]string)
 		for key := range netdev.Tags {
 			config.NodeProfiles[profileID].NetDevs[devname].Tags[key] = netdev.Tags[key].GetReal()

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -261,7 +261,7 @@ func BuildOverlayIndir(nodeInfo node.NodeInfo, overlayNames []string, outputDir 
 		tstruct.NetDevs[devname].Gateway = netdev.Gateway.Get()
 		tstruct.NetDevs[devname].Type = netdev.Type.Get()
 		tstruct.NetDevs[devname].OnBoot = netdev.OnBoot.Get()
-		tstruct.NetDevs[devname].Default = netdev.Default.Get()
+		tstruct.NetDevs[devname].Primary = netdev.Primary.Get()
 		mask := net.IPMask(net.ParseIP(netdev.Netmask.Get()).To4())
 		ipaddr := net.ParseIP(netdev.Ipaddr.Get()).To4()
 		netaddr := net.IPNet{IP: ipaddr, Mask: mask}

--- a/overlays/host/etc/dhcp/dhcpd.conf.ww
+++ b/overlays/host/etc/dhcp/dhcpd.conf.ww
@@ -41,7 +41,7 @@ subnet {{$.Network}} netmask {{$.Netmask}} {
 }
 {{range $nodes := .AllNodes}}
 {{- range $netdevs := $nodes.NetDevs}}
-{{- if $netdevs.Default.Get}}
+{{- if $netdevs.Primary.Get}}
 host {{$nodes.Id.Get}} {
    hardware ethernet {{$netdevs.Hwaddr.Get}};
    fixed-address {{$netdevs.Ipaddr.Get}};

--- a/overlays/host/etc/hosts.ww
+++ b/overlays/host/etc/hosts.ww
@@ -8,7 +8,7 @@
 # Entry for {{$node.Id.Get}}
 {{- range $devname, $netdev := $node.NetDevs}} {{/* for each network device on the node */}}
 {{- if $netdev.Ipaddr.Defined}}                {{/* if we have an ip address on this network device */}}
-{{- if $netdev.Default.GetB}}                  {{/* emit the node name as hostname if this is the default */}}
+{{- if $netdev.Primary.GetB}}                  {{/* emit the node name as hostname if this is the default */}}
 {{$netdev.Ipaddr.Get}} {{$node.Id.Get}} {{$node.Id.Get}}-{{$devname}} {{$node.Id.Get}}-{{$netdev.Device.Get}}
 {{- else}}
 {{$netdev.Ipaddr.Get}} {{$node.Id.Get}}-{{$devname}} {{$node.Id.Get}}-{{$netdev.Device.Get}}

--- a/overlays/wwinit/etc/systemd/network/10-persistent-net.link.ww
+++ b/overlays/wwinit/etc/systemd/network/10-persistent-net.link.ww
@@ -1,6 +1,6 @@
 # /etc/systemd/network/10-persistent-net.link
 {{range $devname, $netdev := .NetDevs}}
-{{- if $netdev.Default}}
+{{- if $netdev.Primary}}
 [Match]
 MACAddress={{$netdev.Hwaddr}}
 [Link]


### PR DESCRIPTION
Signed-off-by: jcsiadal <jeremy.c.siadal@intel.com>

Within netdev structs, Default is renamed to Primary. Cobra commander variables using "default" for the primary network are also renamed.