### PR TITLE
Install kernel-modules in warewulf rocky-8 image

### DIFF
--- a/containers/Docker/rocky-8
+++ b/containers/Docker/rocky-8
@@ -11,6 +11,7 @@ RUN dnf update -y ;\
     ipmitool \
     iproute \
     kernel-core \
+    kernel-modules \
     net-tools \
     network-scripts \
     nfs-utils \


### PR DESCRIPTION
Without the kernel-modules package installed I was not able to use apptainer, as squashfs was not available.

Porting this in from https://github.com/anderbubble/warewulf/pull/2, where I had accidentally created it before.