### PR TITLE
Fix use of uninitialised Tags map

### DIFF
--- a/internal/pkg/overlay/datastructure.go
+++ b/internal/pkg/overlay/datastructure.go
@@ -83,6 +83,7 @@ func InitStruct(nodeInfo node.NodeInfo) TemplateStruct {
 	dt := time.Now()
 	tstruct.BuildTime = dt.Format("01-02-2006 15:04:05 MST")
 	tstruct.BuildTimeUnix = strconv.FormatInt(dt.Unix(), 10)
+	tstruct.NodeConf.Tags = map[string]string{}
 	tstruct.NodeConf.GetFrom(nodeInfo)
 	// FIXME: Set ipCIDR address at this point, will fail with
 	// invalid ipv4 addr


### PR DESCRIPTION
NodeConf.Tags doesn't get initialized and panics when building an overlay that has a .ww template file for a node which has tags set.