### PR TITLE
Trim whitespace from IPMI output

### DIFF
--- a/internal/pkg/power/ipmitool.go
+++ b/internal/pkg/power/ipmitool.go
@@ -3,6 +3,7 @@ package power
 import (
 	"os"
 	"os/exec"
+	"strings"
 )
 
 type IPMIResult struct {
@@ -66,7 +67,7 @@ func (ipmi *IPMI) IPMIInteractiveCommand(args ...string) error {
 
 func (ipmi *IPMI) IPMICommand(args ...string) (string, error) {
 	ipmiOut, err := ipmi.Command(args)
-	ipmi.result.out = string(ipmiOut)
+	ipmi.result.out = strings.TrimSpace(string(ipmiOut))
 	ipmi.result.err = err
 	return ipmi.result.out, ipmi.result.err
 


### PR DESCRIPTION
Historically, warewulf IPMI commands output extraneous newlines, producing output like this:

```
$ sudo wwctl power status c[1-4].dell-ciq.lan
c2.dell-ciq.lan: Chassis Power is on

c4.dell-ciq.lan: Chassis Power is on

c3.dell-ciq.lan: Chassis Power is on

c1.dell-ciq.lan: Chassis Power is on

```

This change trims extraneous whitespace, leading to output like this:

```
$ sudo wwctl power status c[1-4].dell-ciq.lan
c2.dell-ciq.lan: Chassis Power is on
c4.dell-ciq.lan: Chassis Power is on
c3.dell-ciq.lan: Chassis Power is on
c1.dell-ciq.lan: Chassis Power is on
```

This makes the output more like the output from `wwctl ssh` and other similar tools, improves readability, and better supports use with `dshbak`.

Signed-off-by: Jonathon Anderson <janderson@ciq.co>