### PR TITLE
Replace all instances of wwlog.Printf

### DIFF
--- a/internal/app/wwclient/root.go
+++ b/internal/app/wwclient/root.go
@@ -58,7 +58,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	pid, err := pidfile.Write(PIDFile)
 	if err != nil && pid == -1 {
-		wwlog.Printf(wwlog.WARN, "%v. starting new wwclient", err)
+		wwlog.Warn("%v. starting new wwclient", err)
 	} else if err != nil && pid > 0 {
 		return errors.New("found pidfile " + PIDFile + " not starting")
 	}
@@ -66,7 +66,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	if os.Args[0] == path.Join(buildconfig.WWCLIENTDIR(), "wwclient") {
 		err := os.Chdir("/")
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "failed to change dir: %s", err)
+			wwlog.Error("failed to change dir: %s", err)
 			_ = os.Remove(PIDFile)
 			os.Exit(1)
 		}
@@ -78,14 +78,14 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		fmt.Printf("For full functionality call with: %s\n", path.Join(buildconfig.WWCLIENTDIR(), "wwclient"))
 		err := os.MkdirAll("/warewulf/wwclient-test", 0755)
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "failed to create dir: %s", err)
+			wwlog.Error("failed to create dir: %s", err)
 			_ = os.Remove(PIDFile)
 			os.Exit(1)
 		}
 
 		err = os.Chdir("/warewulf/wwclient-test")
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "failed to change dir: %s", err)
+			wwlog.Error("failed to change dir: %s", err)
 			_ = os.Remove(PIDFile)
 			os.Exit(1)
 		}
@@ -95,7 +95,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	if conf.Warewulf.Secure {
 		// Setup local port to something privileged (<1024)
 		localTCPAddr.Port = 987
-		wwlog.Printf(wwlog.INFO, "Running from trusted port\n")
+		wwlog.Info("Running from trusted port\n")
 	}
 
 	Webclient = &http.Client{
@@ -114,7 +114,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	}
 	smbiosDump, err := smbios.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not get SMBIOS info: %s\n", err)
+		wwlog.Error("Could not get SMBIOS info: %s\n", err)
 		os.Exit(1)
 	}
 	sysinfoDump := smbiosDump.SystemInformation()
@@ -124,13 +124,13 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	cmdline, err := ioutil.ReadFile("/proc/cmdline")
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not read from /proc/cmdline: %s\n", err)
+		wwlog.Error("Could not read from /proc/cmdline: %s\n", err)
 		os.Exit(1)
 	}
 
 	wwid_tmp := strings.Split(string(cmdline), "wwid=")
 	if len(wwid_tmp) < 2 {
-		wwlog.Printf(wwlog.ERROR, "'wwid' is not defined in /proc/cmdline\n")
+		wwlog.Error("'wwid' is not defined in /proc/cmdline\n")
 		os.Exit(1)
 	}
 
@@ -153,7 +153,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 				stopTimer.Stop()
 				stopTimer.Reset(0)
 			case syscall.SIGTERM, syscall.SIGINT:
-				wwlog.Printf(wwlog.INFO, "termination wwclient!, %v", sig)
+				wwlog.Info("termination wwclient!, %v", sig)
 				cleanUp()
 				os.Exit(0)
 			}
@@ -179,7 +179,7 @@ func updateSystem(ipaddr string, port int, wwid string, tag string, localUUID uu
 	for {
 		var err error
 		getString := fmt.Sprintf("http://%s:%d/provision/%s?assetkey=%s&uuid=%s&stage=runtime&compress=gz", ipaddr, port, wwid, tag, localUUID)
-		wwlog.Printf(wwlog.DEBUG, "Making request: %s\n", getString)
+		wwlog.Debug("Making request: %s\n", getString)
 		resp, err = Webclient.Get(getString)
 		if err == nil {
 			break
@@ -211,6 +211,6 @@ func updateSystem(ipaddr string, port int, wwid string, tag string, localUUID uu
 func cleanUp() {
 	err := pidfile.Remove(PIDFile)
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "could not remove pidfile: %s\n", err)
+		wwlog.Error("could not remove pidfile: %s\n", err)
 	}
 }

--- a/internal/app/wwctl/configure/main.go
+++ b/internal/app/wwctl/configure/main.go
@@ -13,25 +13,25 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	if allFunctions {
 		err = configure.Dhcp()
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "%s\n", err)
+			wwlog.Error("%s\n", err)
 			os.Exit(1)
 		}
 
 		err = configure.NFS()
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "%s\n", err)
+			wwlog.Error("%s\n", err)
 			os.Exit(1)
 		}
 
 		err = configure.SSH()
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "%s\n", err)
+			wwlog.Error("%s\n", err)
 			os.Exit(1)
 		}
 
 		err = configure.TFTP()
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "%s\n", err)
+			wwlog.Error("%s\n", err)
 			os.Exit(1)
 		}
 	} else {

--- a/internal/app/wwctl/container/exec/child/main.go
+++ b/internal/app/wwctl/container/exec/child/main.go
@@ -19,14 +19,14 @@ import (
 
 func CobraRunE(cmd *cobra.Command, args []string) error {
 	if os.Getpid() != 1 {
-		wwlog.Printf(wwlog.ERROR, "PID is not 1: %d\n", os.Getpid())
+		wwlog.Error("PID is not 1: %d\n", os.Getpid())
 		os.Exit(1)
 	}
 
 	containerName := args[0]
 
 	if !container.ValidSource(containerName) {
-		wwlog.Printf(wwlog.ERROR, "Unknown Warewulf container: %s\n", containerName)
+		wwlog.Error("Unknown Warewulf container: %s\n", containerName)
 		os.Exit(1)
 	}
 	containerPath := container.RootFsDir(containerName)
@@ -36,8 +36,8 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	fileStat, _ = os.Stat(path.Join(containerPath, "/etc/group"))
 	unixStat = fileStat.Sys().(*syscall.Stat_t)
 	groupTime := time.Unix(int64(unixStat.Ctim.Sec), int64(unixStat.Ctim.Nsec))
-	wwlog.Printf(wwlog.DEBUG, "passwd: %v\n", passwdTime)
-	wwlog.Printf(wwlog.DEBUG, "group: %v\n", groupTime)
+	wwlog.Debug("passwd: %v\n", passwdTime)
+	wwlog.Debug("group: %v\n", groupTime)
 
 	err := syscall.Mount("", "/", "", syscall.MS_PRIVATE|syscall.MS_REC, "")
 	if err != nil {
@@ -90,21 +90,21 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	err = syscall.Exec(args[1], args[1:], os.Environ())
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "%s\n", err)
+		wwlog.Error("%s\n", err)
 		os.Exit(1)
 	}
 	fileStat, _ = os.Stat(path.Join(containerPath, "/etc/passwd"))
 	unixStat = fileStat.Sys().(*syscall.Stat_t)
 	if passwdTime.Before(time.Unix(int64(unixStat.Ctim.Sec), int64(unixStat.Ctim.Nsec))) {
-		wwlog.Printf(wwlog.WARN, "/etc/passwd has been modified, maybe you want to run syncuser")
+		wwlog.Warn("/etc/passwd has been modified, maybe you want to run syncuser")
 	}
-	wwlog.Printf(wwlog.DEBUG, "passwd: %v\n", time.Unix(int64(unixStat.Ctim.Sec), int64(unixStat.Ctim.Nsec)))
+	wwlog.Debug("passwd: %v\n", time.Unix(int64(unixStat.Ctim.Sec), int64(unixStat.Ctim.Nsec)))
 	fileStat, _ = os.Stat(path.Join(containerPath, "/etc/group"))
 	unixStat = fileStat.Sys().(*syscall.Stat_t)
 	if groupTime.Before(time.Unix(int64(unixStat.Ctim.Sec), int64(unixStat.Ctim.Nsec))) {
-		wwlog.Printf(wwlog.WARN, "/etc/group has been modified, maybe you want to run syncuser")
+		wwlog.Warn("/etc/group has been modified, maybe you want to run syncuser")
 	}
-	wwlog.Printf(wwlog.DEBUG, "group: %v\n", time.Unix(int64(unixStat.Ctim.Sec), int64(unixStat.Ctim.Nsec)))
+	wwlog.Debug("group: %v\n", time.Unix(int64(unixStat.Ctim.Sec), int64(unixStat.Ctim.Nsec)))
 
 	return nil
 }

--- a/internal/app/wwctl/container/exec/child/non-Linux.go
+++ b/internal/app/wwctl/container/exec/child/non-Linux.go
@@ -9,7 +9,7 @@ import (
 )
 
 func CobraRunE(cmd *cobra.Command, args []string) error {
-	wwlog.Printf(wwlog.ERROR, "This command does not work on non-Linux hosts\n")
+	wwlog.Error("This command does not work on non-Linux hosts\n")
 
 	return nil
 }

--- a/internal/app/wwctl/container/exec/main.go
+++ b/internal/app/wwctl/container/exec/main.go
@@ -18,7 +18,7 @@ import (
 )
 
 func runContainedCmd(args []string) error {
-	wwlog.Printf(wwlog.VERBOSE, "Running contained command: %s\n", args[1:])
+	wwlog.Verbose("Running contained command: %s\n", args[1:])
 	c := exec.Command("/proc/self/exe", append([]string{"container", "exec", "__child"}, args...)...)
 
 	c.SysProcAttr = &syscall.SysProcAttr{
@@ -41,7 +41,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	var allargs []string
 
 	if !container.ValidSource(containerName) {
-		wwlog.Printf(wwlog.ERROR, "Unknown Warewulf container: %s\n", containerName)
+		wwlog.Error("Unknown Warewulf container: %s\n", containerName)
 		os.Exit(1)
 	}
 
@@ -57,20 +57,20 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	fileStat, _ = os.Stat(path.Join(containerPath, "/etc/group"))
 	unixStat = fileStat.Sys().(*syscall.Stat_t)
 	groupTime := time.Unix(int64(unixStat.Ctim.Sec), int64(unixStat.Ctim.Nsec))
-	wwlog.Printf(wwlog.DEBUG, "passwd: %v\n", passwdTime)
-	wwlog.Printf(wwlog.DEBUG, "group: %v\n", groupTime)
+	wwlog.Debug("passwd: %v\n", passwdTime)
+	wwlog.Debug("group: %v\n", groupTime)
 
 	err := runContainedCmd(allargs)
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Failed executing container command: %s\n", err)
+		wwlog.Error("Failed executing container command: %s\n", err)
 		os.Exit(1)
 	}
 
 	if util.IsFile(path.Join(container.RootFsDir(allargs[0]), "/etc/warewulf/container_exit.sh")) {
-		wwlog.Printf(wwlog.VERBOSE, "Found clean script: /etc/warewulf/container_exit.sh\n")
+		wwlog.Verbose("Found clean script: /etc/warewulf/container_exit.sh\n")
 		err = runContainedCmd([]string{allargs[0], "/bin/sh", "/etc/warewulf/container_exit.sh"})
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "Failed executing exit script: %s\n", err)
+			wwlog.Error("Failed executing exit script: %s\n", err)
 			os.Exit(1)
 		}
 	}
@@ -79,31 +79,31 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	syncuids := false
 	if passwdTime.Before(time.Unix(int64(unixStat.Ctim.Sec), int64(unixStat.Ctim.Nsec))) {
 		if !SyncUser {
-			wwlog.Printf(wwlog.WARN, "/etc/passwd has been modified, maybe you want to run syncuser\n")
+			wwlog.Warn("/etc/passwd has been modified, maybe you want to run syncuser\n")
 		}
 		syncuids = true
 	}
-	wwlog.Printf(wwlog.DEBUG, "passwd: %v\n", time.Unix(int64(unixStat.Ctim.Sec), int64(unixStat.Ctim.Nsec)))
+	wwlog.Debug("passwd: %v\n", time.Unix(int64(unixStat.Ctim.Sec), int64(unixStat.Ctim.Nsec)))
 	fileStat, _ = os.Stat(path.Join(containerPath, "/etc/group"))
 	unixStat = fileStat.Sys().(*syscall.Stat_t)
 	if groupTime.Before(time.Unix(int64(unixStat.Ctim.Sec), int64(unixStat.Ctim.Nsec))) {
 		if !SyncUser {
-			wwlog.Printf(wwlog.WARN, "/etc/group has been modified, maybe you want to run syncuser\n")
+			wwlog.Warn("/etc/group has been modified, maybe you want to run syncuser\n")
 		}
 		syncuids = true
 	}
-	wwlog.Printf(wwlog.DEBUG, "group: %v\n", time.Unix(int64(unixStat.Ctim.Sec), int64(unixStat.Ctim.Nsec)))
+	wwlog.Debug("group: %v\n", time.Unix(int64(unixStat.Ctim.Sec), int64(unixStat.Ctim.Nsec)))
 	if syncuids && SyncUser {
 		err = container.SyncUids(containerName, true)
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "Error in user sync, fix error and run 'syncuser' manually, but trying to build container: %s\n", err)
+			wwlog.Error("Error in user sync, fix error and run 'syncuser' manually, but trying to build container: %s\n", err)
 		}
 	}
 
 	fmt.Printf("Rebuilding container...\n")
 	err = container.Build(containerName, false)
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not build container %s: %s\n", containerName, err)
+		wwlog.Error("Could not build container %s: %s\n", containerName, err)
 		os.Exit(1)
 	}
 

--- a/internal/app/wwctl/container/exec/non-linux.go
+++ b/internal/app/wwctl/container/exec/non-linux.go
@@ -9,7 +9,7 @@ import (
 )
 
 func CobraRunE(cmd *cobra.Command, args []string) error {
-	wwlog.Printf(wwlog.ERROR, "This command does not work on non-Linux hosts\n")
+	wwlog.Error("This command does not work on non-Linux hosts\n")
 
 	return nil
 }

