### PR TITLE
4.3.0rc6 fixes

### DIFF
--- a/etc/ipxe/default.ipxe
+++ b/etc/ipxe/default.ipxe
@@ -19,40 +19,41 @@ echo Warewulf Controller: {{.Ipaddr}}
 echo Downloading Kernel Image:
 kernel --name kernel ${uri_base}&stage=kernel       || goto reboot
 
-## try extracting compressed images first
-## NOTE: system overlay tends to be the smallest, so failure here is the cheapest
-#echo Downloading Container Image:
-#imgextract --name container ${uri_base}&stage=container&compress=gz || goto nocompress
-#
-#echo Downloading System Overlay:
-#imgextract --name system ${uri_base}&stage=system&compress=gz       || goto reboot
-#
-#echo Downloading Runtime Overlay:
-#imgextract --name runtime ${uri_base}&stage=runtime&compress=gz     || goto reboot
-#
-#{{if ne .KernelOverride "" -}}
-#echo Downloading Kernel Modules:
-#imgextract --name kmods ${uri_base}&stage=kmods&compress=gz         || goto reboot
-#{{- end}}
-#
-#goto imoktogo
-#
-#:nocompress
-#
-#echo Extraction failed, attempting un-compressed version of images
-
+# try extracting compressed images first
+# NOTE: system overlay tends to be the smallest, so failure here is the cheapest
 echo Downloading Container Image:
-initrd --name container ${uri_base}&stage=container     || goto reboot
+imgextract --name container ${uri_base}&stage=container&compress=gz || goto nocompress
 
 echo Downloading System Overlay:
-initrd --name system ${uri_base}&stage=system           || goto reboot
+imgextract --name system ${uri_base}&stage=system&compress=gz       || goto reboot
 
 echo Downloading Runtime Overlay:
-initrd --name runtime ${uri_base}&stage=runtime         || goto reboot
+imgextract --name runtime ${uri_base}&stage=runtime&compress=gz     || goto reboot
 
 {{if ne .KernelOverride "" -}}
 echo Downloading Kernel Modules:
-initrd --name kmods ${uri_base}&stage=kmods             || goto reboot
+imgextract --name kmods ${uri_base}&stage=kmods&compress=gz         || goto reboot
+{{- end}}
+
+goto imoktogo
+
+:nocompress
+
+echo
+echo Image extract not supported in this iPXE, using standard initrd mode
+
+echo Downloading Container Image:
+initrd --name container ${uri_base}&stage=container&compress=gz     || goto reboot
+
+echo Downloading System Overlay:
+initrd --name system ${uri_base}&stage=system&compress=gz           || goto reboot
+
+echo Downloading Runtime Overlay:
+initrd --name runtime ${uri_base}&stage=runtime&compress=gz         || goto reboot
+
+{{if ne .KernelOverride "" -}}
+echo Downloading Kernel Modules:
+initrd --name kmods ${uri_base}&stage=kmods&compress=gz             || goto reboot
 {{- end}}
 
 

--- a/internal/pkg/warewulfd/util.go
+++ b/internal/pkg/warewulfd/util.go
@@ -2,7 +2,6 @@ package warewulfd
 
 import (
 	"io"
-	"bytes"
 	"net/http"
 	"os"
 	"strconv"
@@ -36,17 +35,15 @@ func sendFile(w http.ResponseWriter, filename string, sendto string) error {
 		return errors.Wrap(err, "failed to seek")
 	}
 
-	var buf bytes.Buffer
-	_, err = io.Copy(&buf, fd)
+	w.Header().Set("Content-Disposition", "attachment; filename=kernel")
+	w.Header().Set("Content-Type", FileContentType)
+	w.Header().Set("Content-Length", FileSize)
+
+	_, err = io.Copy(w, fd)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return errors.Wrap(err, "failed to copy")
 	}
-
-	w.Header().Set("Content-Disposition", "attachment; filename=kernel")
-	w.Header().Set("Content-Type", FileContentType)
-	w.Header().Set("Content-Length", FileSize)
-	_, err = buf.WriteTo(w)
 
 	wwlog.Send("%15s: %s", sendto, filename)
 


### PR DESCRIPTION
DO NOT MERGE YET!

A minor fix/workaround to always use compression for what Norm Gaywood found in Slack with regards to the compute nodes running out of memory while trying to fetch the container images.

Also, I included an optimization in the `sendFile()` function to not load full binary data blobs into memory before sending over the the HTTP writer as doing that in parallel would kill a control server.

note: We might decide a different/better fix for the first issue and I'd like validation on the second.