### PR TITLE
[CI/CD] Check owner of repo before running documentaton GH action

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   publish:
+    if: ${{ github.repository_owner == 'hcpng' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
If a fork is running GH actions, do not create the static documentation and try to push to the warewulf documentation repo.

Signed-off-by: Michael L. Young <myoung@ciq.co>