### PR TITLE
Use primary netdev for ssh

### DIFF
--- a/internal/app/wwctl/ssh/main.go
+++ b/internal/app/wwctl/ssh/main.go
@@ -40,21 +40,25 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, node := range nodes {
-
-		if _, ok := node.NetDevs["default"]; !ok {
-			fmt.Fprintf(os.Stderr, "%s: Default network device doesn't exist\n", node.Id.Get())
+		var primaryNet string
+		for netName := range node.NetDevs {
+			if node.NetDevs[netName].Primary.GetB() {
+				primaryNet = netName
+			}
+		}
+		if primaryNet == "" {
+			fmt.Fprintf(os.Stderr, "%s: Primary network device doesn't exist\n", node.Id.Get())
 			continue
 		}
-
-		if node.NetDevs["default"].Ipaddr.Get() == "" {
-			fmt.Fprintf(os.Stderr, "%s: Default network IP address not configured\n", node.Id.Get())
+		if node.NetDevs[primaryNet].Ipaddr.Get() == "" {
+			fmt.Fprintf(os.Stderr, "%s: Primary  network IP address not configured\n", node.Id.Get())
 			continue
 		}
 
 		nodename := node.Id.Print()
 		var command []string
 
-		command = append(command, node.NetDevs["default"].Ipaddr.Get())
+		command = append(command, node.NetDevs[primaryNet].Ipaddr.Get())
 		command = append(command, args[1:]...)
 
 		batchpool.Submit(func() {

--- a/internal/app/wwctl/ssh/main.go
+++ b/internal/app/wwctl/ssh/main.go
@@ -38,20 +38,11 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		cmd.Usage()
 		os.Exit(1)
 	}
-	globalPrimary := ""
 	for _, node := range nodes {
 		var primaryNet string
-		if _, ok := node.NetDevs[globalPrimary]; ok {
-			if node.NetDevs[globalPrimary].Primary.GetB() {
-				primaryNet = globalPrimary
-			}
-		}
 		for netName := range node.NetDevs {
 			if node.NetDevs[netName].Primary.GetB() {
 				primaryNet = netName
-				if globalPrimary == "" {
-					globalPrimary = netName
-				}
 				break
 			}
 		}

--- a/internal/app/wwctl/ssh/main.go
+++ b/internal/app/wwctl/ssh/main.go
@@ -51,7 +51,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 			continue
 		}
 		if node.NetDevs[primaryNet].Ipaddr.Get() == "" {
-			wwlog.Error("%s: Primary  network IP address not configured\n", node.Id.Get())
+			wwlog.Error("%s: Primary network IP address not configured\n", node.Id.Get())
 			continue
 		}
 

--- a/internal/app/wwctl/ssh/main.go
+++ b/internal/app/wwctl/ssh/main.go
@@ -38,20 +38,29 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		cmd.Usage()
 		os.Exit(1)
 	}
-
+	globalPrimary := ""
 	for _, node := range nodes {
 		var primaryNet string
+		if _, ok := node.NetDevs[globalPrimary]; ok {
+			if node.NetDevs[globalPrimary].Primary.GetB() {
+				primaryNet = globalPrimary
+			}
+		}
 		for netName := range node.NetDevs {
 			if node.NetDevs[netName].Primary.GetB() {
 				primaryNet = netName
+				if globalPrimary == "" {
+					globalPrimary = netName
+				}
+				break
 			}
 		}
 		if primaryNet == "" {
-			fmt.Fprintf(os.Stderr, "%s: Primary network device doesn't exist\n", node.Id.Get())
+			wwlog.Error("%s: Primary network device doesn't exist\n", node.Id.Get())
 			continue
 		}
 		if node.NetDevs[primaryNet].Ipaddr.Get() == "" {
-			fmt.Fprintf(os.Stderr, "%s: Primary  network IP address not configured\n", node.Id.Get())
+			wwlog.Error("%s: Primary  network IP address not configured\n", node.Id.Get())
 			continue
 		}
 


### PR DESCRIPTION
`wwctl ssh` has the "default" network interface hardcoded. Use the interface with the primary field instead.

@anderbubble can you please review
