### PR TITLE
Env var to identify when in container shell

### DIFF
--- a/internal/app/wwctl/container/shell/main.go
+++ b/internal/app/wwctl/container/shell/main.go
@@ -40,7 +40,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
 
-	os.Setenv("WW_CONTAINER_SHELL", "1")
+	os.Setenv("WW_CONTAINER_SHELL", containerName)
 
 	if err := c.Run(); err != nil {
 		fmt.Println(err)

--- a/internal/app/wwctl/container/shell/main.go
+++ b/internal/app/wwctl/container/shell/main.go
@@ -40,7 +40,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
 
-	os.Setenv("WW_CONTAINER_SHELL", "true")
+	os.Setenv("WW_CONTAINER_SHELL", "1")
 
 	if err := c.Run(); err != nil {
 		fmt.Println(err)

--- a/internal/app/wwctl/container/shell/main.go
+++ b/internal/app/wwctl/container/shell/main.go
@@ -40,6 +40,8 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
 
+	os.Setenv("WW_CONTAINER_SHELL", "true")
+
 	if err := c.Run(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
Set environment variable `WW_CONTAINER_SHELL` to the name of the container when a user shells into it via command `wwctl container shell ...`. 

Resolves #574 