### PR TITLE
Fix output of wwctl container show

### DIFF
--- a/internal/app/wwctl/container/show/main.go
+++ b/internal/app/wwctl/container/show/main.go
@@ -24,8 +24,12 @@ func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 	if !ShowAll {
 		fmt.Printf("%s\n", r.Rootfs)
 	} else {
+		kernelVersion := r.KernelVersion
+		if kernelVersion == "" {
+			kernelVersion = "not found"
+		}
 		fmt.Printf("Name: %s\n", r.Name)
-		fmt.Printf("KernelVersion: %s\n", r.KernelVersion)
+		fmt.Printf("KernelVersion: %s\n", kernelVersion)
 		fmt.Printf("Rootfs: %s\n", r.Rootfs)
 		fmt.Printf("Nr nodes: %d\n", len(r.Nodes))
 		fmt.Printf("Nodes: %s\n", r.Nodes)

--- a/internal/app/wwctl/container/show/main.go
+++ b/internal/app/wwctl/container/show/main.go
@@ -25,6 +25,7 @@ func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 		fmt.Printf("%s\n", r.Rootfs)
 	} else {
 		fmt.Printf("Name: %s\n", r.Name)
+		fmt.Printf("KernelVersion: %s\n", r.KernelVersion)
 		fmt.Printf("Rootfs: %s\n", r.Rootfs)
 		fmt.Printf("Nr nodes: %d\n", len(r.Nodes))
 		fmt.Printf("Nodes: %s\n", r.Nodes)

--- a/internal/pkg/api/container/container.go
+++ b/internal/pkg/api/container/container.go
@@ -315,9 +315,6 @@ func ContainerShow(csp *wwapiv1.ContainerShowParameter) (response *wwapiv1.Conta
 	rootFsDir := container.RootFsDir(containerName)
 
 	kernelVersion := container.KernelVersion(containerName)
-	if kernelVersion == "" {
-		kernelVersion = "not found"
-	}
 
 	nodeDB, err := node.New()
 	if err != nil {

--- a/internal/pkg/api/container/container.go
+++ b/internal/pkg/api/container/container.go
@@ -315,9 +315,8 @@ func ContainerShow(csp *wwapiv1.ContainerShowParameter) (response *wwapiv1.Conta
 	rootFsDir := container.RootFsDir(containerName)
 
 	kernelVersion := container.KernelVersion(containerName)
-	if kernelVersion != "" {
+	if kernelVersion == "" {
 		kernelVersion = "not found"
-		fmt.Printf("Kernelversion: %s\n", kernelVersion)
 	}
 
 	nodeDB, err := node.New()
@@ -333,7 +332,6 @@ func ContainerShow(csp *wwapiv1.ContainerShowParameter) (response *wwapiv1.Conta
 	var nodeList []string
 	for _, n := range nodes {
 		if n.ContainerName.Get() == containerName {
-
 			nodeList = append(nodeList, n.Id.Get())
 		}
 	}


### PR DESCRIPTION
Commit d8cd6049 introduced erroneous output coming from an inner function of container show, and (seemingly) erroneously replaces valid kernel versions with "not found". This commit fixes both of those issues, and moves the output to the outer cli function.