### PR TITLE
Fix server thread safety of discoverable node and overlay build

### DIFF
--- a/internal/app/wwctl/overlay/build/main.go
+++ b/internal/app/wwctl/overlay/build/main.go
@@ -3,11 +3,9 @@ package build
 import (
 	"errors"
 	"os"
-	"strings"
 
 	"github.com/hpcng/warewulf/internal/pkg/node"
 	"github.com/hpcng/warewulf/internal/pkg/overlay"
-	"github.com/hpcng/warewulf/internal/pkg/util"
 	"github.com/hpcng/warewulf/internal/pkg/warewulfconf"
 	"github.com/hpcng/warewulf/internal/pkg/wwlog"
 	"github.com/hpcng/warewulf/pkg/hostlist"
@@ -54,7 +52,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 			}
 
 			for _, node := range nodes {
-				return overlay.BuildOverlayIndir(node, OverlayNames), OverlayDir)
+				return overlay.BuildOverlayIndir(node, OverlayNames, OverlayDir)
 			}
 		} else {
 			// TODO this seems different than what is set in BuildHostOverlay

--- a/internal/app/wwctl/overlay/build/main.go
+++ b/internal/app/wwctl/overlay/build/main.go
@@ -3,6 +3,7 @@ package build
 import (
 	"errors"
 	"os"
+	"strings"
 
 	"github.com/hpcng/warewulf/internal/pkg/node"
 	"github.com/hpcng/warewulf/internal/pkg/overlay"
@@ -38,6 +39,15 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 			return errors.New("Failed to find nodes")
 		}
 	}