--- a/internal/app/wwctl/container/list/main.go
+++ b/internal/app/wwctl/container/list/main.go
@@ -12,7 +12,7 @@ func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 
 	containerInfo, err := container.ContainerList()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "%s\n", err)
+		wwlog.Error("%s\n", err)
 		return
 	}
 

--- a/internal/app/wwctl/container/shell/main.go
+++ b/internal/app/wwctl/container/shell/main.go
@@ -20,7 +20,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	var allargs []string
 
 	if !container.ValidSource(containerName) {
-		wwlog.Printf(wwlog.ERROR, "Unknown Warewulf container: %s\n", containerName)
+		wwlog.Error("Unknown Warewulf container: %s\n", containerName)
 		os.Exit(1)
 	}
 

--- a/internal/app/wwctl/container/syncuser/main.go
+++ b/internal/app/wwctl/container/syncuser/main.go
@@ -16,7 +16,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	}
 	err := container.SyncUids(containerName, !write)
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Error in synchronize: %s\n", err)
+		wwlog.Error("Error in synchronize: %s\n", err)
 		os.Exit(1)
 	}
 

--- a/internal/app/wwctl/kernel/delete/main.go
+++ b/internal/app/wwctl/kernel/delete/main.go
@@ -14,7 +14,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not open nodeDB: %s\n", err)
+		wwlog.Error("Could not open nodeDB: %s\n", err)
 		os.Exit(1)
 	}
 
@@ -24,14 +24,14 @@ ARG_LOOP:
 	for _, arg := range args {
 		for _, n := range nodes {
 			if n.Kernel.Override.Get() == arg {
-				wwlog.Printf(wwlog.ERROR, "Kernel is configured for nodes, skipping: %s\n", arg)
+				wwlog.Error("Kernel is configured for nodes, skipping: %s\n", arg)
 				continue ARG_LOOP
 			}
 		}
 
 		err := kernel.DeleteKernel(arg)
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "Could not delete kernel: %s\n", arg)
+			wwlog.Error("Could not delete kernel: %s\n", arg)
 		} else {
 			fmt.Printf("Kernel has been deleted: %s\n", arg)
 		}

--- a/internal/app/wwctl/kernel/imprt/main.go
+++ b/internal/app/wwctl/kernel/imprt/main.go
@@ -15,11 +15,11 @@ import (
 
 func CobraRunE(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 && !OptDetect {
-		wwlog.Printf(wwlog.ERROR, "the '--detect' flag is needed, if no kernel version is suppiled")
+		wwlog.Error("the '--detect' flag is needed, if no kernel version is suppiled")
 		os.Exit(1)
 	}
 	if OptDetect && (OptRoot == "" || OptContainer == "") {
-		wwlog.Printf(wwlog.ERROR, "the '--detect flag needs the '--container' or '--root' flag")
+		wwlog.Error("the '--detect flag needs the '--container' or '--root' flag")
 		os.Exit(1)
 	}
 	// Checking if container flag was set, then overwriting OptRoot
@@ -27,7 +27,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		if container.ValidSource(OptContainer) {
 			OptRoot = container.RootFsDir(OptContainer)
 		} else {
-			wwlog.Printf(wwlog.ERROR, " %s is not a valid container", OptContainer)
+			wwlog.Error(" %s is not a valid container", OptContainer)
 			os.Exit(1)
 		}
 	}
@@ -39,7 +39,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	} else {
 		kernelVersion, err = kernel.FindKernelVersion(OptRoot)
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "could not detect kernel under %s\n", OptRoot)
+			wwlog.Error("could not detect kernel under %s\n", OptRoot)
 			os.Exit(1)
 		}
 	}
@@ -51,7 +51,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	}
 	output, err := kernel.Build(kernelVersion, kernelName, OptRoot)
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Failed building kernel: %s\n", err)
+		wwlog.Error("Failed building kernel: %s\n", err)
 		os.Exit(1)
 	} else {
 		fmt.Printf("%s: %s\n", kernelName, output)
@@ -61,15 +61,15 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 		nodeDB, err := node.New()
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "Could not open node configuration: %s\n", err)
+			wwlog.Error("Could not open node configuration: %s\n", err)
 			os.Exit(1)
 		}
 		//TODO: Don't loop through profiles, instead have a nodeDB function that goes directly to the map
 		profiles, _ := nodeDB.FindAllProfiles()
 		for _, profile := range profiles {
-			wwlog.Printf(wwlog.DEBUG, "Looking for profile default: %s\n", profile.Id.Get())
+			wwlog.Debug("Looking for profile default: %s\n", profile.Id.Get())
 			if profile.Id.Get() == "default" {
-				wwlog.Printf(wwlog.DEBUG, "Found profile default, setting kernel version to: %s\n", args[0])
+				wwlog.Debug("Found profile default, setting kernel version to: %s\n", args[0])
 				profile.Kernel.Override.Set(args[0])
 				err := nodeDB.ProfileUpdate(profile)
 				if err != nil {

--- a/internal/app/wwctl/kernel/list/main.go
+++ b/internal/app/wwctl/kernel/list/main.go
@@ -14,7 +14,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	kernels, err := kernel.ListKernels()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "%s\n", err)
+		wwlog.Error("%s\n", err)
 		os.Exit(1)
 	}
 

--- a/internal/app/wwctl/node/console/power.go
+++ b/internal/app/wwctl/node/console/power.go
@@ -16,13 +16,13 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not open node configuration: %s\n", err)
+		wwlog.Error("Could not open node configuration: %s\n", err)
 		os.Exit(1)
 	}
 
 	nodes, err := nodeDB.FindAllNodes()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not get node list: %s\n", err)
+		wwlog.Error("Could not get node list: %s\n", err)
 		os.Exit(1)
 	}
 
@@ -44,7 +44,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	for _, node := range nodes {
 
 		if node.Ipmi.Ipaddr.Get() == "" {
-			wwlog.Printf(wwlog.ERROR, "%s: No IPMI IP address\n", node.Id.Get())
+			wwlog.Error("%s: No IPMI IP address\n", node.Id.Get())
 			continue
 		}
 
@@ -61,7 +61,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		err := ipmiCmd.Console()
 
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "%s: Console problem\n", node.Id.Get())
+			wwlog.Error("%s: Console problem\n", node.Id.Get())
 			returnErr = err
 			continue
 		}

--- a/internal/app/wwctl/node/sensors/power.go
+++ b/internal/app/wwctl/node/sensors/power.go
@@ -17,13 +17,13 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not open node configuration: %s\n", err)
+		wwlog.Error("Could not open node configuration: %s\n", err)
 		os.Exit(1)
 	}
 
 	nodes, err := nodeDB.FindAllNodes()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not get node list: %s\n", err)
+		wwlog.Error("Could not get node list: %s\n", err)
 		os.Exit(1)
 	}
 
@@ -48,7 +48,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	for _, node := range nodes {
 		if node.Ipmi.Ipaddr.Get() == "" {
-			wwlog.Printf(wwlog.ERROR, "%s: No IPMI IP address\n", node.Id.Get())
+			wwlog.Error("%s: No IPMI IP address\n", node.Id.Get())
 			continue
 		}
 		var ipmiInterface = "lan"
@@ -92,7 +92,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		out, err := result.Result()
 
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "%s: %s\n", result.NodeName, out)
+			wwlog.Error("%s: %s\n", result.NodeName, out)
 			returnErr = err
 			continue
 		}

--- a/internal/app/wwctl/node/status/main.go
+++ b/internal/app/wwctl/node/status/main.go
@@ -21,12 +21,12 @@ func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 
 	controller, err := warewulfconf.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "%s\n", err)
+		wwlog.Error("%s\n", err)
 		os.Exit(1)
 	}
 
 	if controller.Ipaddr == "" {
-		wwlog.Printf(wwlog.ERROR, "The Warewulf Server IP Address is not properly configured\n")
+		wwlog.Error("The Warewulf Server IP Address is not properly configured\n")
 		os.Exit(1)
 	}
 
@@ -46,7 +46,7 @@ func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 			fmt.Print("\033[H\033[2J")
 			_, height, err = term.GetSize(0)
 			if err != nil {
-				wwlog.Printf(wwlog.WARN, "Could not get terminal height, using 24\n")
+				wwlog.Warn("Could not get terminal height, using 24\n")
 				height = 24
 			}
 		}
@@ -54,7 +54,7 @@ func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 		fmt.Printf("%-20s %-20s %-25s %-10s\n", "NODENAME", "STAGE", "SENT", "LASTSEEN (s)")
 		fmt.Printf("%s\n", strings.Repeat("=", 80))
 
-		wwlog.Printf(wwlog.VERBOSE, "Building sort index\n")
+		wwlog.Verbose("Building sort index\n")
 		var statuses []*wwapiv1.NodeStatus
 		if len(args) > 0 {
 			nodeList := hostlist.Expand(args)
@@ -72,7 +72,7 @@ func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 			}
 		}
 
-		wwlog.Printf(wwlog.VERBOSE, "Sorting index\n")
+		wwlog.Verbose("Sorting index\n")
 		if SetSortLast {
 			sort.Slice(statuses, func(i, j int) bool {
 				if statuses[i].Lastseen > statuses[j].Lastseen {
@@ -84,7 +84,7 @@ func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 				}
 			})
 		} else if SetSortReverse {
-			wwlog.Printf(wwlog.VERBOSE, "Reversing sort order\n")
+			wwlog.Verbose("Reversing sort order\n")
 			sort.Slice(statuses, func(i, j int) bool {
 				return statuses[i].NodeName > statuses[j].NodeName
 			})
@@ -95,7 +95,7 @@ func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 			})
 		}
 
-		wwlog.Printf(wwlog.VERBOSE, "Printing results\n")
+		wwlog.Verbose("Printing results\n")
 		for i := 0; i < len(statuses); i++ {
 			o := statuses[i]
 			if SetTime > 0 && o.Lastseen < SetTime {

--- a/internal/app/wwctl/overlay/build/main.go
+++ b/internal/app/wwctl/overlay/build/main.go
@@ -16,18 +16,18 @@ import (
 func CobraRunE(cmd *cobra.Command, args []string) error {
 	controller, err := warewulfconf.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "%s\n", err)
+		wwlog.Error("%s\n", err)
 		os.Exit(1)
 	}
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not open node configuration: %s\n", err)
+		wwlog.Error("Could not open node configuration: %s\n", err)
 		os.Exit(1)
 	}
 
 	nodes, err := nodeDB.FindAllNodes()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not get node list: %s\n", err)
+		wwlog.Error("Could not get node list: %s\n", err)
 		os.Exit(1)
 	}
 
@@ -81,7 +81,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	if BuildHost || (!BuildHost && !BuildNodes && len(args) == 0 && controller.Warewulf.EnableHostOverlay) {
 		err := overlay.BuildHostOverlay()
 		if err != nil {
-			wwlog.Printf(wwlog.WARN, "host overlay could not be built: %s\n", err)
+			wwlog.Warn("host overlay could not be built: %s\n", err)
 		}
 	}
 
@@ -93,7 +93,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		}
 
 		if err != nil {
-			wwlog.Printf(wwlog.WARN, "Some overlays failed to be generated: %s\n", err)
+			wwlog.Warn("Some overlays failed to be generated: %s\n", err)
 		}
 	}
 	return nil

--- a/internal/app/wwctl/overlay/chmod/main.go
+++ b/internal/app/wwctl/overlay/chmod/main.go
@@ -19,27 +19,27 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	permissionMode, err := strconv.ParseUint(args[2], 8, 32)
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not convert requested mode: %s\n", err)
+		wwlog.Error("Could not convert requested mode: %s\n", err)
 		os.Exit(1)
 	}
 
 	overlaySourceDir = overlay.OverlaySourceDir(overlayName)
 
 	if !util.IsDir(overlaySourceDir) {
-		wwlog.Printf(wwlog.ERROR, "Overlay does not exist: %s\n", overlayName)
+		wwlog.Error("Overlay does not exist: %s\n", overlayName)
 		os.Exit(1)
 	}
 
 	overlayFile := path.Join(overlaySourceDir, fileName)
 
 	if !util.IsFile(overlayFile) && !util.IsDir(overlayFile) {
-		wwlog.Printf(wwlog.ERROR, "File does not exist within overlay: %s:%s\n", overlayName, fileName)
+		wwlog.Error("File does not exist within overlay: %s:%s\n", overlayName, fileName)
 		os.Exit(1)
 	}
 
 	err = os.Chmod(overlayFile, os.FileMode(permissionMode))
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not set permission: %s\n", err)
+		wwlog.Error("Could not set permission: %s\n", err)
 		os.Exit(1)
 	}
 

--- a/internal/app/wwctl/overlay/chown/main.go
+++ b/internal/app/wwctl/overlay/chown/main.go
@@ -23,14 +23,14 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	uid, err = strconv.Atoi(args[2])
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "UID is not an integer: %s\n", args[2])
+		wwlog.Error("UID is not an integer: %s\n", args[2])
 		os.Exit(1)
 	}
 
 	if len(args) > 3 {
 		gid, err = strconv.Atoi(args[3])
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "GID is not an integer: %s\n", args[3])
+			wwlog.Error("GID is not an integer: %s\n", args[3])
 			os.Exit(1)
 		}
 	} else {
@@ -40,20 +40,20 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	overlaySourceDir = overlay.OverlaySourceDir(overlayName)
 
 	if !util.IsDir(overlaySourceDir) {
-		wwlog.Printf(wwlog.ERROR, "Overlay does not exist: %s\n", overlayName)
+		wwlog.Error("Overlay does not exist: %s\n", overlayName)
 		os.Exit(1)
 	}
 
 	overlayFile := path.Join(overlaySourceDir, fileName)
 
 	if !util.IsFile(overlayFile) && !util.IsDir(overlayFile) {
-		wwlog.Printf(wwlog.ERROR, "File does not exist within overlay: %s:%s\n", overlayName, fileName)
+		wwlog.Error("File does not exist within overlay: %s:%s\n", overlayName, fileName)
 		os.Exit(1)
 	}
 
 	err = os.Chown(overlayFile, uid, gid)
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not set ownership: %s\n", err)
+		wwlog.Error("Could not set ownership: %s\n", err)
 		os.Exit(1)
 	}
 

