### PR TITLE
Fix-openSUSE-dhcpd

### DIFF
--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -417,12 +417,23 @@ func BuildOverlayIndir(nodeInfo node.NodeInfo, overlayNames []string, outputDir 
 				if err != nil {
 					wwlog.ErrorExc(err, "")
 				}
+				if util.IsFile(path.Join(outputDir, location)) {
+					if !util.IsFile(path.Join(outputDir, location+".wwbackup")) {
+						wwlog.Debug("Target exists, creating backup file")
+						err = os.Rename(path.Join(outputDir, location), path.Join(outputDir, location+"wwbackup"))
+					} else {
+						wwlog.Debug("%s exists, keeping the backup file", path.Join(outputDir, location+".wwbackup"))
+						err = os.Remove(path.Join(outputDir, location))
+					}
+					if err != nil {
+						wwlog.ErrorExc(err, "")
+					}
+				}
 				err = os.Symlink(destination, path.Join(outputDir, location))
 				if err != nil {
 					wwlog.ErrorExc(err, "")
 				}
 			} else {
-
 				err := util.CopyFile(location, path.Join(outputDir, location))
 				if err == nil {
 					wwlog.Debug("Copied file into overlay: %s", location)

--- a/overlays/host/etc/dhcpd.conf
+++ b/overlays/host/etc/dhcpd.conf
@@ -1,0 +1,1 @@
+dhcp/dhcpd.conf


### PR DESCRIPTION
openSUSE like distro use '/etc/dhdp.conf` instead of `/etc/.dhcp/dhcpd.conf`.
To have a unviersal config a soft link is used now, and also handling of softlinks got updated in this PR.
Fixes #439