### PR TITLE
Fix CI build release

### DIFF
--- a/ci/mockbuild.sh
+++ b/ci/mockbuild.sh
@@ -10,8 +10,8 @@ tar -xf warewulf-${VERSION}.tar.gz warewulf-${VERSION}/warewulf.spec
 RELEASE=$(grep 'Release: ' warewulf-${VERSION}/warewulf.spec | cut -d ':' -f2 | awk -F'%' '{print $1}' | tr -d ' ')
 echo RELEASE=${RELEASE} >> $GITHUB_ENV
 
-mock -r epel-8-x86_64 --rebuild --spec=warewulf-${VERSION}/warewulf.spec --sources=.
-mv /var/lib/mock/epel-8-x86_64/result/warewulf-${VERSION}-${RELEASE}.el8.x86_64.rpm .
+mock -r rocky+epel-8-x86_64 --rebuild --spec=warewulf-${VERSION}/warewulf.spec --sources=.
+mv /var/lib/mock/rocky+epel-8-x86_64/result/warewulf-${VERSION}-${RELEASE}.el8.x86_64.rpm .
 
-mock -r epel-7-x86_64 --rebuild --spec=warewulf-${VERSION}/warewulf.spec --sources=.
-mv /var/lib/mock/epel-7-x86_64/result/warewulf-${VERSION}-${RELEASE}.el7.x86_64.rpm .
+mock -r centos+epel-7-x86_64 --rebuild --spec=warewulf-${VERSION}/warewulf.spec --sources=.
+mv /var/lib/mock/centos+epel-7-x86_64/result/warewulf-${VERSION}-${RELEASE}.el7.x86_64.rpm .


### PR DESCRIPTION
This PR is fix CI build release.
New mock need explicit config file.
Rocky 7 not available use centos-7 instead.