### PR TITLE
Correct host overlay processing during configure

### DIFF
--- a/internal/pkg/configure/hostfile.go
+++ b/internal/pkg/configure/hostfile.go
@@ -15,7 +15,8 @@ import (
 Creates '/etc/hosts' from the host template.
 */
 func Hostfile() error {
-	if !(util.IsFile(path.Join(overlay.OverlaySourceDir("host"), "/host/etc/hosts.ww"))) {
+	hostTemplate := path.Join(overlay.OverlaySourceDir("host"), "/etc/hosts.ww")
+	if !(util.IsFile(hostTemplate)) {
 		wwlog.Error("'the overlay template '/etc/hosts.ww' does not exists in 'host' overlay")
 		os.Exit(1)
 	}
@@ -24,13 +25,13 @@ func Hostfile() error {
 	hostname, _ := os.Hostname()
 	nodeInfo.Id.Set(hostname)
 	buffer, backupFile, writeFile, err := overlay.RenderTemplateFile(
-		path.Join(overlay.OverlaySourceDir("host"), "/host/etc/hosts.ww"),
+		hostTemplate,
 		tstruct)
 	if err != nil {
 		wwlog.Error("%s", err)
 		os.Exit(1)
 	}
-	info, err := os.Stat(path.Join(overlay.OverlaySourceDir("host"), "/host/etc/hosts.ww"))
+	info, err := os.Stat(hostTemplate)
 	if err != nil {
 		wwlog.Error("%s", err)
 		os.Exit(1)

--- a/internal/pkg/configure/hostfile.go
+++ b/internal/pkg/configure/hostfile.go
@@ -20,10 +20,11 @@ func Hostfile() error {
 		wwlog.Error("'the overlay template '/etc/hosts.ww' does not exists in 'host' overlay")
 		os.Exit(1)
 	}
-	var nodeInfo node.NodeInfo
-	tstruct := overlay.InitStruct(nodeInfo)
+
+	nodeInfo := node.NewInfo()
 	hostname, _ := os.Hostname()
 	nodeInfo.Id.Set(hostname)
+	tstruct := overlay.InitStruct(nodeInfo)
 	buffer, backupFile, writeFile, err := overlay.RenderTemplateFile(
 		hostTemplate,
 		tstruct)

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -81,14 +81,11 @@ func BuildSpecificOverlays(nodes []node.NodeInfo, overlayNames []string) error {
 Build overlay for the host, so no argument needs to be given
 */
 func BuildHostOverlay() error {
-	var host node.NodeInfo
-	host.Kernel = new(node.KernelEntry)
-	host.Ipmi = new(node.IpmiEntry)
-	var idEntry node.Entry
+	host := node.NewInfo()
 	hostname, _ := os.Hostname()
+	host.Id.Set(hostname)
+
 	wwlog.Info("Building overlay for %s: host", hostname)
-	idEntry.Set(hostname)
-	host.Id = idEntry
 	hostdir := OverlaySourceDir("host")
 	stats, err := os.Stat(hostdir)
 	if err != nil {


### PR DESCRIPTION
wwctl configure hostfile was using the /host/ path twice, causing it to look in the wrong place for /etc/hosts.ww

Fixes #571 

Signed-off-by: Jonathon Anderson <janderson@ciq.co>