### PR TITLE
add openSUSE release build(not out-of-box now)

### DIFF
--- a/.github/workflows/releasebuild.yml
+++ b/.github/workflows/releasebuild.yml
@@ -87,6 +87,12 @@ jobs:
             name: warewulf-${{ env.VERSION }}-${{ env.RELEASE }}.el7.x86_64.rpm
             path: warewulf-${{ env.VERSION }}-${{ env.RELEASE }}.el7.x86_64.rpm
 
+        - name: Upload openSUSE Leap 15.3 RPM
+          uses: actions/upload-artifact@v2
+          with:
+            name: warewulf-${{ env.VERSION }}-${{ env.RELEASE }}.suse.lp153.x86_64.rpm
+            path: warewulf-${{ env.VERSION }}-${{ env.RELEASE }}.suse.lp153.x86_64.rpm
+            
         - name: Upload Assets To Release
           uses: xresloader/upload-to-github-release@master
           env:

--- a/ci/mockbuild.sh
+++ b/ci/mockbuild.sh
@@ -15,3 +15,6 @@ mv /var/lib/mock/rocky+epel-8-x86_64/result/warewulf-${VERSION}-${RELEASE}.el8.x
 
 mock -r centos+epel-7-x86_64 --rebuild --spec=warewulf-${VERSION}/warewulf.spec --sources=.
 mv /var/lib/mock/centos+epel-7-x86_64/result/warewulf-${VERSION}-${RELEASE}.el7.x86_64.rpm .
+
+mock -r opensuse-leap-15.3-x86_64 --rebuild --spec=warewulf-${VERSION}/warewulf.spec --sources=.
+mv /var/lib/mock/opensuse-leap-15.3-x86_64/result/warewulf-${VERSION}-${RELEASE}.suse.lp153.x86_64.rpm .


### PR DESCRIPTION
Current openSUSE build is not out of box!!
Due to dhcpd.conf for openSUSE is in \etc.
In RHEL case is \etc\dhcp\.
Whether I can unpack warewulf-${VERSION}.tar after EL mock build move the file into the right place and repack before openSUSE mock build?
