### PR TITLE
can disable tftp services with warewulf.conf

### DIFF
--- a/internal/pkg/configure/tftp.go
+++ b/internal/pkg/configure/tftp.go
@@ -35,6 +35,11 @@ func TFTP() error {
 		}
 	}
 
+	if !controller.Tftp.Enabled {
+		wwlog.Printf(wwlog.INFO, "Warewulf does not auto start TFTP services due to disable by warewulf.conf\n")
+		os.Exit(0)
+	}
+	
 	fmt.Printf("Enabling and restarting the TFTP services\n")
 	err = util.SystemdStart(controller.Tftp.SystemdName)
 	if err != nil {


### PR DESCRIPTION
fix issue #319 
We meet three situations in tftp enable config.

1. do nothing(don't mkdir and copy files).
2. prepare dir and copy files to tftproot path.
3. do step 2 and more with start service, enable service

boolean cannot handle theses.

In this fix 'enable' only decide whether we start service.