--- a/internal/app/wwctl/overlay/create/main.go
+++ b/internal/app/wwctl/overlay/create/main.go
@@ -12,7 +12,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	err := overlay.OverlayInit(args[0])
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "%s\n", err)
+		wwlog.Error("%s\n", err)
 		os.Exit(1)
 	}
 

--- a/internal/app/wwctl/overlay/delete/main.go
+++ b/internal/app/wwctl/overlay/delete/main.go
@@ -25,12 +25,12 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	overlayPath = overlay.OverlaySourceDir(overlayName)
 
 	if overlayPath == "" {
-		wwlog.Printf(wwlog.ERROR, "Overlay name did not resolve: '%s'\n", overlayName)
+		wwlog.Error("Overlay name did not resolve: '%s'\n", overlayName)
 		os.Exit(1)
 	}
 
 	if !util.IsDir(overlayPath) {
-		wwlog.Printf(wwlog.ERROR, "Overlay does not exist: %s\n", overlayName)
+		wwlog.Error("Overlay does not exist: %s\n", overlayName)
 		os.Exit(1)
 	}
 
@@ -55,22 +55,22 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		removePath := path.Join(overlayPath, fileName)
 
 		if !util.IsDir(removePath) && !util.IsFile(removePath) {
-			wwlog.Printf(wwlog.ERROR, "Path to remove doesn't exist in overlay: %s\n", removePath)
+			wwlog.Error("Path to remove doesn't exist in overlay: %s\n", removePath)
 			os.Exit(1)
 		}
 
 		if Force {
 			err := os.RemoveAll(removePath)
 			if err != nil {
-				wwlog.Printf(wwlog.ERROR, "Failed deleting file from overlay: %s:%s\n", overlayName, overlayPath)
-				wwlog.Printf(wwlog.ERROR, "%s\n", err)
+				wwlog.Error("Failed deleting file from overlay: %s:%s\n", overlayName, overlayPath)
+				wwlog.Error("%s\n", err)
 				os.Exit(1)
 			}
 		} else {
 			err := os.Remove(removePath)
 			if err != nil {
-				wwlog.Printf(wwlog.ERROR, "Failed deleting overlay: %s:%s\n", overlayName, overlayPath)
-				wwlog.Printf(wwlog.ERROR, "%s\n", err)
+				wwlog.Error("Failed deleting overlay: %s:%s\n", overlayName, overlayPath)
+				wwlog.Error("%s\n", err)
 				os.Exit(1)
 			}
 		}
@@ -79,13 +79,13 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 			// Cleanup any empty directories left behind...
 			i := path.Dir(removePath)
 			for i != overlayPath {
-				wwlog.Printf(wwlog.DEBUG, "Evaluating directory to remove: %s\n", i)
+				wwlog.Debug("Evaluating directory to remove: %s\n", i)
 				err := os.Remove(i)
 				if err != nil {
 					break
 				}
 
-				wwlog.Printf(wwlog.VERBOSE, "Removed empty directory: %s\n", i)
+				wwlog.Verbose("Removed empty directory: %s\n", i)
 				i = path.Dir(i)
 			}
 		}

--- a/internal/app/wwctl/overlay/edit/main.go
+++ b/internal/app/wwctl/overlay/edit/main.go
@@ -26,34 +26,34 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	overlaySourceDir = overlay.OverlaySourceDir(overlayName)
 
 	if !util.IsDir(overlaySourceDir) {
-		wwlog.Printf(wwlog.ERROR, "Overlay does not exist: %s\n", overlayName)
+		wwlog.Error("Overlay does not exist: %s\n", overlayName)
 		os.Exit(1)
 	}
 
 	overlayFile := path.Join(overlaySourceDir, fileName)
 
-	wwlog.Printf(wwlog.DEBUG, "Will edit overlay file: %s\n", overlayFile)
+	wwlog.Debug("Will edit overlay file: %s\n", overlayFile)
 
 	if CreateDirs {
 		err := os.MkdirAll(path.Dir(overlayFile), 0755)
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "Could not create directory: %s\n", path.Dir(overlayFile))
+			wwlog.Error("Could not create directory: %s\n", path.Dir(overlayFile))
 			os.Exit(1)
 		}
 	} else {
 		if !util.IsDir(path.Dir(overlayFile)) {
-			wwlog.Printf(wwlog.ERROR, "Can not create file, parent directory does not exist, try adding the\n")
-			wwlog.Printf(wwlog.ERROR, "'--parents' option to create the directory.\n")
+			wwlog.Error("Can not create file, parent directory does not exist, try adding the\n")
+			wwlog.Error("'--parents' option to create the directory.\n")
 			os.Exit(1)
 		}
 	}
 
 	if !util.IsFile(overlayFile) && filepath.Ext(overlayFile) == ".ww" {
-		wwlog.Printf(wwlog.VERBOSE, "This is a new file, creating some default content\n")
+		wwlog.Verbose("This is a new file, creating some default content\n")
 
 		w, err := os.OpenFile(overlayFile, os.O_RDWR|os.O_CREATE, os.FileMode(PermMode))
 		if err != nil {
-			wwlog.Printf(wwlog.WARN, "Could not create file for writing: %s\n", err)
+			wwlog.Warn("Could not create file for writing: %s\n", err)
 		}
 
 		fmt.Fprintf(w, "# This is a Warewulf Template file.\n")
@@ -72,7 +72,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	err := util.ExecInteractive(editor, overlayFile)
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Editor process existed with non-zero\n")
+		wwlog.Error("Editor process existed with non-zero\n")
 		os.Exit(1)
 	}
 

--- a/internal/app/wwctl/overlay/imprt/main.go
+++ b/internal/app/wwctl/overlay/imprt/main.go
@@ -25,11 +25,11 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		dest = source
 	}
 
-	wwlog.Printf(wwlog.VERBOSE, "Copying '%s' into overlay '%s:%s'\n", source, overlayName, dest)
+	wwlog.Verbose("Copying '%s' into overlay '%s:%s'\n", source, overlayName, dest)
 	overlaySource = overlay.OverlaySourceDir(overlayName)
 
 	if !util.IsDir(overlaySource) {
-		wwlog.Printf(wwlog.ERROR, "Overlay does not exist: %s\n", overlayName)
+		wwlog.Error("Overlay does not exist: %s\n", overlayName)
 		os.Exit(1)
 	}
 
@@ -38,7 +38,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if util.IsFile(path.Join(overlaySource, dest)) {
-		wwlog.Printf(wwlog.ERROR, "A file with that name already exists in the overlay %s\n:", overlayName)
+		wwlog.Error("A file with that name already exists in the overlay %s\n:", overlayName)
 		os.Exit(1)
 	}
 
@@ -50,13 +50,13 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	if !NoOverlayUpdate {
 		n, err := node.New()
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "Could not open node configuration: %s\n", err)
+			wwlog.Error("Could not open node configuration: %s\n", err)
 			os.Exit(1)
 		}
 
 		nodes, err := n.FindAllNodes()
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "Could not get node list: %s\n", err)
+			wwlog.Error("Could not get node list: %s\n", err)
 			os.Exit(1)
 		}
 

--- a/internal/app/wwctl/overlay/list/main.go
+++ b/internal/app/wwctl/overlay/list/main.go
@@ -38,7 +38,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		if util.IsDir(path) {
 			files := util.FindFiles(path)
 
-			wwlog.Printf(wwlog.DEBUG, "Iterating overlay path: %s\n", path)
+			wwlog.Debug("Iterating overlay path: %s\n", path)
 			if ListContents {
 				var fileCount int
 				for file := range files {
@@ -68,7 +68,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 			}
 
 		} else {
-			wwlog.Printf(wwlog.ERROR, "system/%s (path not found:%s)\n", overlays[o], path)
+			wwlog.Error("system/%s (path not found:%s)\n", overlays[o], path)
 		}
 	}
 

--- a/internal/app/wwctl/overlay/mkdir/main.go
+++ b/internal/app/wwctl/overlay/mkdir/main.go
@@ -19,17 +19,17 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	overlaySourceDir = overlay.OverlaySourceDir(overlayName)
 
 	if !util.IsDir(overlaySourceDir) {
-		wwlog.Printf(wwlog.ERROR, "Overlay does not exist: %s\n", overlayName)
+		wwlog.Error("Overlay does not exist: %s\n", overlayName)
 		os.Exit(1)
 	}
 
 	overlayDir := path.Join(overlaySourceDir, dirName)
 
-	wwlog.Printf(wwlog.DEBUG, "Will create directory in overlay: %s:%s\n", overlayName, dirName)
+	wwlog.Debug("Will create directory in overlay: %s:%s\n", overlayName, dirName)
 
 	err := os.MkdirAll(overlayDir, os.FileMode(PermMode))
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not create directory: %s\n", path.Dir(overlayDir))
+		wwlog.Error("Could not create directory: %s\n", path.Dir(overlayDir))
 		os.Exit(1)
 	}
 

--- a/internal/app/wwctl/overlay/show/main.go
+++ b/internal/app/wwctl/overlay/show/main.go
@@ -26,21 +26,21 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	overlaySourceDir = overlay.OverlaySourceDir(overlayName)
 
 	if !util.IsDir(overlaySourceDir) {
-		wwlog.Printf(wwlog.ERROR, "Overlay does not exist: %s\n", overlayName)
+		wwlog.Error("Overlay does not exist: %s\n", overlayName)
 		os.Exit(1)
 	}
 
 	overlayFile := path.Join(overlaySourceDir, fileName)
 
 	if !util.IsFile(overlayFile) {
-		wwlog.Printf(wwlog.ERROR, "File does not exist within overlay: %s:%s\n", overlayName, fileName)
+		wwlog.Error("File does not exist within overlay: %s:%s\n", overlayName, fileName)
 		os.Exit(1)
 	}
 
 	if NodeName == "" {
 		f, err := ioutil.ReadFile(overlayFile)
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "Could not read file: %s\n", err)
+			wwlog.Error("Could not read file: %s\n", err)
 			os.Exit(1)
 		}
 
@@ -49,23 +49,23 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		var host node.NodeInfo
 		nodeDB, err := node.New()
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "Could not open node configuration: %s\n", err)
+			wwlog.Error("Could not open node configuration: %s\n", err)
 			os.Exit(1)
 		}
 		nodes, err := nodeDB.FindAllNodes()
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "Could not get node list: %s\n", err)
+			wwlog.Error("Could not get node list: %s\n", err)
 			os.Exit(1)
 		}
 		node := node.FilterByName(nodes, []string{NodeName})
 		if len(node) != 1 {
-			wwlog.Printf(wwlog.ERROR, "%v does not identify a single node\n", NodeName)
+			wwlog.Error("%v does not identify a single node\n", NodeName)
 			os.Exit(1)
 		}
 		host = node[0]
 
 		if !util.IsFile(args[0]) {
-			wwlog.Printf(wwlog.ERROR, "%s is not a file\n", args[0])
+			wwlog.Error("%s is not a file\n", args[0])
 		}
 		tstruct := overlay.InitStruct(host)
 		tstruct.BuildSource = args[0]
@@ -74,7 +74,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		if filepath.Ext(args[0]) != ".ww" {
-			wwlog.Printf(wwlog.WARN, "%s has not the '.ww' so wont be rendered if in overlay\n", args[0])
+			wwlog.Warn("%s has not the '.ww' so wont be rendered if in overlay\n", args[0])
 		}
 		var outBuffer bytes.Buffer
 		// search for magic file name comment
@@ -87,13 +87,13 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 			line := bufferScanner.Text()
 			filenameFromTemplate := reg.FindAllStringSubmatch(line, -1)
 			if len(filenameFromTemplate) != 0 {
-				wwlog.Printf(wwlog.DEBUG, "Found multifile comment, new filename %s\n", filenameFromTemplate[0][1])
+				wwlog.Debug("Found multifile comment, new filename %s\n", filenameFromTemplate[0][1])
 				if foundFileComment {
 					if !Quiet {
-						wwlog.Printf(wwlog.INFO, "backupFile: %v\nwriteFile: %v\n", backupFile, writeFile)
-						wwlog.Printf(wwlog.INFO, "Filename: %s\n\n", destFileName)
+						wwlog.Info("backupFile: %v\nwriteFile: %v\n", backupFile, writeFile)
+						wwlog.Info("Filename: %s\n\n", destFileName)
 					}
-					wwlog.Printf(wwlog.INFO, "%s", outBuffer.String())
+					wwlog.Info("%s", outBuffer.String())
 					outBuffer.Reset()
 				}
 				destFileName = filenameFromTemplate[0][1]
@@ -103,10 +103,10 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 			}
 		}
 		if !Quiet {
-			wwlog.Printf(wwlog.INFO, "backupFile: %v\nwriteFile: %v\n", backupFile, writeFile)
-			wwlog.Printf(wwlog.INFO, "Filename: %s\n\n", destFileName)
+			wwlog.Info("backupFile: %v\nwriteFile: %v\n", backupFile, writeFile)
+			wwlog.Info("Filename: %s\n\n", destFileName)
 		}
-		wwlog.Printf(wwlog.INFO, "%s", outBuffer.String())
+		wwlog.Info("%s", outBuffer.String())
 
 	}
 	return nil

--- a/internal/app/wwctl/power/cycle/power.go
+++ b/internal/app/wwctl/power/cycle/power.go
@@ -17,13 +17,13 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not open node configuration: %s\n", err)
+		wwlog.Error("Could not open node configuration: %s\n", err)
 		os.Exit(1)
 	}
 
 	nodes, err := nodeDB.FindAllNodes()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not get node list: %s\n", err)
+		wwlog.Error("Could not get node list: %s\n", err)
 		os.Exit(1)
 	}
 
