### PR TITLE
syncucer will only write witrh syncuser switch

### DIFF
--- a/internal/app/wwctl/container/imprt/main.go
+++ b/internal/app/wwctl/container/imprt/main.go
@@ -130,8 +130,8 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		wwlog.Printf(wwlog.WARN, "Could not copy /etc/resolv.conf into container: %s\n", err)
 	}
 
-	err = container.SyncUids(name, !NoSyncUser)
-	if err != nil && !NoSyncUser {
+	err = container.SyncUids(name, !SyncUser)
+	if err != nil && !SyncUser {
 		wwlog.Printf(wwlog.ERROR, "Error in user sync, fix error and run 'syncuser' manually: %s\n", err)
 		os.Exit(1)
 	}

--- a/internal/app/wwctl/container/imprt/root.go
+++ b/internal/app/wwctl/container/imprt/root.go
@@ -24,7 +24,7 @@ Imported containers are used to create bootable VNFS images.`,
 	SetUpdate  bool
 	SetBuild   bool
 	SetDefault bool
-	NoSyncUser bool
+	SyncUser   bool
 )
 
 func init() {
@@ -32,7 +32,7 @@ func init() {
 	baseCmd.PersistentFlags().BoolVarP(&SetUpdate, "update", "u", false, "Update and overwrite an existing container")
 	baseCmd.PersistentFlags().BoolVarP(&SetBuild, "build", "b", false, "Build container when after pulling")
 	baseCmd.PersistentFlags().BoolVar(&SetDefault, "setdefault", false, "Set this container for the default profile")
-	baseCmd.PersistentFlags().BoolVar(&NoSyncUser, "nosyncuser", false, "Don't synchronize uis/gods from host to container")
+	baseCmd.PersistentFlags().BoolVar(&SyncUser, "syncuser", false, "Synchronize uis/gods from host to container")
 }
 
 // GetRootCommand returns the root cobra.Command for the application.

--- a/internal/app/wwctl/container/syncuser/main.go
+++ b/internal/app/wwctl/container/syncuser/main.go
@@ -14,7 +14,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	if !container.ValidName(containerName) {
 		return fmt.Errorf("%s is not a valid container", containerName)
 	}
-	err := container.SyncUids(containerName, noSyncUser)
+	err := container.SyncUids(containerName, !write)
 	if err != nil {
 		wwlog.Printf(wwlog.ERROR, "Error in synchronize: %s\n", err)
 		os.Exit(1)

--- a/internal/app/wwctl/container/syncuser/root.go
+++ b/internal/app/wwctl/container/syncuser/root.go
@@ -24,11 +24,11 @@ uid/gid collision is detected. File ownerships are also changed.`,
 
 		Args: cobra.MinimumNArgs(1),
 	}
-	noSyncUser bool
+	write bool
 )
 
 func init() {
-	baseCmd.PersistentFlags().BoolVar(&noSyncUser, "nosyncuser", false, "Don't synchronize uis/gods just check")
+	baseCmd.PersistentFlags().BoolVar(&write, "write", false, "Synchronize uis/gids and write files in container")
 }
 
 // GetRootCommand returns the root cobra.Command for the application.

--- a/internal/pkg/container/syncuids.go
+++ b/internal/pkg/container/syncuids.go
@@ -100,7 +100,8 @@ func SyncUids(containerName string, showOnly bool) error {
 		*/
 
 	}
-	if !showOnly {
+	if showOnly {
+		wwlog.Printf(wwlog.INFO, "uid./gid not synced, run \nwwctl container syncuser --write %s\nto synchronize uid/gids.\n", containerName)
 		return nil
 	}
 	// create list of files which need changed ownerships in order to change them later what


### PR DESCRIPTION
uid/gid are not synced at container import but checked. An apropriate
message is printed, regarding users which are not present on host.
The `wwctl container syncuser` needs the `--write` switch to actually
write to the container.

The command `wwctl container syncuser` will always operate at the
container level, but as the 'generic` overlay reads in the container
passwd/group, following two steps will update the passwd/group on a
running cluster:
1. Add passwd/group to container
wwctl container syncuser --write CONTAINER
2. Synchronize overlay
wwctl overlay build -N
