### PR TITLE
Fix /opt defaults in warewulf.conf

### DIFF
--- a/etc/warewulf.conf
+++ b/etc/warewulf.conf
@@ -30,7 +30,7 @@ nfs:
     mount: true
   - path: /opt
     export options: ro,sync,no_root_squash
-    mount options: ""
+    mount options: defaults
     mount: false
   systemd name: nfs-server
 


### PR DESCRIPTION
Signed-off-by: jcsiadal <jeremy.c.siadal@intel.com>

Update the default warewulf.conf file, so that working /opt mount arguments are supplied.