@@ -47,7 +47,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	for _, node := range nodes {
 
 		if node.Ipmi.Ipaddr.Get() == "" {
-			wwlog.Printf(wwlog.ERROR, "%s: No IPMI IP address\n", node.Id.Get())
+			wwlog.Error("%s: No IPMI IP address\n", node.Id.Get())
 			continue
 		}
 		var ipmiInterface = "lan"
@@ -85,7 +85,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		out, err := result.Result()
 
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "%s: %s\n", result.NodeName, out)
+			wwlog.Error("%s: %s\n", result.NodeName, out)
 			returnErr = err
 			continue
 		}

--- a/internal/app/wwctl/power/off/power.go
+++ b/internal/app/wwctl/power/off/power.go
@@ -17,13 +17,13 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not open node configuration: %s\n", err)
+		wwlog.Error("Could not open node configuration: %s\n", err)
 		os.Exit(1)
 	}
 
 	nodes, err := nodeDB.FindAllNodes()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not get node list: %s\n", err)
+		wwlog.Error("Could not get node list: %s\n", err)
 		os.Exit(1)
 	}
 
@@ -47,7 +47,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	for _, node := range nodes {
 
 		if node.Ipmi.Ipaddr.Get() == "" {
-			wwlog.Printf(wwlog.ERROR, "%s: No IPMI IP address\n", node.Id.Get())
+			wwlog.Error("%s: No IPMI IP address\n", node.Id.Get())
 			continue
 		}
 		var ipmiInterface = "lan"
@@ -85,7 +85,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		out, err := result.Result()
 
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "%s: %s\n", result.NodeName, out)
+			wwlog.Error("%s: %s\n", result.NodeName, out)
 			returnErr = err
 			continue
 		}

--- a/internal/app/wwctl/power/on/power.go
+++ b/internal/app/wwctl/power/on/power.go
@@ -17,13 +17,13 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not open node configuration: %s\n", err)
+		wwlog.Error("Could not open node configuration: %s\n", err)
 		os.Exit(1)
 	}
 
 	nodes, err := nodeDB.FindAllNodes()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not get node list: %s\n", err)
+		wwlog.Error("Could not get node list: %s\n", err)
 		os.Exit(1)
 	}
 
@@ -47,7 +47,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	for _, node := range nodes {
 
 		if node.Ipmi.Ipaddr.Get() == "" {
-			wwlog.Printf(wwlog.ERROR, "%s: No IPMI IP address\n", node.Id.Get())
+			wwlog.Error("%s: No IPMI IP address\n", node.Id.Get())
 			continue
 		}
 		var ipmiInterface = "lan"
@@ -85,7 +85,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		out, err := result.Result()
 
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "%s: %s\n", result.NodeName, out)
+			wwlog.Error("%s: %s\n", result.NodeName, out)
 			returnErr = err
 			continue
 		}

--- a/internal/app/wwctl/power/reset/power.go
+++ b/internal/app/wwctl/power/reset/power.go
@@ -17,13 +17,13 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not open node configuration: %s\n", err)
+		wwlog.Error("Could not open node configuration: %s\n", err)
 		os.Exit(1)
 	}
 
 	nodes, err := nodeDB.FindAllNodes()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Cloud not get nodeList: %s\n", err)
+		wwlog.Error("Cloud not get nodeList: %s\n", err)
 		os.Exit(1)
 	}
 
@@ -47,7 +47,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	for _, node := range nodes {
 
 		if node.Ipmi.Ipaddr.Get() == "" {
-			wwlog.Printf(wwlog.ERROR, "%s: No IPMI IP address\n", node.Id.Get())
+			wwlog.Error("%s: No IPMI IP address\n", node.Id.Get())
 			continue
 		}
 		var ipmiInterface = "lan"
@@ -85,7 +85,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		out, err := result.Result()
 
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "%s: %s\n", result.NodeName, out)
+			wwlog.Error("%s: %s\n", result.NodeName, out)
 			returnErr = err
 			continue
 		}

--- a/internal/app/wwctl/power/soft/power.go
+++ b/internal/app/wwctl/power/soft/power.go
@@ -17,13 +17,13 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not open node configuration: %s\n", err)
+		wwlog.Error("Could not open node configuration: %s\n", err)
 		os.Exit(1)
 	}
 
 	nodes, err := nodeDB.FindAllNodes()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Cloud not get nodeList: %s\n", err)
+		wwlog.Error("Cloud not get nodeList: %s\n", err)
 		os.Exit(1)
 	}
 
@@ -47,7 +47,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	for _, node := range nodes {
 
 		if node.Ipmi.Ipaddr.Get() == "" {
-			wwlog.Printf(wwlog.ERROR, "%s: No IPMI IP address\n", node.Id.Get())
+			wwlog.Error("%s: No IPMI IP address\n", node.Id.Get())
 			continue
 		}
 		var ipmiInterface = "lan"
@@ -85,7 +85,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		out, err := result.Result()
 
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "%s: %s\n", result.NodeName, out)
+			wwlog.Error("%s: %s\n", result.NodeName, out)
 			returnErr = err
 			continue
 		}

--- a/internal/app/wwctl/power/status/power.go
+++ b/internal/app/wwctl/power/status/power.go
@@ -17,13 +17,13 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not open node configuration: %s\n", err)
+		wwlog.Error("Could not open node configuration: %s\n", err)
 		os.Exit(1)
 	}
 
 	nodes, err := nodeDB.FindAllNodes()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not get node list: %s\n", err)
+		wwlog.Error("Could not get node list: %s\n", err)
 		os.Exit(1)
 	}
 
@@ -47,7 +47,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	for _, node := range nodes {
 
 		if node.Ipmi.Ipaddr.Get() == "" {
-			wwlog.Printf(wwlog.ERROR, "%s: No IPMI IP address\n", node.Id.Get())
+			wwlog.Error("%s: No IPMI IP address\n", node.Id.Get())
 			continue
 		}
 		var ipmiInterface = "lan"
@@ -85,7 +85,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		out, err := result.Result()
 
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "%s: %s\n", result.NodeName, out)
+			wwlog.Error("%s: %s\n", result.NodeName, out)
 			returnErr = err
 			continue
 		}

--- a/internal/app/wwctl/profile/delete/main.go
+++ b/internal/app/wwctl/profile/delete/main.go
@@ -16,13 +16,13 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Failed to open node database: %s\n", err)
+		wwlog.Error("Failed to open node database: %s\n", err)
 		os.Exit(1)
 	}
 
 	profiles, err := nodeDB.FindAllProfiles()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not load all profiles: %s\n", err)
+		wwlog.Error("Could not load all profiles: %s\n", err)
 		os.Exit(1)
 	}
 
@@ -31,13 +31,13 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 			if p.Id.Get() == r {
 				nodes, err := nodeDB.FindAllNodes()
 				if err != nil {
-					wwlog.Printf(wwlog.ERROR, "Could not load all nodes: %s\n", err)
+					wwlog.Error("Could not load all nodes: %s\n", err)
 					os.Exit(1)
 				}
 				for _, n := range nodes {
 					for _, np := range n.Profiles.GetSlice() {
 						if np == r {
-							wwlog.Printf(wwlog.VERBOSE, "Removing profile from node %s: %s\n", n.Id.Get(), r)
+							wwlog.Verbose("Removing profile from node %s: %s\n", n.Id.Get(), r)
 							n.Profiles.SliceRemoveElement(r)
 							err := nodeDB.NodeUpdate(n)
 							if err != nil {
@@ -58,7 +58,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 				found = true
 				err := nodeDB.DelProfile(r)
 				if err != nil {
-					wwlog.Printf(wwlog.ERROR, "%s\n", err)
+					wwlog.Error("%s\n", err)
 				}
 			}
 		}

--- a/internal/app/wwctl/profile/list/main.go
+++ b/internal/app/wwctl/profile/list/main.go
@@ -14,13 +14,13 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not open node configuration: %s\n", err)
+		wwlog.Error("Could not open node configuration: %s\n", err)
 		os.Exit(1)
 	}
 
 	profiles, err := nodeDB.FindAllProfiles()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not find all nodes: %s\n", err)
+		wwlog.Error("Could not find all nodes: %s\n", err)
 		os.Exit(1)
 	}
 

--- a/internal/app/wwctl/ssh/main.go
+++ b/internal/app/wwctl/ssh/main.go
@@ -21,13 +21,13 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not open node configuration: %s\n", err)
+		wwlog.Error("Could not open node configuration: %s\n", err)
 		os.Exit(1)
 	}
 
 	nodes, err := nodeDB.FindAllNodes()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not get node list: %s\n", err)
+		wwlog.Error("Could not get node list: %s\n", err)
 		os.Exit(1)
 	}
 
@@ -63,7 +63,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 				fmt.Printf("%s: %s %s\n", nodename, SshPath, strings.Join(command, " "))
 			} else {
 
-				wwlog.Printf(wwlog.DEBUG, "Sending command to node '%s': %s\n", nodename, command)
+				wwlog.Debug("Sending command to node '%s': %s\n", nodename, command)
 				var stdout, stderr bytes.Buffer
 				cmd := exec.Command(SshPath, command...)
 				cmd.Stdin = os.Stdin

--- a/internal/pkg/api/apiconfig/container/container.go
+++ b/internal/pkg/api/apiconfig/container/container.go
@@ -40,34 +40,34 @@ func ContainerBuild(cbp *wwapiv1.ContainerBuildParameter) (err error) {
 	for _, c := range containers {
 		if !container.ValidSource(c) {
 			err = fmt.Errorf("VNFS name does not exist: %s", c)
-			wwlog.Printf(wwlog.ERROR, "%s\n", err)
+			wwlog.Error("%s\n", err)
 			return
 		}
 
 		err = container.Build(c, cbp.Force)
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "Could not build container %s: %s\n", c, err)
+			wwlog.Error("Could not build container %s: %s\n", c, err)
 			return
 		}
 	}
 
 	if cbp.Default {
 		if len(containers) != 1 {
-			wwlog.Printf(wwlog.ERROR, "Can only set default for one container\n")
+			wwlog.Error("Can only set default for one container\n")
 		} else {
 			var nodeDB node.NodeYaml
 			nodeDB, err = node.New()
 			if err != nil {
-				wwlog.Printf(wwlog.ERROR, "Could not open node configuration: %s\n", err)
+				wwlog.Error("Could not open node configuration: %s\n", err)
 				return
 			}
 
 			//TODO: Don't loop through profiles, instead have a nodeDB function that goes directly to the map
 			profiles, _ := nodeDB.FindAllProfiles()
 			for _, profile := range profiles {
-				wwlog.Printf(wwlog.DEBUG, "Looking for profile default: %s\n", profile.Id.Get())
+				wwlog.Debug("Looking for profile default: %s\n", profile.Id.Get())
 				if profile.Id.Get() == "default" {
-					wwlog.Printf(wwlog.DEBUG, "Found profile default, setting container name to: %s\n", containers[0])
+					wwlog.Debug("Found profile default, setting container name to: %s\n", containers[0])
 					profile.ContainerName.Set(containers[0])
 					err := nodeDB.ProfileUpdate(profile)
 					if err != nil {
@@ -94,7 +94,7 @@ func ContainerDelete(cdp *wwapiv1.ContainerDeleteParameter) (err error) {
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not open nodeDB: %s\n", err)
+		wwlog.Error("Could not open nodeDB: %s\n", err)
 		return
 	}
 
@@ -109,18 +109,18 @@ ARG_LOOP:
 		containerName := cdp.ContainerNames[i]
 		for _, n := range nodes {
 			if n.ContainerName.Get() == containerName {
-				wwlog.Printf(wwlog.ERROR, "Container is configured for nodes, skipping: %s\n", containerName)
+				wwlog.Error("Container is configured for nodes, skipping: %s\n", containerName)
 				continue ARG_LOOP
 			}
 		}
 
 		if !container.ValidSource(containerName) {
-			wwlog.Printf(wwlog.ERROR, "Container name is not a valid source: %s\n", containerName)
+			wwlog.Error("Container name is not a valid source: %s\n", containerName)
 			continue
 		}
 		err := container.DeleteSource(containerName)
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "Could not remove source: %s\n", containerName)
+			wwlog.Error("Could not remove source: %s\n", containerName)
 		} else {
 			fmt.Printf("Container has been deleted: %s\n", containerName)
 		}
@@ -143,7 +143,7 @@ func ContainerImport(cip *wwapiv1.ContainerImportParameter) (containerName strin
 	}
 	if !container.ValidName(cip.Name) {
 		err = fmt.Errorf("VNFS name contains illegal characters: %s", cip.Name)
-		wwlog.Printf(wwlog.ERROR, "%s\n", err)
+		wwlog.Error("%s\n", err)
 		return
 	}
 
@@ -155,53 +155,53 @@ func ContainerImport(cip *wwapiv1.ContainerImportParameter) (containerName strin
 			fmt.Printf("Overwriting existing VNFS\n")
 			err = os.RemoveAll(fullPath)
 			if err != nil {
-				wwlog.Printf(wwlog.ERROR, "%s\n", err)
+				wwlog.Error("%s\n", err)
 				return
 			}
 		} else if cip.Update {
 			fmt.Printf("Updating existing VNFS\n")
 		} else {
 			err = fmt.Errorf("VNFS Name exists, specify --force, --update, or choose a different name: %s", cip.Name)
-			wwlog.Printf(wwlog.ERROR, "%s\n", err)
+			wwlog.Error("%s\n", err)
 			return
 		}
 	} else if strings.HasPrefix(cip.Source, "docker://") || strings.HasPrefix(cip.Source, "docker-daemon://") {
 		var sCtx *types.SystemContext
 		sCtx, err = getSystemContext()
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "%s\n", err)
+			wwlog.Error("%s\n", err)
 			// return was missing here. Was that deliberate?
 		}
 
 		err = container.ImportDocker(cip.Source, cip.Name, sCtx)
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "Could not import image: %s\n", err)
+			wwlog.Error("Could not import image: %s\n", err)
 			_ = container.DeleteSource(cip.Name)
 			return
 		}
 	} else if util.IsDir(cip.Source) {
 		err = container.ImportDirectory(cip.Source, cip.Name)
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "Could not import image: %s\n", err)
+			wwlog.Error("Could not import image: %s\n", err)
 			_ = container.DeleteSource(cip.Name)
 			return
 		}
 	} else {
 		err = fmt.Errorf("Invalid dir or uri: %s", cip.Source)
-		wwlog.Printf(wwlog.ERROR, "%s\n", err)
+		wwlog.Error("%s\n", err)
 		return
 	}
 
 	fmt.Printf("Updating the container's /etc/resolv.conf\n")
 	err = util.CopyFile("/etc/resolv.conf", path.Join(container.RootFsDir(cip.Name), "/etc/resolv.conf"))
 	if err != nil {
-		wwlog.Printf(wwlog.WARN, "Could not copy /etc/resolv.conf into container: %s\n", err)
+		wwlog.Warn("Could not copy /etc/resolv.conf into container: %s\n", err)
 	}
 
 	fmt.Printf("Building container: %s\n", cip.Name)
 	err = container.Build(cip.Name, true)
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not build container %s: %s\n", cip.Name, err)
+		wwlog.Error("Could not build container %s: %s\n", cip.Name, err)
 		return
 	}
 
