### PR TITLE
Add execreload and execstop to warewulfd.service.

### DIFF
--- a/include/systemd/warewulfd.service.in
+++ b/include/systemd/warewulfd.service.in
@@ -10,6 +10,9 @@ User=root
 Group=root
 
 ExecStart=@BINDIR@/wwctl server start
+ExecReload=/usr/bin/wwctl server reload
+ExecStop=/usr/bin/wwctl server stop
+
 PIDFile=/var/run/warewulfd.pid
 Restart=always
 


### PR DESCRIPTION
We discussed this a while back and I volunteered to look into it, but I didn't expect it to be this easy to do. Putting in this PR in case this is the right thing, but I have a faint recollection we discussed changing how warewulfd is started so that logs would go to stdout/stderr and get picked up by `systemd`? 