### PR TITLE
add type to network configs

### DIFF
--- a/overlays/wwinit/etc/sysconfig/network-scripts/ifcfg.ww
+++ b/overlays/wwinit/etc/sysconfig/network-scripts/ifcfg.ww
@@ -20,6 +20,9 @@ GATEWAY={{ $netdev.Gateway }}
 {{ if $netdev.Hwaddr -}}
 HWADDR={{ $netdev.Hwaddr }}
 {{ end -}}
+{{ if $netdev.Type -}}
+TYPE={{ $netdev.Type }}
+{{ end -}}
 ONBOOT=yes
 IPV6INIT=yes
 IPV6_AUTOCONF=yes

--- a/overlays/wwinit/etc/wicked/ifconfig/ifcfg.xml.ww
+++ b/overlays/wwinit/etc/wicked/ifconfig/ifcfg.xml.ww
@@ -12,6 +12,9 @@ Source: {{ $source }}
 -->
 <interface origin="static generated warewulf config">
   <name>{{$netdev.Device}}</name>
+  {{ if $netdev.Type -}}
+  <link-type>{{ $netdev.Type }}</link-type>
+  {{ end -}}
   <control>
     <mode>boot</mode>
   </control>


### PR DESCRIPTION
The type of a network was not evaluated in the network config templates.

Close #457