+
+	// NOTE: this is to keep backward compatible
+	// passing -O a,b,c versus -O a -O b -O c, but will also accept -O a,b -O c
+	overlayNames := []string{}
+	for _, name := range OverlayNames {
+		names := strings.Split(name, ",")
+		overlayNames = append(overlayNames, names...)
+	}
+	OverlayNames = overlayNames
 
 	if OverlayDir != "" {
 		if len(OverlayNames) == 0 {

--- a/internal/app/wwctl/overlay/build/main.go
+++ b/internal/app/wwctl/overlay/build/main.go
@@ -31,63 +31,61 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		wwlog.Printf(wwlog.ERROR, "Could not get node list: %s\n", err)
 		os.Exit(1)
 	}
-	if OverlayDir != "" {
-		if OverlayName == "" {
-			return errors.New("no overlay name given")
+
+	if len(args) > 0 {
+		args = hostlist.Expand(args)
+		nodes = node.FilterByName(nodes, args)
+
+		if len(nodes) < len(args) {
+			return errors.New("Failed to find nodes")
 		}
+	}
+
+	if OverlayDir != "" {
+		if len(OverlayNames) == 0 {
+			// TODO: should this behave the same as OverlayDir == "", and build default
+			// set to overlays?
+			return errors.New("Must specify overlay(s) to build")
+		}
+
 		if len(args) > 0 {
-			args = hostlist.Expand(args)
+			if len(nodes) != 1 {
+				return errors.New("Must specify one node to build overlay")
+			}
+
 			for _, node := range nodes {
-				if util.InSlice(node.RuntimeOverlay.GetSlice(), OverlayName) ||
-					util.InSlice(node.SystemOverlay.GetSlice(), OverlayName) {
-					return overlay.BuildOverlayIndir(node, strings.Split(OverlayName, ","), OverlayDir)
-				} else {
-					return errors.New("no node uses the given overlay")
-				}
+				return overlay.BuildOverlayIndir(node, OverlayNames), OverlayDir)
 			}
 		} else {
+			// TODO this seems different than what is set in BuildHostOverlay
 			var host node.NodeInfo
 			var idEntry node.Entry
 			hostname, _ := os.Hostname()
-			wwlog.Printf(wwlog.INFO, "Building overlay for %s: host\n", hostname)
+			wwlog.Info("Building overlay for host: %s", hostname)
 			idEntry.Set(hostname)
 			host.Id = idEntry
-			return overlay.BuildOverlayIndir(host, strings.Split(OverlayName, ","), OverlayDir)
+			return overlay.BuildOverlayIndir(host, OverlayNames, OverlayDir)
 
 		}
 
 	}
+
 	if BuildHost || (!BuildHost && !BuildNodes && len(args) == 0 && controller.Warewulf.EnableHostOverlay) {
 		err := overlay.BuildHostOverlay()
 		if err != nil {
 			wwlog.Printf(wwlog.WARN, "host overlay could not be built: %s\n", err)
 		}
 	}
-	if BuildNodes || (!BuildHost && !BuildNodes) {
 
-		if len(args) > 0 {
-			args = hostlist.Expand(args)
-			if OverlayName != "" {
-				err = overlay.BuildSpecificOverlays(node.FilterByName(nodes, args), OverlayName)
-			} else {
-				err = overlay.BuildAllOverlays(node.FilterByName(nodes, args))
-			}
+	if BuildNodes || (!BuildHost && !BuildNodes) {
+		if len(OverlayNames) > 0 {
+			err = overlay.BuildSpecificOverlays(nodes, OverlayNames)
 		} else {
-			if OverlayName != "" {
-				for _, n := range nodes {
-					if util.InSlice(n.RuntimeOverlay.GetSlice(), OverlayName) ||
-						util.InSlice(n.SystemOverlay.GetSlice(), OverlayName) {
-						err = overlay.BuildSpecificOverlays([]node.NodeInfo{n}, OverlayName)
-					}
-				}
-			} else {
-				err = overlay.BuildAllOverlays(nodes)
-			}
+			err = overlay.BuildAllOverlays(nodes)
 		}
 
 		if err != nil {
-			wwlog.Printf(wwlog.WARN, "Some system overlays failed to be generated: %s\n", err)
-
+			wwlog.Printf(wwlog.WARN, "Some overlays failed to be generated: %s\n", err)
 		}
 	}
 	return nil

--- a/internal/app/wwctl/overlay/build/root.go
+++ b/internal/app/wwctl/overlay/build/root.go
@@ -38,7 +38,7 @@ var (
 func init() {
 	baseCmd.PersistentFlags().BoolVarP(&BuildHost, "host", "H", false, "Build overlays only for the host")
 	baseCmd.PersistentFlags().BoolVarP(&BuildNodes, "nodes", "N", false, "Build overlays only for the nodes")
-	baseCmd.PersistentFlags().StringSliceVar(&OverlayNames, "overlay", "O", []string{}, "Build only specific overlay(s)")
+	baseCmd.PersistentFlags().StringSliceVarP(&OverlayNames, "overlay", "O", []string{}, "Build only specific overlay(s)")
 
 	if err := baseCmd.RegisterFlagCompletionFunc("overlay", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		list, _ := overlay.FindOverlays()

--- a/internal/app/wwctl/overlay/build/root.go
+++ b/internal/app/wwctl/overlay/build/root.go
@@ -31,14 +31,15 @@ var (
 	}
 	BuildHost   bool
 	BuildNodes  bool
-	OverlayName string
+	OverlayNames []string
 	OverlayDir  string
 )
 
 func init() {
 	baseCmd.PersistentFlags().BoolVarP(&BuildHost, "host", "H", false, "Build overlays only for the host")
 	baseCmd.PersistentFlags().BoolVarP(&BuildNodes, "nodes", "N", false, "Build overlays only for the nodes")
-	baseCmd.PersistentFlags().StringVarP(&OverlayName, "overlay", "O", "", "Build only specific overlay")
+	baseCmd.PersistentFlags().StringSliceVar(&OverlayNames, "overlay", "O", []string{}, "Build only specific overlay(s)")
+
 	if err := baseCmd.RegisterFlagCompletionFunc("overlay", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		list, _ := overlay.FindOverlays()
 		return list, cobra.ShellCompDirectiveNoFileComp

--- a/internal/app/wwctl/overlay/imprt/main.go
+++ b/internal/app/wwctl/overlay/imprt/main.go
@@ -70,7 +70,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		return overlay.BuildSpecificOverlays(updateNodes, overlayName)
+		return overlay.BuildSpecificOverlays(updateNodes, []string{overlayName})
 	}
 
 	return nil

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -68,13 +68,13 @@ func BuildAllOverlays(nodes []node.NodeInfo) error {
 
 // TODO: Add an Overlay Delete for both sourcedir and image
 
-func BuildSpecificOverlays(nodes []node.NodeInfo, overlayName string) error {
+func BuildSpecificOverlays(nodes []node.NodeInfo, overlayNames []string) error {
 	for _, n := range nodes {
 
-		wwlog.Info("Building overlay for %s: %s", n.Id.Get(), overlayName)
-		err := BuildOverlay(n, []string{overlayName})
+		wwlog.Info("Building overlay for %s: %v", n.Id.Get(), overlayNames)
+		err := BuildOverlay(n, overlayNames)
 		if err != nil {
-			return errors.Wrap(err, "could not build overlay "+n.Id.Get()+"/"+overlayName+".img")
+			return errors.Wrapf(err, "could not build overlay for node %s: %v", n.Id.Get(), overlayNames)
 		}
 
 	}

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -658,11 +658,11 @@ func BuildFsImage(
 /*******************************************************************************
 	Runs wwctl command
 */
-func RunWWCTL(args ...string) (out string, err error) {
+func RunWWCTL(args ...string) (out []byte, err error) {
 
 	proc := exec.Command("wwctl", args...)
 
-	out, err := proc.CombinedOutput()
+	out, err = proc.CombinedOutput()
 
 	return out, err
 }

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -31,7 +31,7 @@ var processLimitedNum int32 = 0
 // Counter over total history of started processes
 var processLimitedCounter uint32 = 0
 
-func ProcessLimitedEnter() (index int32) {
+func ProcessLimitedEnter() (index uint32) {
 	atomic.AddInt32(&processLimitedNum, 1)
 	index = atomic.AddUint32(&processLimitedCounter, 1)
 	// NOTE: blocks when channel is full (i.e. processLimitedMax)
@@ -45,8 +45,8 @@ func ProcessLimitedExit() {
 	atomic.AddInt32(&processLimitedNum, -1)
 }
 
-func ProcessLimitedStatus() (running int, queued int) {
-	running = len(processLimitedChan)
+func ProcessLimitedStatus() (running int32, queued int32) {
+	running = int32(len(processLimitedChan))
 	queued = processLimitedNum - running
 	return
 }

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -654,3 +654,15 @@ func BuildFsImage(
 
 	return nil
 }
+
+/*******************************************************************************
+	Runs wwctl command
+*/
+func RunWWCTL(args ...string) (out string, err error) {
+
+	proc := exec.Command("wwctl", args...)
+
+	out, err := proc.CombinedOutput()
+
+	return out, err
+}

--- a/internal/pkg/warewulfd/nodedb.go
+++ b/internal/pkg/warewulfd/nodedb.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/hpcng/warewulf/internal/pkg/node"
-	"github.com/hpcng/warewulf/internal/pkg/overlay"
 	"github.com/hpcng/warewulf/internal/pkg/wwlog"
 )
 

--- a/internal/pkg/warewulfd/nodedb.go
+++ b/internal/pkg/warewulfd/nodedb.go
@@ -7,6 +7,8 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/hpcng/warewulf/internal/pkg/node"
+	"github.com/hpcng/warewulf/internal/pkg/overlay"
+	"github.com/hpcng/warewulf/internal/pkg/wwlog"
 )
 
 type nodeDB struct {
@@ -56,4 +58,65 @@ func GetNode(val string) (node.NodeInfo, error) {
 
 	var empty node.NodeInfo
 	return empty, errors.New("No node found")
+}
+
+func GetNodeOrSetDiscoverable(hwaddr string) (node.NodeInfo, error) {
+	// NOTE: since discoverable nodes will write an updated DB to file and then
+	// reload, it is not enough to lock individual reads from the DB
+	// to ensure the condition on which the node is updated is still satisfied
+	// after the DB is read back in.
+	db.lock.Lock()
+	defer db.lock.Unlock()
+
+	n, err := GetNode(hwaddr)
+	if err == nil {
+		return n, nil
+	}
+
+	// If we failed to find a node, let's see if we can add one...
+	var netdev string
+
+	wwlog.WarnExc(err, "%s (node not configured)", hwaddr)
+
+	config, err := node.New()
+	if err != nil {
+		return n, errors.Wrapf(err, "%s (failed to read node configuration file)", hwaddr)
+	}
+
+	_n, netdev, err := config.FindDiscoverableNode()
+	if err != nil {
+		// NOTE: this is taken as there is no discoverable node, so return the
+		// empty one
+		return n, nil
+	}
+
+	_n.NetDevs[netdev].Hwaddr.Set(hwaddr)
+	_n.Discoverable.SetB(false)
+
+	// NOTE: errors here should return the empty node if the state cannot
+	// be saved and re-loaded, since subsequent requests will be made on invalid
+	// assumption that the database is up to date.
+	err = config.NodeUpdate(_n)
+	if err != nil {
+		return n, errors.Wrapf(err, "%s (failed to set node configuration)", hwaddr)
+	}
+
+	err = config.Persist()
+	if err != nil {
+		return n, errors.Wrapf(err, "%s (failed to persist node configuration)", hwaddr)
+	}
+
+	err = LoadNodeDB()
+	if err != nil {
+		return n, errors.Wrapf(err, "%s (failed to reload configuration)", hwaddr)
+	}
+
+	// NOTE: previously all overlays were built here, but that will also
+	// be done automatically when attempting to serve an overlay that
+	// hasn't been built (without blocking the database).
+
+	wwlog.Serv("%s (node automatically configured)", hwaddr)
+
+	// return the discovered node
+	return _n, nil
 }

--- a/internal/pkg/warewulfd/provision.go
+++ b/internal/pkg/warewulfd/provision.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hpcng/warewulf/internal/pkg/buildconfig"
 	"github.com/hpcng/warewulf/internal/pkg/container"
 	"github.com/hpcng/warewulf/internal/pkg/kernel"
-	nodepkg "github.com/hpcng/warewulf/internal/pkg/node"
 	"github.com/hpcng/warewulf/internal/pkg/util"
 	"github.com/hpcng/warewulf/internal/pkg/warewulfconf"
 	"github.com/hpcng/warewulf/internal/pkg/wwlog"

--- a/internal/pkg/warewulfd/provision.go
+++ b/internal/pkg/warewulfd/provision.go
@@ -162,7 +162,7 @@ func ProvisionSend(w http.ResponseWriter, req *http.Request) {
 			if !util.IsFile(stage_file) || util.PathIsNewer(stage_file, nodepkg.ConfigFile) || oneoverlaynewer {
 				wwlog.Serv("BUILD %15s, overlays %v", node.Id.Get(), stage_overlays)
 
-				args := []string{}
+				args := []string{"overlay", "build"}
 
 				for _, overlayname := range stage_overlays {
 					args = append(args, "-O", overlayname)
@@ -170,11 +170,11 @@ func ProvisionSend(w http.ResponseWriter, req *http.Request) {
 
 				args = append(args, node.Id.Get())
 
-				out, err := util.RunWWCTL("overlay", "build", args...)
+				out, err := util.RunWWCTL(args...)
 
 				if err != nil {
 					w.WriteHeader(http.StatusInternalServerError)
-					wwlog.ErrorExc(err, out)
+					wwlog.ErrorExc(err, string(out))
 					return
 				}
 			}

--- a/internal/pkg/warewulfd/util.go
+++ b/internal/pkg/warewulfd/util.go
@@ -4,6 +4,9 @@ import (
 	"net/http"
 	"os"
 
+	nodepkg "github.com/hpcng/warewulf/internal/pkg/node"
+	"github.com/hpcng/warewulf/internal/pkg/overlay"
+	"github.com/hpcng/warewulf/internal/pkg/util"
 	"github.com/hpcng/warewulf/internal/pkg/wwlog"
 )
 
@@ -36,4 +39,44 @@ func sendFile(
 	wwlog.Send("%15s: %s", sendto, filename)
 
 	return nil
+}
+
+func getOverlayFile(
+	nodeId string,
+	stage_overlays []string,
+	autobuild bool ) (stage_file string, err error) {
+
+	stage_file = overlay.OverlayImage(nodeId, stage_overlays)
+	err = nil
+
+	build := !util.IsFile(stage_file)
+
+	if !build && autobuild {
+		build = util.PathIsNewer(stage_file, nodepkg.ConfigFile)
+
+		for _, overlayname := range stage_overlays {
+			build = build || util.PathIsNewer(stage_file, overlay.OverlaySourceDir(overlayname))
+		}
+	}
+
+	if build {
+		wwlog.Serv("BUILD %15s, overlays %v", nodeId, stage_overlays)
+
+		args := []string{"overlay", "build"}
+
+		for _, overlayname := range stage_overlays {
+			args = append(args, "-O", overlayname)
+		}
+
+		args = append(args, nodeId)
+
+		out, err := util.RunWWCTL(args...)
+
+		if err != nil {
+			wwlog.Error("Failed to build overlay: %s, %s, %s\n%s",
+				nodeId, stage_overlays, stage_file, string(out))
+		}
+	}
+
+	return
 }


### PR DESCRIPTION
Fixes

* Thread safety of configuring discoverable nodes and overlay builds
* Update to `wwctl overlay build` command in handling of lists of overlay names.