@@ -209,16 +209,16 @@ func ContainerImport(cip *wwapiv1.ContainerImportParameter) (containerName strin
 		var nodeDB node.NodeYaml
 		nodeDB, err = node.New()
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "Could not open node configuration: %s\n", err)
+			wwlog.Error("Could not open node configuration: %s\n", err)
 			return
 		}
 
 		//TODO: Don't loop through profiles, instead have a nodeDB function that goes directly to the map
 		profiles, _ := nodeDB.FindAllProfiles()
 		for _, profile := range profiles {
-			wwlog.Printf(wwlog.DEBUG, "Looking for profile default: %s\n", profile.Id.Get())
+			wwlog.Debug("Looking for profile default: %s\n", profile.Id.Get())
 			if profile.Id.Get() == "default" {
-				wwlog.Printf(wwlog.DEBUG, "Found profile default, setting container name to: %s\n", cip.Name)
+				wwlog.Debug("Found profile default, setting container name to: %s\n", cip.Name)
 				profile.ContainerName.Set(cip.Name)
 				err = nodeDB.ProfileUpdate(profile)
 				if err != nil {
@@ -251,19 +251,19 @@ func ContainerList() (containerInfo []*wwapiv1.ContainerInfo, err error) {
 
 	sources, err = container.ListSources()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "%s\n", err)
+		wwlog.Error("%s\n", err)
 		return
 	}
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "%s\n", err)
+		wwlog.Error("%s\n", err)
 		return
 	}
 
 	nodes, err := nodeDB.FindAllNodes()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "%s\n", err)
+		wwlog.Error("%s\n", err)
 		return
 	}
 
@@ -277,7 +277,7 @@ func ContainerList() (containerInfo []*wwapiv1.ContainerInfo, err error) {
 			nodemap[source] = 0
 		}
 
