### PR TITLE
Fix handling of uid and gid arguments during chown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to be changed accordingly
 - host overlays can globaly disbaled, but are enabled per default
 - `wwctl overlay build -H` will only build the overlays which are assigned to the nodes
-### Fixes
+### Fixed
 - GID is no longer changed to `0` when unspecified during chown
+- Proper handling of uid/gid arguments during `wwctl overlay chown`
 
 
 ## [4.1.0] - 2021-07-29

--- a/internal/app/wwctl/overlay/chown/main.go
+++ b/internal/app/wwctl/overlay/chown/main.go
@@ -21,16 +21,16 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	overlayName := args[0]
 	fileName := args[1]
 
-	uid, err = strconv.Atoi(args[3])
+	uid, err = strconv.Atoi(args[2])
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "UID is not an integer: %s\n", args[3])
+		wwlog.Printf(wwlog.ERROR, "UID is not an integer: %s\n", args[2])
 		os.Exit(1)
 	}
 
-	if len(args) > 4 {
-		gid, err = strconv.Atoi(args[4])
+	if len(args) > 3 {
+		gid, err = strconv.Atoi(args[3])
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "GID is not an integer: %s\n", args[4])
+			wwlog.Printf(wwlog.ERROR, "GID is not an integer: %s\n", args[3])
 			os.Exit(1)
 		}
 	} else {


### PR DESCRIPTION
It appears that the intended behavior of overlay chown was changed in 00d8d42e9, but the argument handling was not updated to reflect the removal of overlayKind. This led to a crash when only the uid was specified, and a processing of the gid as the uid otherwise.

Fixes #486 

Signed-off-by: Jonathon Anderson <janderson@ciq.co>