### PR TITLE
Fix of container build include/exclude handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - GID is no longer changed to `0` when unspecified during chown
 - Proper handling of uid/gid arguments during `wwctl overlay chown`
+- /etc/warewulf/excludes stored in the container definition is now
+  processed correctly, also excluding the contents of an excluded
+  directory automatically.
 
 
 ## [4.1.0] - 2021-07-29

--- a/internal/pkg/container/build.go
+++ b/internal/pkg/container/build.go
@@ -2,7 +2,6 @@ package container
 
 import (
 	"path"
-	"strings"
 
 	"github.com/pkg/errors"
 
@@ -27,19 +26,13 @@ func Build(name string, buildForce bool) error {
 		}
 	}
 
-	excludes_file := path.Join(rootfsPath, "./etc/warewulf/excludes")
 	ignore := []string{}
-
+	excludes_file := path.Join(rootfsPath, "./etc/warewulf/excludes")
 	if util.IsFile(excludes_file) {
-		ignore, err := util.ReadFile(excludes_file)
+		var err error
+		ignore, err = util.ReadFile(excludes_file)
 		if err != nil {
 			return errors.Wrapf(err, "Failed creating directory: %s", imagePath)
-		}
-
-		for i, pattern := range ignore {
-			if ( strings.HasPrefix(pattern, "/") ) {
-				ignore[i] = pattern[1:]
-			}
 		}
 	}
 

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -260,34 +260,16 @@ func FindFilterFiles(
 	defer func() {
 		err = FirstError(err, os.Chdir(cwd))
 	}()
-
 	err = os.Chdir(path)
 	if err != nil {
 		return ofiles, errors.Wrapf(err, "Failed to change path: %s", path)
 	}
 
-	files := []string{}
-
-	for _, pattern := range include {
-
-		_files, err := filepath.Glob(pattern)
-		if err != nil {
-			return ofiles, errors.Wrapf(err, "Failed to apply pattern: %s", pattern)
-		}
-		wwlog.Debug("Including pattern: %s -> %d matches", pattern, len(_files))
-
-		files = append(files, _files...)
-	}
-
-
-	for i, pattern := range(ignore) {
-		ignore[i] = strings.TrimLeft(pattern, "/")
-		if strings.HasPrefix(pattern, "./") {
-			ignore[i] = strings.TrimPrefix(pattern, "./")
-		}
+	for i := range(ignore) {
+		ignore[i] = strings.TrimLeft(ignore[i], "/")
+		ignore[i] = strings.TrimPrefix(ignore[i], "./")
 		wwlog.Debug("Ignore pattern (%d): %s", i, ignore[i])
 	}
-
 
 	if ignore_xdev {
 		wwlog.Debug("Ignoring cross-device (xdev) files")
@@ -300,76 +282,72 @@ func FindFilterFiles(
 
 	dev := path_stat.Sys().(*syscall.Stat_t).Dev
 
-	for _, ifile := range files {
-		stat, err := os.Stat(ifile)
+
+	includeDirs := []string{}
+	ignoreDirs := []string{}
+	err = filepath.Walk(".", func(location string, info os.FileInfo, err error) error {
 		if err != nil {
-			return ofiles, err
+			return err
 		}
 
-		if stat.IsDir() {
-			// recursivly include from the matched directory
+		if location == "." {
+			return nil
+		}
 
-			num_init := len(ofiles)
-			ignoreDirs := []string{}
-			err = filepath.Walk(ifile, func(location string, info os.FileInfo, err error) error {
-				var file string
-
-				if err != nil {
-					return err
-				}
-
-				if location == "." {
-					return nil
-				}
-
-				if info.IsDir() {
-					file = location + "/"
-				} else {
-					file = location
-				}
-
-				if ignore_xdev && info.Sys().(*syscall.Stat_t).Dev != dev {
-					wwlog.Debug("Ignored (cross-device): %s", file)
-					return nil
-				}
-
-				for _, ignoreDir := range(ignoreDirs) {
-					if strings.HasPrefix(location, ignoreDir) {
-						wwlog.Debug("Ignored (dir): %s", location)
-						return nil
-					}
-				}
-				for i, pattern := range(ignore) {
-					m, err := filepath.Match(pattern, location)
-					if err != nil {
-						return err
-					}
-
-					if m {
-						wwlog.Debug("Ignored (%d): %s", i, file)
-						if info.IsDir() {
-							ignoreDirs = append(ignoreDirs, file)
-						}
-						return nil
-					}
-				}
-
-				ofiles = append(ofiles, file)
-
-				return nil
-			})
-
-			num_final := len(ofiles)
-			wwlog.Debug("Included: %s -> %d files", ifile, num_final-num_init)
-
-			if err != nil {
-				return ofiles, err
-			}
+		var file string
+		if info.IsDir() {
+			file = location + "/"
 		} else {
-			wwlog.Debug("Included: %s", ifile)
-			ofiles = append(ofiles, ifile)
+			file = location
 		}
-	}
+
+		if ignore_xdev && info.Sys().(*syscall.Stat_t).Dev != dev {
+			wwlog.Debug("Ignored (cross-device): %s", file)
+			return nil
+		}
+
+		for _, ignoreDir := range(ignoreDirs) {
+			if strings.HasPrefix(location, ignoreDir) {
+				wwlog.Debug("Ignored (dir): %s", file)
+				return nil
+			}
+		}
+		for i, pattern := range(ignore) {
+			m, err := filepath.Match(pattern, location)
+			if err != nil {
+				return err
+			} else if m {
+				wwlog.Debug("Ignored (%d): %s", i, file)
+				if info.IsDir() {
+					ignoreDirs = append(ignoreDirs, file)
+				}
+				return nil
+			}
+		}
+
+		for _, includeDir := range(includeDirs) {
+			if strings.HasPrefix(location, includeDir) {
+				wwlog.Debug("Included (dir): %s", file)
+				ofiles = append(ofiles, location)
+				return nil
+			}
+		}
+		for i, pattern := range(include) {
+			m, err := filepath.Match(pattern, location)
+			if err != nil {
+				return err
+			} else if m {
+				wwlog.Debug("Included (%d): %s", i, file)
+				ofiles = append(ofiles, location)
+				if info.IsDir() {
+					includeDirs = append(includeDirs, file)
+				}
+				return nil
+			}
+		}
+
+		return nil
+	})
 
 	return ofiles, err
 }


### PR DESCRIPTION
This PR fixes the handling of the `/etc/warewulf/excludes` file read from the container definition, and further excludes files that reside in an excluded directory. (This functionality is otherwise missing due to deficiencies in `filepath.Match`. See https://github.com/golang/go/issues/11862)

This PR also largely rewrites `FindFilterFiles` in an attempt to prevent such errors in the future.

This is a rather significant rewrite of an integral function, and likely merits close review by senior developers / maintainers. However, it also includes a fix for a significant functional regression, so I suggest that it also merits priority.

Fixes #532 