-		wwlog.Printf(wwlog.DEBUG, "Finding kernel version for: %s\n", source)
+		wwlog.Debug("Finding kernel version for: %s\n", source)
 		kernelVersion := container.KernelVersion(source)
 
 		containerInfo = append(containerInfo, &wwapiv1.ContainerInfo{

--- a/internal/pkg/api/container/container.go
+++ b/internal/pkg/api/container/container.go
@@ -38,34 +38,34 @@ func ContainerBuild(cbp *wwapiv1.ContainerBuildParameter) (err error) {
 	for _, c := range containers {
 		if !container.ValidSource(c) {
 			err = fmt.Errorf("VNFS name does not exist: %s", c)
-			wwlog.Printf(wwlog.ERROR, "%s\n", err)
+			wwlog.Error("%s\n", err)
 			return
 		}
 
 		err = container.Build(c, cbp.Force)
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "Could not build container %s: %s\n", c, err)
+			wwlog.Error("Could not build container %s: %s\n", c, err)
 			return
 		}
 	}
 
 	if cbp.Default {
 		if len(containers) != 1 {
-			wwlog.Printf(wwlog.ERROR, "Can only set default for one container\n")
+			wwlog.Error("Can only set default for one container\n")
 		} else {
 			var nodeDB node.NodeYaml
 			nodeDB, err = node.New()
 			if err != nil {
-				wwlog.Printf(wwlog.ERROR, "Could not open node configuration: %s\n", err)
+				wwlog.Error("Could not open node configuration: %s\n", err)
 				return
 			}
 
 			//TODO: Don't loop through profiles, instead have a nodeDB function that goes directly to the map
 			profiles, _ := nodeDB.FindAllProfiles()
 			for _, profile := range profiles {
-				wwlog.Printf(wwlog.DEBUG, "Looking for profile default: %s\n", profile.Id.Get())
+				wwlog.Debug("Looking for profile default: %s\n", profile.Id.Get())
 				if profile.Id.Get() == "default" {
-					wwlog.Printf(wwlog.DEBUG, "Found profile default, setting container name to: %s\n", containers[0])
+					wwlog.Debug("Found profile default, setting container name to: %s\n", containers[0])
 					profile.ContainerName.Set(containers[0])
 					err := nodeDB.ProfileUpdate(profile)
 					if err != nil {
@@ -92,7 +92,7 @@ func ContainerDelete(cdp *wwapiv1.ContainerDeleteParameter) (err error) {
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not open nodeDB: %s\n", err)
+		wwlog.Error("Could not open nodeDB: %s\n", err)
 		return
 	}
 
@@ -107,18 +107,18 @@ ARG_LOOP:
 		containerName := cdp.ContainerNames[i]
 		for _, n := range nodes {
 			if n.ContainerName.Get() == containerName {
-				wwlog.Printf(wwlog.ERROR, "Container is configured for nodes, skipping: %s\n", containerName)
+				wwlog.Error("Container is configured for nodes, skipping: %s\n", containerName)
 				continue ARG_LOOP
 			}
 		}
 
 		if !container.ValidSource(containerName) {
-			wwlog.Printf(wwlog.ERROR, "Container name is not a valid source: %s\n", containerName)
+			wwlog.Error("Container name is not a valid source: %s\n", containerName)
 			continue
 		}
 		err := container.DeleteSource(containerName)
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "Could not remove source: %s\n", containerName)
+			wwlog.Error("Could not remove source: %s\n", containerName)
 		} else {
 			fmt.Printf("Container has been deleted: %s\n", containerName)
 		}
@@ -196,7 +196,7 @@ func ContainerImport(cip *wwapiv1.ContainerImportParameter) (containerName strin
 	wwlog.Info("Updating the container's /etc/resolv.conf")
 	err = util.CopyFile("/etc/resolv.conf", path.Join(container.RootFsDir(cip.Name), "/etc/resolv.conf"))
 	if err != nil {
-		wwlog.Printf(wwlog.WARN, "Could not copy /etc/resolv.conf into container: %s\n", err)
+		wwlog.Warn("Could not copy /etc/resolv.conf into container: %s\n", err)
 	}
 
 	err = container.SyncUids(cip.Name, !cip.SyncUser)
@@ -226,9 +226,9 @@ func ContainerImport(cip *wwapiv1.ContainerImportParameter) (containerName strin
 		//TODO: Don't loop through profiles, instead have a nodeDB function that goes directly to the map
 		profiles, _ := nodeDB.FindAllProfiles()
 		for _, profile := range profiles {
-			wwlog.Printf(wwlog.DEBUG, "Looking for profile default: %s", profile.Id.Get())
+			wwlog.Debug("Looking for profile default: %s", profile.Id.Get())
 			if profile.Id.Get() == "default" {
-				wwlog.Printf(wwlog.DEBUG, "Found profile default, setting container name to: %s", cip.Name)
+				wwlog.Debug("Found profile default, setting container name to: %s", cip.Name)
 				profile.ContainerName.Set(cip.Name)
 				err = nodeDB.ProfileUpdate(profile)
 				if err != nil {
@@ -261,19 +261,19 @@ func ContainerList() (containerInfo []*wwapiv1.ContainerInfo, err error) {
 
 	sources, err = container.ListSources()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "%s\n", err)
+		wwlog.Error("%s\n", err)
 		return
 	}
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "%s\n", err)
+		wwlog.Error("%s\n", err)
 		return
 	}
 
 	nodes, err := nodeDB.FindAllNodes()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "%s\n", err)
+		wwlog.Error("%s\n", err)
 		return
 	}
 
@@ -287,7 +287,7 @@ func ContainerList() (containerInfo []*wwapiv1.ContainerInfo, err error) {
 			nodemap[source] = 0
 		}
 
-		wwlog.Printf(wwlog.DEBUG, "Finding kernel version for: %s\n", source)
+		wwlog.Debug("Finding kernel version for: %s\n", source)
 		kernelVersion := container.KernelVersion(source)
 
 		containerInfo = append(containerInfo, &wwapiv1.ContainerInfo{

--- a/internal/pkg/api/node/node.go
+++ b/internal/pkg/api/node/node.go
@@ -43,7 +43,7 @@ func NodeAdd(nap *wwapiv1.NodeAddParameter) (err error) {
 		if err != nil {
 			return errors.Wrap(err, "failed to add node")
 		}
-		wwlog.Printf(wwlog.INFO, "Added node: %s\n", a)
+		wwlog.Info("Added node: %s\n", a)
 		var netName string
 		for netName = range nodeConf.NetDevs {
 			// as map should only have key this should give is the first and
@@ -92,14 +92,14 @@ func NodeDelete(ndp *wwapiv1.NodeDeleteParameter) (err error) {
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Failed to open node database: %s\n", err)
+		wwlog.Error("Failed to open node database: %s\n", err)
 		return
 	}
 
 	for _, n := range nodeList {
 		err := nodeDB.DelNode(n.Id.Get())
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "%s\n", err)
+			wwlog.Error("%s\n", err)
 		} else {
 			//count++
 			fmt.Printf("Deleting node: %s\n", n.Id.Print())
@@ -130,13 +130,13 @@ func NodeDeleteParameterCheck(ndp *wwapiv1.NodeDeleteParameter, console bool) (n
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Failed to open node database: %s\n", err)
+		wwlog.Error("Failed to open node database: %s\n", err)
 		return
 	}
 
 	nodes, err := nodeDB.FindAllNodes()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not get node list: %s\n", err)
+		wwlog.Error("Could not get node list: %s\n", err)
 		return
 	}
 
@@ -201,13 +201,13 @@ func NodeSetParameterCheck(set *wwapiv1.NodeSetParameter, console bool) (nodeDB 
 
 	nodeDB, err = node.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not open node configuration: %s\n", err)
+		wwlog.Error("Could not open node configuration: %s\n", err)
 		return
 	}
 
 	nodes, err := nodeDB.FindAllNodes()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not get node list: %s\n", err)
+		wwlog.Error("Could not get node list: %s\n", err)
 		return
 	}
 
@@ -229,22 +229,22 @@ func NodeSetParameterCheck(set *wwapiv1.NodeSetParameter, console bool) (nodeDB 
 	}
 
 	for _, n := range nodes {
-		wwlog.Printf(wwlog.VERBOSE, "Evaluating node: %s\n", n.Id.Get())
+		wwlog.Verbose("Evaluating node: %s\n", n.Id.Get())
 		var nodeConf node.NodeConf
 		err = yaml.Unmarshal([]byte(set.NodeConfYaml), &nodeConf)
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, fmt.Sprintf("%v\n", err.Error()))
+			wwlog.Error(fmt.Sprintf("%v\n", err.Error()))
 			return
 		}
 		n.SetFrom(&nodeConf)
 		if set.NetdevDelete != "" {
 			if _, ok := n.NetDevs[set.NetdevDelete]; !ok {
 				err = fmt.Errorf("network device name doesn't exist: %s", set.NetdevDelete)
-				wwlog.Printf(wwlog.ERROR, fmt.Sprintf("%v\n", err.Error()))
+				wwlog.Error(fmt.Sprintf("%v\n", err.Error()))
 				return
 			}
 
-			wwlog.Printf(wwlog.VERBOSE, "Node: %s, Deleting network device: %s\n", n.Id.Get(), set.NetdevDelete)
+			wwlog.Verbose("Node: %s, Deleting network device: %s\n", n.Id.Get(), set.NetdevDelete)
 			delete(n.NetDevs, set.NetdevDelete)
 		}
 		for _, key := range nodeConf.TagsDel {
@@ -262,7 +262,7 @@ func NodeSetParameterCheck(set *wwapiv1.NodeSetParameter, console bool) (nodeDB 
 		}
 		err := nodeDB.NodeUpdate(n)
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "%s\n", err)
+			wwlog.Error("%s\n", err)
 			os.Exit(1)
 		}
 
@@ -292,22 +292,22 @@ func NodeStatus(nodeNames []string) (nodeStatusResponse *wwapiv1.NodeStatusRespo
 
 	controller, err := warewulfconf.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "%s\n", err)
+		wwlog.Error("%s\n", err)
 		return
 	}
 
 	if controller.Ipaddr == "" {
 		err = fmt.Errorf("the Warewulf Server IP Address is not properly configured")
-		wwlog.Printf(wwlog.ERROR, fmt.Sprintf("%v\n", err.Error()))
+		wwlog.Error(fmt.Sprintf("%v\n", err.Error()))
 		return
 	}
 
 	statusURL := fmt.Sprintf("http://%s:%d/status", controller.Ipaddr, controller.Warewulf.Port)
-	wwlog.Printf(wwlog.VERBOSE, "Connecting to: %s\n", statusURL)
+	wwlog.Verbose("Connecting to: %s\n", statusURL)
 
 	resp, err := http.Get(statusURL)
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not connect to Warewulf server: %s\n", err)
+		wwlog.Error("Could not connect to Warewulf server: %s\n", err)
 		return
 	}
 	defer resp.Body.Close()
@@ -317,7 +317,7 @@ func NodeStatus(nodeNames []string) (nodeStatusResponse *wwapiv1.NodeStatusRespo
 
 	err = decoder.Decode(&wwNodeStatus)
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not decode JSON: %s\n", err)
+		wwlog.Error("Could not decode JSON: %s\n", err)
 		return
 	}
 

--- a/internal/pkg/api/profile/profile.go
+++ b/internal/pkg/api/profile/profile.go
@@ -78,13 +78,13 @@ func ProfileSetParameterCheck(set *wwapiv1.NodeSetParameter, console bool) (node
 	var pConf node.NodeConf
 	err = yaml.Unmarshal([]byte(set.NodeConfYaml), &pConf)
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, fmt.Sprintf("%v\n", err.Error()))
+		wwlog.Error(fmt.Sprintf("%v\n", err.Error()))
 		return
 	}
 
 	for _, p := range profiles {
 		if util.InSlice(set.NodeNames, p.Id.Get()) {
-			wwlog.Printf(wwlog.VERBOSE, "Evaluating profile: %s\n", p.Id.Get())
+			wwlog.Verbose("Evaluating profile: %s\n", p.Id.Get())
 			p.SetFrom(&pConf)
 			if set.NetdevDelete != "" {
 				if _, ok := p.NetDevs[set.NetdevDelete]; !ok {
@@ -92,7 +92,7 @@ func ProfileSetParameterCheck(set *wwapiv1.NodeSetParameter, console bool) (node
 					wwlog.Error(fmt.Sprintf("%v\n", err.Error()))
 					return
 				}
-				wwlog.Printf(wwlog.VERBOSE, "Profile: %s, Deleting network device: %s\n", p.Id.Get(), set.NetdevDelete)
+				wwlog.Verbose("Profile: %s, Deleting network device: %s\n", p.Id.Get(), set.NetdevDelete)
 				delete(p.NetDevs, set.NetdevDelete)
 			}
 			for _, key := range pConf.TagsDel {

--- a/internal/pkg/buildconfig/defaults.go
+++ b/internal/pkg/buildconfig/defaults.go
@@ -22,71 +22,71 @@ var (
 )
 
 func BINDIR() string {
-	wwlog.Printf(wwlog.DEBUG, "BINDIR = '%s'\n", bindir)
+	wwlog.Debug("BINDIR = '%s'\n", bindir)
 	return bindir
 }
 
 func DATADIR() string {
-	wwlog.Printf(wwlog.DEBUG, "DATADIR = '%s'\n", bindir)
+	wwlog.Debug("DATADIR = '%s'\n", bindir)
 	return datadir
 }
 
 func SYSCONFDIR() string {
-	wwlog.Printf(wwlog.DEBUG, "SYSCONFDIR = '%s'\n", sysconfdir)
+	wwlog.Debug("SYSCONFDIR = '%s'\n", sysconfdir)
 	return sysconfdir
 }
 
 func LOCALSTATEDIR() string {
-	wwlog.Printf(wwlog.DEBUG, "LOCALSTATEDIR = '%s'\n", localstatedir)
+	wwlog.Debug("LOCALSTATEDIR = '%s'\n", localstatedir)
 	return localstatedir
 }
 
 func SRVDIR() string {
-	wwlog.Printf(wwlog.DEBUG, "SRVDIR = '%s'\n", srvdir)
+	wwlog.Debug("SRVDIR = '%s'\n", srvdir)
 	return srvdir
 }
 
 func TFTPDIR() string {
-	wwlog.Printf(wwlog.DEBUG, "TFTPDIR = '%s'\n", tftpdir)
+	wwlog.Debug("TFTPDIR = '%s'\n", tftpdir)
 	return tftpdir
 }
 
 func FIREWALLDDIR() string {
-	wwlog.Printf(wwlog.DEBUG, "FIREWALLDDIR = '%s'\n", firewallddir)
+	wwlog.Debug("FIREWALLDDIR = '%s'\n", firewallddir)
 	return firewallddir
 }
 
 func SYSTEMDDIR() string {
-	wwlog.Printf(wwlog.DEBUG, "SYSTEMDDIR = '%s'\n", systemddir)
+	wwlog.Debug("SYSTEMDDIR = '%s'\n", systemddir)
 	return systemddir
 }
 
 func WWOVERLAYDIR() string {
-	wwlog.Printf(wwlog.DEBUG, "WWOVERLAYDIR = '%s'\n", wwoverlaydir)
+	wwlog.Debug("WWOVERLAYDIR = '%s'\n", wwoverlaydir)
 	return wwoverlaydir
 }
 
 func WWCHROOTDIR() string {
-	wwlog.Printf(wwlog.DEBUG, "WWCHROOTDIR = '%s'\n", wwchrootdir)
+	wwlog.Debug("WWCHROOTDIR = '%s'\n", wwchrootdir)
 	return wwchrootdir
 }
 
 func WWPROVISIONDIR() string {
-	wwlog.Printf(wwlog.DEBUG, "WWPROVISIONDIR = '%s'\n", wwprovisiondir)
+	wwlog.Debug("WWPROVISIONDIR = '%s'\n", wwprovisiondir)
 	return wwprovisiondir
 }
 
 func VERSION() string {
-	wwlog.Printf(wwlog.DEBUG, "VERSION = '%s'\n", version)
+	wwlog.Debug("VERSION = '%s'\n", version)
 	return version
 }
 
 func RELEASE() string {
-	wwlog.Printf(wwlog.DEBUG, "RELEASE = '%s'\n", release)
+	wwlog.Debug("RELEASE = '%s'\n", release)
 	return release
 }
 
 func WWCLIENTDIR() string {
-	wwlog.Printf(wwlog.DEBUG, "WWCLIENTDIR = '%s'\n", wwclientdir)
+	wwlog.Debug("WWCLIENTDIR = '%s'\n", wwclientdir)
 	return wwclientdir
 }

--- a/internal/pkg/configure/dhcp.go
+++ b/internal/pkg/configure/dhcp.go
@@ -19,31 +19,31 @@ func Dhcp() error {
 
 	controller, err := warewulfconf.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "%s\n", err)
+		wwlog.Error("%s\n", err)
 		os.Exit(1)
 	}
 
 	if !controller.Dhcp.Enabled {
-		wwlog.Printf(wwlog.INFO, "This system is not configured as a Warewulf DHCP controller\n")
+		wwlog.Info("This system is not configured as a Warewulf DHCP controller\n")
 		os.Exit(1)
 	}
 
 	if controller.Dhcp.RangeStart == "" {
-		wwlog.Printf(wwlog.ERROR, "Configuration is not defined: `dhcpd range start`\n")
+		wwlog.Error("Configuration is not defined: `dhcpd range start`\n")
 		os.Exit(1)
 	}
 
 	if controller.Dhcp.RangeEnd == "" {
-		wwlog.Printf(wwlog.ERROR, "Configuration is not defined: `dhcpd range end`\n")
+		wwlog.Error("Configuration is not defined: `dhcpd range end`\n")
 		os.Exit(1)
 	}
 	if controller.Warewulf.EnableHostOverlay {
 		err = overlay.BuildHostOverlay()
 		if err != nil {
-			wwlog.Printf(wwlog.WARN, "host overlay could not be built: %s\n", err)
+			wwlog.Warn("host overlay could not be built: %s\n", err)
 		}
 	} else {
-		wwlog.Printf(wwlog.INFO, "host overlays are disabled, did not modify/create dhcpd configuration")
+		wwlog.Info("host overlays are disabled, did not modify/create dhcpd configuration")
 	}
 	fmt.Printf("Enabling and restarting the DHCP services\n")
 	err = util.SystemdStart(controller.Dhcp.SystemdName)

--- a/internal/pkg/configure/nfs.go
+++ b/internal/pkg/configure/nfs.go
@@ -19,7 +19,7 @@ func NFS() error {
 
 	controller, err := warewulfconf.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "%s\n", err)
+		wwlog.Error("%s\n", err)
 		os.Exit(1)
 	}
 
@@ -30,10 +30,10 @@ func NFS() error {
 		if controller.Warewulf.EnableHostOverlay {
 			err = overlay.BuildHostOverlay()
 			if err != nil {
-				wwlog.Printf(wwlog.WARN, "host overlay could not be built: %s\n", err)
+				wwlog.Warn("host overlay could not be built: %s\n", err)
 			}
 		} else {
-			wwlog.Printf(wwlog.INFO, "host overlays are disabled, did not modify exports")
+			wwlog.Info("host overlays are disabled, did not modify exports")
 		}
 		fmt.Printf("Enabling and restarting the NFS services\n")
 		if controller.Nfs.SystemdName == "" {

--- a/internal/pkg/configure/ssh.go
+++ b/internal/pkg/configure/ssh.go
@@ -19,7 +19,7 @@ func SSH() error {
 
 		err := os.MkdirAll(path.Join(buildconfig.SYSCONFDIR(), "warewulf/keys"), 0755)
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "Could not create base directory: %s\n", err)
+			wwlog.Error("Could not create base directory: %s\n", err)
 			os.Exit(1)
 		}
 
@@ -27,10 +27,10 @@ func SSH() error {
 			keytype := "ssh_host_" + k + "_key"
 			if !util.IsFile(path.Join(wwkeydir, keytype)) {
 				fmt.Printf("Setting up key: %s\n", keytype)
-				wwlog.Printf(wwlog.DEBUG, "Creating new %s key\n", keytype)
+				wwlog.Debug("Creating new %s key\n", keytype)
 				err = util.ExecInteractive("ssh-keygen", "-q", "-t", k, "-f", path.Join(wwkeydir, keytype), "-C", "", "-N", "")
 				if err != nil {
-					wwlog.Printf(wwlog.ERROR, "Failed to exec ssh-keygen: %s\n", err)
+					wwlog.Error("Failed to exec ssh-keygen: %s\n", err)
 					return errors.Wrap(err, "failed to exec ssh-keygen command")
 				}
 			} else {
@@ -43,7 +43,7 @@ func SSH() error {
 
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not obtain the user's home directory: %s\n", err)
+		wwlog.Error("Could not obtain the user's home directory: %s\n", err)
 		os.Exit(1)
 	}
 

--- a/internal/pkg/configure/tftp.go
+++ b/internal/pkg/configure/tftp.go
@@ -16,13 +16,13 @@ var tftpdir string = path.Join(buildconfig.TFTPDIR(), "warewulf")
 func TFTP() error {
 	controller, err := warewulfconf.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "%s\n", err)
+		wwlog.Error("%s\n", err)
 		return err
 	}
 
 	err = os.MkdirAll(tftpdir, 0755)
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "%s\n", err)
+		wwlog.Error("%s\n", err)
 		return err
 	}
 
@@ -30,20 +30,20 @@ func TFTP() error {
 	for _, f := range [4]string{"x86_64.efi", "x86_64.kpxe", "arm64.efi"} {
 		err = util.SafeCopyFile(path.Join(buildconfig.DATADIR(), "warewulf", "ipxe", f), path.Join(tftpdir, f))
 		if err != nil {
-			wwlog.Printf(wwlog.ERROR, "%s\n", err)
+			wwlog.Error("%s\n", err)
 			return err
 		}
 	}
 
 	if !controller.Tftp.Enabled {
-		wwlog.Printf(wwlog.INFO, "Warewulf does not auto start TFTP services due to disable by warewulf.conf\n")
+		wwlog.Info("Warewulf does not auto start TFTP services due to disable by warewulf.conf\n")
 		os.Exit(0)
 	}
 	
 	fmt.Printf("Enabling and restarting the TFTP services\n")
 	err = util.SystemdStart(controller.Tftp.SystemdName)
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "%s\n", err)
+		wwlog.Error("%s\n", err)
 		return err
 	}
 

--- a/internal/pkg/container/kernel.go
+++ b/internal/pkg/container/kernel.go
@@ -23,16 +23,16 @@ var (
 )
 
 func KernelFind(container string) string {
-	wwlog.Printf(wwlog.DEBUG, "Finding kernel\n")
+	wwlog.Debug("Finding kernel\n")
 	container_path := RootFsDir(container)
 	if container_path == "" {
 		return ""
 	}
 
 	for _, kdir := range kernelDirs {
-		wwlog.Printf(wwlog.DEBUG, "Checking kernel directory: %s\n", kdir)
+		wwlog.Debug("Checking kernel directory: %s\n", kdir)
 		for _, kname := range kernelNames {
-			wwlog.Printf(wwlog.DEBUG, "Checking for kernel name: %s\n", kname)
+			wwlog.Debug("Checking for kernel name: %s\n", kname)
 			kernelPaths, err := filepath.Glob(path.Join(container_path, kdir, kname))
 			if err != nil {
 				return ""
@@ -47,7 +47,7 @@ func KernelFind(container string) string {
 			})
 
 			for _, kernelPath := range kernelPaths {
-				wwlog.Printf(wwlog.DEBUG, "Checking for kernel path: %s\n", kernelPath)
+				wwlog.Debug("Checking for kernel path: %s\n", kernelPath)
 				if util.IsFile(kernelPath) {
 					return kernelPath
 				}
@@ -59,7 +59,7 @@ func KernelFind(container string) string {
 }
 
 func KernelVersion(container string) string {
-	wwlog.Printf(wwlog.DEBUG, "Finding kernel version inside container: %s\n", container)
+	wwlog.Debug("Finding kernel version inside container: %s\n", container)
 	kernel := KernelFind(container)
 	if kernel == "" {
 		return ""

--- a/internal/pkg/container/syncuids.go
+++ b/internal/pkg/container/syncuids.go
@@ -42,7 +42,7 @@ func SyncUids(containerName string, showOnly bool) error {
 	fullPath := RootFsDir(containerName)
 	hostName, err := createPasswdMap(passwdName)
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not open "+passwdName)
+		wwlog.Error("Could not open "+passwdName)
 		return err
 	}
 	// populate db with the user of the
@@ -53,7 +53,7 @@ func SyncUids(containerName string, showOnly bool) error {
 
 	contName, err := createPasswdMap(path.Join(fullPath, passwdName))
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not open "+path.Join(fullPath, passwdName))
+		wwlog.Error("Could not open "+path.Join(fullPath, passwdName))
 		return err
 	}
 	var userOnlyCont []string
@@ -69,7 +69,7 @@ func SyncUids(containerName string, showOnly bool) error {
 		if !foundUser {
 			userDb = append(userDb, completeUserInfo{Name: userCont.name,
 				UidHost: -1, GidHost: -1, UidCont: userCont.uid, GidCont: userCont.gid})
-			wwlog.Printf(wwlog.WARN, "user: %s:%v:%v not present on host\n", userCont.name, userCont.uid, userCont.gid)
+			wwlog.Warn("user: %s:%v:%v not present on host\n", userCont.name, userCont.uid, userCont.gid)
 			userOnlyCont = append(userOnlyCont, userCont.name)
 		}
 
@@ -79,7 +79,7 @@ func SyncUids(containerName string, showOnly bool) error {
 		if user.UidHost == -1 {
 			for _, userCheck := range userDb {
 				if userCheck.UidHost == user.UidCont {
-					wwlog.Printf(wwlog.WARN, fmt.Sprintf("uid(%v) collision for host: %s and container: %s\n",
+					wwlog.Warn(fmt.Sprintf("uid(%v) collision for host: %s and container: %s\n",
 						user.UidCont, user.Name, userCheck.Name))
 					return errors.New(fmt.Sprintf("user %s only present in container has same uid(%v) as user %s on host,\n"+
 						"add this user to /etc/passwd on host", user.Name, user.UidCont, userCheck.Name))
@@ -90,7 +90,7 @@ func SyncUids(containerName string, showOnly bool) error {
 		if user.GidHost == -1 {
 			for _, userCheck := range userDb {
 				if userCheck.GidHost == user.GidCont {
-					wwlog.Printf(wwlog.WARN, fmt.Sprintf("gid(%v) collision for host: %s and container: %s\n",
+					wwlog.Warn(fmt.Sprintf("gid(%v) collision for host: %s and container: %s\n",
 						user.GidCont, user.Name, userCheck.Name))
 					return errors.New(fmt.Sprintf("user %s only present in container has same gid(%v) as user %s on host,\n"+
 						" add this group to /etc/group on host", user.Name, user.GidCont, userCheck.Name))
@@ -101,7 +101,7 @@ func SyncUids(containerName string, showOnly bool) error {
 
 	}
 	if showOnly {
-		wwlog.Printf(wwlog.INFO, "uid/gid not synced, run \nwwctl container syncuser --write %s\nto synchronize uid/gids.\n", containerName)
+		wwlog.Info("uid/gid not synced, run \nwwctl container syncuser --write %s\nto synchronize uid/gids.\n", containerName)
 		return nil
 	}
 	// create list of files which need changed ownerships in order to change them later what
@@ -109,7 +109,7 @@ func SyncUids(containerName string, showOnly bool) error {
 	for idx, user := range userDb {
 		if (user.UidHost != user.UidCont && user.UidHost != -1) ||
 			(user.GidHost != user.GidCont && user.GidHost != -1 && user.UidHost != -1) {
-			wwlog.Printf(wwlog.VERBOSE, fmt.Sprintf("host %s:%v:%v <-> container %s:%v:%v\n",
+			wwlog.Verbose(fmt.Sprintf("host %s:%v:%v <-> container %s:%v:%v\n",
 				user.Name, user.UidHost, user.GidHost, user.Name, user.UidCont, user.GidCont))
 			err = filepath.Walk(fullPath, func(filePath string, info fs.FileInfo, err error) error {
 				// root is always good, if we fail to get UID/GID of a file
@@ -144,7 +144,7 @@ func SyncUids(containerName string, showOnly bool) error {
 				if stat, ok := fsInfo.Sys().(*syscall.Stat_t); ok {
 					gid = int(stat.Gid)
 				}
-				wwlog.Printf(wwlog.DEBUG, "%s chown(%v,%v)\n", file, user.UidHost, gid)
+				wwlog.Debug("%s chown(%v,%v)\n", file, user.UidHost, gid)
 				err = os.Chown(file, user.UidHost, gid)
 				if err != nil {
 					return err
@@ -162,7 +162,7 @@ func SyncUids(containerName string, showOnly bool) error {
 				if stat, ok := fsInfo.Sys().(*syscall.Stat_t); ok {
 					uid = int(stat.Uid)
 				}
-				wwlog.Printf(wwlog.DEBUG, "%s chown(%v,%v)\n", file, user.UidHost, uid)
+				wwlog.Debug("%s chown(%v,%v)\n", file, user.UidHost, uid)
 				// only chown files and dirs
 				if fsInfo.IsDir() && fsInfo.Mode().IsRegular() {
 					err = os.Chown(file, uid, user.GidHost)
@@ -224,18 +224,18 @@ func createPasswdMap(fileName string) ([]simpleUserInfo, error) {
 		name := entries[0]
 		uid, err := strconv.Atoi(entries[2])
 		if err != nil {
-			wwlog.Printf(wwlog.WARN, "could not parse uid(%s) for %s\n", entries[2], name)
+			wwlog.Warn("could not parse uid(%s) for %s\n", entries[2], name)
 		}
 		gid, err := strconv.Atoi(entries[3])
 		if err != nil {
-			wwlog.Printf(wwlog.WARN, "could not parse gid(%s) for %s\n", entries[2], name)
+			wwlog.Warn("could not parse gid(%s) for %s\n", entries[2], name)
 		}
 		if name != "" {
 			nameDb = append(nameDb, simpleUserInfo{name: name, uid: uid, gid: gid})
 
 		}
 	}
-	wwlog.Printf(wwlog.DEBUG, fmt.Sprintf("created uid/gid map with %v entries from %s\n", len(nameDb), fileName))
+	wwlog.Debug(fmt.Sprintf("created uid/gid map with %v entries from %s\n", len(nameDb), fileName))
 	return nameDb, nil
 }
 
@@ -259,6 +259,6 @@ func getEntires(fileName string, names []string) ([]string, error) {
 			}
 		}
 	}
-	wwlog.Printf(wwlog.DEBUG, "file: %s, list: %v\n", fileName, list)
+	wwlog.Debug("file: %s, list: %v\n", fileName, list)
 	return list, nil
 }

--- a/internal/pkg/container/util.go
+++ b/internal/pkg/container/util.go
@@ -12,7 +12,7 @@ import (
 
 func ValidName(name string) bool {
 	if !util.ValidString(name, "^[\\w\\-\\.\\:]+$") {
-		wwlog.Printf(wwlog.WARN, "VNFS name has illegal characters: %s\n", name)
+		wwlog.Warn("VNFS name has illegal characters: %s\n", name)
 		return false
 	}
 	return true
@@ -25,7 +25,7 @@ func ListSources() ([]string, error) {
 	if err != nil {
 		return ret, errors.New("Could not create VNFS source parent directory: " + SourceParentDir())
 	}
-	wwlog.Printf(wwlog.DEBUG, "Searching for VNFS Rootfs directories: %s\n", SourceParentDir())
+	wwlog.Debug("Searching for VNFS Rootfs directories: %s\n", SourceParentDir())
 
 	sources, err := ioutil.ReadDir(SourceParentDir())
 	if err != nil {
@@ -33,7 +33,7 @@ func ListSources() ([]string, error) {
 	}
 
 	for _, source := range sources {
-		wwlog.Printf(wwlog.VERBOSE, "Found VNFS source: %s\n", source.Name())
+		wwlog.Verbose("Found VNFS source: %s\n", source.Name())
 
 		if !ValidName(source.Name()) {
 			continue
@@ -57,7 +57,7 @@ func ValidSource(name string) bool {
 	}
 
 	if !util.IsDir(fullPath) {
-		wwlog.Printf(wwlog.VERBOSE, "Location is not a VNFS source directory: %s\n", name)
+		wwlog.Verbose("Location is not a VNFS source directory: %s\n", name)
 		return false
 	}
 
@@ -67,6 +67,6 @@ func ValidSource(name string) bool {
 func DeleteSource(name string) error {
 	fullPath := SourceDir(name)
 
-	wwlog.Printf(wwlog.VERBOSE, "Removing path: %s\n", fullPath)
+	wwlog.Verbose("Removing path: %s\n", fullPath)
 	return os.RemoveAll(fullPath)
 }

--- a/internal/pkg/node/constructors.go
+++ b/internal/pkg/node/constructors.go
@@ -24,19 +24,19 @@ func init() {
 func New() (NodeYaml, error) {
 	var ret NodeYaml
 
-	wwlog.Printf(wwlog.VERBOSE, "Opening node configuration file: %s\n", ConfigFile)
+	wwlog.Verbose("Opening node configuration file: %s\n", ConfigFile)
 	data, err := ioutil.ReadFile(ConfigFile)
 	if err != nil {
 		return ret, err
 	}
 
-	wwlog.Printf(wwlog.DEBUG, "Unmarshaling the node configuration\n")
+	wwlog.Debug("Unmarshaling the node configuration\n")
 	err = yaml.Unmarshal(data, &ret)
 	if err != nil {
 		return ret, err
 	}
 
-	wwlog.Printf(wwlog.DEBUG, "Returning node object\n")
+	wwlog.Debug("Returning node object\n")
 
 	return ret, nil
 }
@@ -54,11 +54,11 @@ func (config *NodeYaml) FindAllNodes() ([]NodeInfo, error) {
 			return ret, err
 		}
 	*/
-	wwlog.Printf(wwlog.DEBUG, "Finding all nodes...\n")
+	wwlog.Debug("Finding all nodes...\n")
 	for nodename, node := range config.Nodes {
 		var n NodeInfo
 
-		wwlog.Printf(wwlog.DEBUG, "In node loop: %s\n", nodename)
+		wwlog.Debug("In node loop: %s\n", nodename)
 		n.NetDevs = make(map[string]*NetDevEntry)
 		n.Tags = make(map[string]*Entry)
 		n.Kernel = new(KernelEntry)
@@ -125,11 +125,11 @@ func (config *NodeYaml) FindAllNodes() ([]NodeInfo, error) {
 
 		for _, profileName := range n.Profiles.GetSlice() {
 			if _, ok := config.NodeProfiles[profileName]; !ok {
-				wwlog.Printf(wwlog.WARN, "Profile not found for node '%s': %s\n", nodename, profileName)
+				wwlog.Warn("Profile not found for node '%s': %s\n", nodename, profileName)
 				continue
 			}
 			// can't call setFrom() as we have to use SetAlt instead of Set for an Entry
-			wwlog.Printf(wwlog.VERBOSE, "Merging profile into node: %s <- %s\n", nodename, profileName)
+			wwlog.Verbose("Merging profile into node: %s <- %s\n", nodename, profileName)
 			n.SetAltFrom(config.NodeProfiles[profileName], profileName)
 		}
 		ret = append(ret, n)

--- a/internal/pkg/node/datastructure.go
+++ b/internal/pkg/node/datastructure.go
@@ -166,7 +166,7 @@ const NoValue = "--"
 func init() {
 	// Check that nodes.conf is found
 	if !util.IsFile(ConfigFile) {
-		wwlog.Printf(wwlog.WARN, "Missing node configuration file\n")
+		wwlog.Warn("Missing node configuration file\n")
 		// just return silently, as init is also called for bash_completion
 		return
 	}

--- a/internal/pkg/node/modifiers.go
+++ b/internal/pkg/node/modifiers.go
@@ -19,7 +19,7 @@ func (config *NodeYaml) AddNode(nodeID string) (NodeInfo, error) {
 	var node NodeConf
 	var n NodeInfo
 
-	wwlog.Printf(wwlog.VERBOSE, "Adding new node: %s\n", nodeID)
+	wwlog.Verbose("Adding new node: %s\n", nodeID)
 
 	if _, ok := config.Nodes[nodeID]; ok {
 		return n, errors.New("Nodename already exists: " + nodeID)
@@ -43,7 +43,7 @@ func (config *NodeYaml) DelNode(nodeID string) error {
 		return errors.New("Nodename does not exist: " + nodeID)
 	}
 
-	wwlog.Printf(wwlog.VERBOSE, "Deleting node: %s\n", nodeID)
+	wwlog.Verbose("Deleting node: %s\n", nodeID)
 	delete(config.Nodes, nodeID)
 
 	return nil
@@ -69,7 +69,7 @@ func (config *NodeYaml) AddProfile(profileID string) (NodeInfo, error) {
 	var node NodeConf
 	var n NodeInfo
 
-	wwlog.Printf(wwlog.VERBOSE, "Adding new profile: %s\n", profileID)
+	wwlog.Verbose("Adding new profile: %s\n", profileID)
 
 	if _, ok := config.NodeProfiles[profileID]; ok {
 		return n, errors.New("Profile name already exists: " + profileID)
@@ -88,7 +88,7 @@ func (config *NodeYaml) DelProfile(profileID string) error {
 		return errors.New("Profile does not exist: " + profileID)
 	}
 
-	wwlog.Printf(wwlog.VERBOSE, "Deleting profile: %s\n", profileID)
+	wwlog.Verbose("Deleting profile: %s\n", profileID)
 	delete(config.NodeProfiles, profileID)
 
 	return nil
@@ -130,7 +130,7 @@ func (config *NodeYaml) Persist() error {
 
 	file, err := os.OpenFile(ConfigFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "%s\n", err)
+		wwlog.Error("%s\n", err)
 		os.Exit(1)
 	}
 

--- a/internal/pkg/overlay/datastructure.go
+++ b/internal/pkg/overlay/datastructure.go
@@ -44,17 +44,17 @@ func InitStruct(nodeInfo node.NodeInfo) TemplateStruct {
 	var tstruct TemplateStruct
 	controller, err := warewulfconf.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "%s\n", err)
+		wwlog.Error("%s\n", err)
 		os.Exit(1)
 	}
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "%s\n", err)
+		wwlog.Error("%s\n", err)
 		os.Exit(1)
 	}
 	allNodes, err := nodeDB.FindAllNodes()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "%s\n", err)
+		wwlog.Error("%s\n", err)
 		os.Exit(1)
 	}
 	// init some convininence vars

--- a/internal/pkg/overlay/funcmap.go
+++ b/internal/pkg/overlay/funcmap.go
@@ -22,10 +22,10 @@ func templateFileInclude(inc string) string {
 	if !strings.HasPrefix(inc, "/") {
 		inc = path.Join(buildconfig.SYSCONFDIR(), "warewulf", inc)
 	}
-	wwlog.Printf(wwlog.DEBUG, "Including file into template: %s\n", inc)
+	wwlog.Debug("Including file into template: %s\n", inc)
 	content, err := ioutil.ReadFile(inc)
 	if err != nil {
-		wwlog.Printf(wwlog.VERBOSE, "Could not include file into template: %s\n", err)
+		wwlog.Verbose("Could not include file into template: %s\n", err)
 	}
 	return strings.TrimSuffix(string(content), "\n")
 }
@@ -39,7 +39,7 @@ func templateFileBlock(inc string, abortStr string) (string, error) {
 	if !strings.HasPrefix(inc, "/") {
 		inc = path.Join(buildconfig.SYSCONFDIR(), "warewulf", inc)
 	}
-	wwlog.Printf(wwlog.DEBUG, "Including file block into template: %s\n", inc)
+	wwlog.Debug("Including file block into template: %s\n", inc)
 	readFile, err := os.Open(inc)
 	if err != nil {
 		return "", err
@@ -72,31 +72,31 @@ Reads a file relative to given container.
 Templates in the file are no evaluated.
 */
 func templateContainerFileInclude(containername string, filepath string) string {
-	wwlog.Printf(wwlog.VERBOSE, "Including file from Container into template: %s:%s\n", containername, filepath)
+	wwlog.Verbose("Including file from Container into template: %s:%s\n", containername, filepath)
 
 	if containername == "" {
-		wwlog.Printf(wwlog.WARN, "Container is not defined for node: %s\n", filepath)
+		wwlog.Warn("Container is not defined for node: %s\n", filepath)
 		return ""
 	}
 
 	if !container.ValidSource(containername) {
-		wwlog.Printf(wwlog.WARN, "Template requires file(s) from non-existant container: %s:%s\n", containername, filepath)
+		wwlog.Warn("Template requires file(s) from non-existant container: %s:%s\n", containername, filepath)
 		return ""
 	}
 
 	containerDir := container.RootFsDir(containername)
 
-	wwlog.Printf(wwlog.DEBUG, "Including file from container: %s:%s\n", containerDir, filepath)
+	wwlog.Debug("Including file from container: %s:%s\n", containerDir, filepath)
 
 	if !util.IsFile(path.Join(containerDir, filepath)) {
-		wwlog.Printf(wwlog.WARN, "Requested file from container does not exist: %s:%s\n", containername, filepath)
+		wwlog.Warn("Requested file from container does not exist: %s:%s\n", containername, filepath)
 		return ""
 	}
 
 	content, err := ioutil.ReadFile(path.Join(containerDir, filepath))
 
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Template include failed: %s\n", err)
+		wwlog.Error("Template include failed: %s\n", err)
 	}
 	return strings.TrimSuffix(string(content), "\n")
 }

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -200,11 +200,11 @@ func BuildOverlayIndir(nodeInfo node.NodeInfo, overlayNames []string, outputDir 
 		return errors.Errorf("overlay names contains illegal characters: %v", overlayNames)
 	}
 
-	wwlog.Printf(wwlog.VERBOSE, "Processing node/overlay: %s/%s\n", nodeInfo.Id.Get(), strings.Join(overlayNames, "-"))
+	wwlog.Verbose("Processing node/overlay: %s/%s\n", nodeInfo.Id.Get(), strings.Join(overlayNames, "-"))
 	for _, overlayName := range overlayNames {
 		wwlog.Verbose("Building overlay %s for node %s in %s", overlayName, nodeInfo.Id.Get(), outputDir)
 		overlaySourceDir := OverlaySourceDir(overlayName)
-		wwlog.Printf(wwlog.DEBUG, "Starting to build overlay %s\nChanging directory to OverlayDir: %s\n", overlayName, overlaySourceDir)
+		wwlog.Debug("Starting to build overlay %s\nChanging directory to OverlayDir: %s\n", overlayName, overlaySourceDir)
 		err := os.Chdir(overlaySourceDir)
 		if err != nil {
 			return errors.Wrap(err, "could not change directory to overlay dir")
@@ -376,12 +376,12 @@ func RenderTemplateFile(fileName string, data TemplateStruct) (
 		"dec":          func(i int) int { return i - 1 },
 		"file":         func(str string) string { return fmt.Sprintf("{{ /* file \"%s\" */ }}", str) },
 		"abort": func() string {
-			wwlog.Printf(wwlog.DEBUG, "abort file called in %s\n", fileName)
+			wwlog.Debug("abort file called in %s\n", fileName)
 			writeFile = false
 			return ""
 		},
 		"nobackup": func() string {
-			wwlog.Printf(wwlog.DEBUG, "not backup for %s\n", fileName)
+			wwlog.Debug("not backup for %s\n", fileName)
 			backupFile = false
 			return ""
 		},

--- a/internal/pkg/util/copyfile.go
+++ b/internal/pkg/util/copyfile.go
@@ -11,40 +11,40 @@ import (
 
 func CopyFile(src string, dst string) error {
 
-	wwlog.Printf(wwlog.DEBUG, "Copying '%s' to '%s'\n", src, dst)
+	wwlog.Debug("Copying '%s' to '%s'\n", src, dst)
 
 	// Open source file
 	srcFD, err := os.Open(src)
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not open source file %s: %s\n", src, err)
+		wwlog.Error("Could not open source file %s: %s\n", src, err)
 		return err
 	}
 	defer srcFD.Close()
 
 	srcInfo, err := srcFD.Stat()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not stat source file %s: %s\n", src, err)
+		wwlog.Error("Could not stat source file %s: %s\n", src, err)
 		return err
 	}
 
 	dstFD, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE, srcInfo.Mode())
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not create destination file %s: %s\n", dst, err)
+		wwlog.Error("Could not create destination file %s: %s\n", dst, err)
 		return err
 	}
 	defer dstFD.Close()
 
 	bytes, err := io.Copy(dstFD, srcFD)
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "File copy from %s to %s failed.\n %s\n", src, dst, err)
+		wwlog.Error("File copy from %s to %s failed.\n %s\n", src, dst, err)
 		return err
 	} else {
-		wwlog.Printf(wwlog.DEBUG, "Copied %d bytes from %s to %s.\n", bytes, src, dst)
+		wwlog.Debug("Copied %d bytes from %s to %s.\n", bytes, src, dst)
 	}
 
 	err = CopyUIDGID(src, dst)
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Ownership copy from %s to %s failed.\n %s\n", src, dst, err)
+		wwlog.Error("Ownership copy from %s to %s failed.\n %s\n", src, dst, err)
 		return err
 	}
 	return nil
@@ -54,7 +54,7 @@ func SafeCopyFile(src string, dst string) error {
 	var err error
 	// Don't overwrite existing files -- should add force overwrite switch
 	if _, err = os.Stat(dst); err == nil {
-		wwlog.Printf(wwlog.DEBUG, "Destination file %s exists.\n", dst)
+		wwlog.Debug("Destination file %s exists.\n", dst)
 	} else {
 		err = CopyFile(src, dst)
 	}
@@ -68,7 +68,7 @@ func CopyFiles(source string, dest string) error {
 		}
 
 		if info.IsDir() {
-			wwlog.Printf(wwlog.DEBUG, "Creating directory: %s\n", location)
+			wwlog.Debug("Creating directory: %s\n", location)
 			info, err := os.Stat(source)
 			if err != nil {
 				return err
@@ -84,7 +84,7 @@ func CopyFiles(source string, dest string) error {
 			}
 
 		} else {
-			wwlog.Printf(wwlog.DEBUG, "Writing file: %s\n", location)
+			wwlog.Debug("Writing file: %s\n", location)
 
 			err := CopyFile(location, path.Join(dest, location))
 			if err != nil {

--- a/internal/pkg/warewulfconf/constructors.go
+++ b/internal/pkg/warewulfconf/constructors.go
@@ -37,18 +37,18 @@ func New() (ControllerConf, error) {
 	ret.Nfs = &nfsConf
 	err := defaults.Set(&ret)
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Coult initialize default variables\n")
+		wwlog.Error("Coult initialize default variables\n")
 		return ret, err
 	}
 	// Check if cached config is old before re-reading config file
 	if !cachedConf.current {
-		wwlog.Printf(wwlog.DEBUG, "Opening Warewulf configuration file: %s\n", ConfigFile)
+		wwlog.Debug("Opening Warewulf configuration file: %s\n", ConfigFile)
 		data, err := ioutil.ReadFile(ConfigFile)
 		if err != nil {
-			wwlog.Printf(wwlog.WARN, "Error reading Warewulf configuration file\n")
+			wwlog.Warn("Error reading Warewulf configuration file\n")
 		}
 
-		wwlog.Printf(wwlog.DEBUG, "Unmarshaling the Warewulf configuration\n")
+		wwlog.Debug("Unmarshaling the Warewulf configuration\n")
 		err = yaml.Unmarshal(data, &ret)
 		if err != nil {
 			return ret, err
@@ -63,12 +63,12 @@ func New() (ControllerConf, error) {
 			localIp := conn.LocalAddr().(*net.UDPAddr)
 			if ret.Ipaddr == "" {
 				ret.Ipaddr = localIp.IP.String()
-				wwlog.Printf(wwlog.WARN, "IP address is not configured in warewulfd.conf, using %s\n", ret.Ipaddr)
+				wwlog.Warn("IP address is not configured in warewulfd.conf, using %s\n", ret.Ipaddr)
 			}
 			if ret.Netmask == "" {
 				mask := localIp.IP.DefaultMask()
 				ret.Netmask = fmt.Sprintf("%d.%d.%d.%d", mask[0], mask[1], mask[2], mask[3])
-				wwlog.Printf(wwlog.WARN, "Netmask address is not configured in warewulfd.conf, using %s\n", ret.Netmask)
+				wwlog.Warn("Netmask address is not configured in warewulfd.conf, using %s\n", ret.Netmask)
 			}
 		}
 
@@ -84,21 +84,21 @@ func New() (ControllerConf, error) {
 		if ret.Ipaddr6 != "" {
 			_, ipv6net, err := net.ParseCIDR(ret.Ipaddr6)
 			if err != nil {
-				wwlog.Printf(wwlog.ERROR, "Invalid ipv6 address specified, mut be CIDR notation: %s\n", ret.Ipaddr6)
+				wwlog.Error("Invalid ipv6 address specified, mut be CIDR notation: %s\n", ret.Ipaddr6)
 				return ret, errors.New("invalid ipv6 network")
 			}
 			if msize, _ := ipv6net.Mask.Size(); msize > 64 {
-				wwlog.Printf(wwlog.ERROR, "ipv6 mask size must be smaller than 64\n")
+				wwlog.Error("ipv6 mask size must be smaller than 64\n")
 				return ret, errors.New("invalid ipv6 network size")
 			}
 		}
 
-		wwlog.Printf(wwlog.DEBUG, "Returning warewulf config object\n")
+		wwlog.Debug("Returning warewulf config object\n")
 		cachedConf = ret
 		cachedConf.current = true
 
 	} else {
-		wwlog.Printf(wwlog.DEBUG, "Returning cached warewulf config object\n")
+		wwlog.Debug("Returning cached warewulf config object\n")
 		// If cached struct isn't empty, use it as the return value
 		ret = cachedConf
 	}

--- a/internal/pkg/warewulfconf/datastructure.go
+++ b/internal/pkg/warewulfconf/datastructure.go
@@ -68,12 +68,12 @@ func (s *NfsConf) Unmarshal(unmarshal func(interface{}) error) error {
 
 func init() {
 	if !util.IsFile(ConfigFile) {
-		wwlog.Printf(wwlog.ERROR, "Configuration file not found: %s\n", ConfigFile)
+		wwlog.Error("Configuration file not found: %s\n", ConfigFile)
 		// fail silently as this also called by bash_completion
 	}
 	_, err := New()
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Could not read Warewulf configuration file: %s\n", err)
+		wwlog.Error("Could not read Warewulf configuration file: %s\n", err)
 	}
 }
 

--- a/internal/pkg/warewulfconf/modifiers.go
+++ b/internal/pkg/warewulfconf/modifiers.go
@@ -16,7 +16,7 @@ func (controller *ControllerConf) Persist() error {
 
 	file, err := os.OpenFile(ConfigFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "%s\n", err)
+		wwlog.Error("%s\n", err)
 		os.Exit(1)
 	}
 
@@ -24,7 +24,7 @@ func (controller *ControllerConf) Persist() error {
 
 	_, err = file.WriteString(string(out)+"\n")
 	if err != nil {
-		wwlog.Printf(wwlog.ERROR, "Unable to write to warewulf.conf\n")
+		wwlog.Error("Unable to write to warewulf.conf\n")
 		return err
 	}
 


### PR DESCRIPTION
wwlog provides named loggers for each level, which requires less code and is clearer than wwlog.Printf. The code has included a mix of both, but this commit consolidates existing code on the per-level functions.

Signed-off-by: Jonathon Anderson <janderson@ciq.co>