### PR TITLE
remove exit from ssh_setup.*sh

### DIFF
--- a/internal/pkg/util/copyfile.go
+++ b/internal/pkg/util/copyfile.go
@@ -27,7 +27,7 @@ func CopyFile(src string, dst string) error {
 		return err
 	}
 
-	dstFD, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE, srcInfo.Mode())
+	dstFD, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, srcInfo.Mode())
 	if err != nil {
 		wwlog.Error("Could not create destination file %s: %s\n", dst, err)
 		return err

--- a/overlays/host/etc/profile.d/ssh_setup.csh
+++ b/overlays/host/etc/profile.d/ssh_setup.csh
@@ -5,12 +5,7 @@
 
 set _UID=`id -u`
 
-if ( $_UID < 500 && $_UID != 0 ) then
-    exit
-endif
-
-
-if ( ! -f "$HOME/.ssh/config" && ! -f "$HOME/.ssh/cluster" ) then
+if ( ( $_UID > 500 || $_UID == 0 ) && ( ! -f "$HOME/.ssh/config" && ! -f "$HOME/.ssh/cluster" ) ) then
     echo "Configuring SSH for cluster access"
     install -d -m 700 $HOME/.ssh
     ssh-keygen -t rsa -f $HOME/.ssh/cluster -N '' -C "Warewulf Cluster key" >& /dev/null

--- a/overlays/host/etc/profile.d/ssh_setup.sh
+++ b/overlays/host/etc/profile.d/ssh_setup.sh
@@ -13,12 +13,7 @@
 
 _UID=`id -u`
 
-if [ $_UID -lt 500 -a $_UID -ne 0 ]; then
-    exit
-fi
-
-
-if [ ! -f "$HOME/.ssh/config" -a ! -f "$HOME/.ssh/cluster" ]; then
+if [ $_UID -ge 500 -o $_UID -eq 0 ] && [ ! -f "$HOME/.ssh/config" -a ! -f "$HOME/.ssh/cluster" ]; then
     echo "Configuring SSH for cluster access"
     install -d -m 700 $HOME/.ssh
     ssh-keygen -t rsa -f $HOME/.ssh/cluster -N '' -C "Warewulf Cluster key" > /dev/null 2>&1


### PR DESCRIPTION
The `exit` statement in `overlay/host/etc/profile.d/ssh_setup.*sh` prevents system user from logging in. Instead, `if` based script is safe under both sourced and execed scenario.
The second commit fixes that destination file is not properly truncated when building the overlay. This can be easily tested with adding `#test` to `/etc/profile.d/ssh_setup.sh` and `#-` to `overlay/host/etc/profile.d/ssh_setup.sh`. Then run `wwctl overlay build -H` and check if the last line in `/etc/profile.d/ssh_setup.sh` becoms `#-est`