### PR TITLE
Capture wwapi binaries in rpm spec

### DIFF
--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -119,6 +119,7 @@ getent group %{wwgroup} >/dev/null || groupadd -r %{wwgroup}
 %{srvdir}/warewulf
 
 %attr(-, root, root) %{_bindir}/wwctl
+%attr(-, root, root) %{_bindir}/wwapi*
 %attr(-, root, root) %{_prefix}/lib/firewalld/services/warewulf.xml
 %attr(-, root, root) %{_unitdir}/warewulfd.service
 %attr(-, root, root) %{_mandir}/man1/wwctl*


### PR DESCRIPTION
Naive implementation; but without some declaration rpmbuild fails.

Signed-off-by: Jonathon Anderson <janderson@ciq.co>