### PR TITLE
Don't change unspecified gid to 0 during chown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to be changed accordingly
 - host overlays can globaly disbaled, but are enabled per default
 - `wwctl overlay build -H` will only build the overlays which are assigned to the nodes
+### Fixes
+- GID is no longer changed to `0` when unspecified during chown
 
 
 ## [4.1.0] - 2021-07-29

--- a/internal/app/wwctl/overlay/chown/main.go
+++ b/internal/app/wwctl/overlay/chown/main.go
@@ -34,7 +34,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 			os.Exit(1)
 		}
 	} else {
-		gid = 0
+		gid = -1
 	}
 
 	overlaySourceDir = overlay.OverlaySourceDir(overlayName)


### PR DESCRIPTION
Specifying 0 for gid as a default during chown causes the gid to be changed to 0 when left unspecified. Changing the default value to -1 causes the gid to be left unmodified when unspecified, which is a less surprising behavior.

Signed-off-by: Jonathon Anderson <janderson@ciq.co>