### PR TITLE
VNFS gzip:  fallback to redirected stdout

### DIFF
--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -615,7 +615,8 @@ func FileGz(
 		outStr := string(out[:])
 		if err != nil && strings.HasSuffix(compressor, "gzip") && strings.Contains(outStr, "unrecognized option") {
 			var		gzippedFile *os.File
-			
+			var     gzipStderr io.ReadCloser
+            
 			/* Older version of gzip, try it another way: */
 			wwlog.Verbose("%s does not recognize the --keep flag, trying piped stdout", compressor)
 			
@@ -633,7 +634,7 @@ func FileGz(
 				"--stdout",
 				file )
 			proc.Stdout = gzippedFile
-			gzipStderr, err := proc.StderrPipe()
+			gzipStderr, err = proc.StderrPipe()
 			if err != nil {
 				return errors.Wrapf(err, "Unable to open stderr pipe for compression program: %s", compressor)
 			}

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -596,7 +596,7 @@ func FileGz(
 	compressor, err := exec.LookPath("pigz")
 	if err != nil {
 		wwlog.Verbose("Could not locate PIGZ")
-		compressor, err := exec.LookPath("gzip")
+		compressor, err = exec.LookPath("gzip")
 		if err != nil {
 			wwlog.Verbose("Could not locate GZIP")
 			return errors.Wrapf(err, "No compressor program for image file: %s", file_gz)
@@ -612,12 +612,15 @@ func FileGz(
 
 	out, err := proc.CombinedOutput()
 	if len(out) > 0 {
-		if err != nil && strings.HasSuffix(compressor, "gzip") && strings.Contains(out, "unrecognized option") {
+		outStr := string(out[:])
+		if err != nil && strings.HasSuffix(compressor, "gzip") && strings.Contains(outStr, "unrecognized option") {
+			var		gzippedFile *os.File
+			
 			/* Older version of gzip, try it another way: */
 			wwlog.Verbose("%s does not recognize the --keep flag, trying piped stdout", compressor)
 			
 			/* Open the output file for writing: */
-			gzippedFile, err := os.Create(file_gz)
+			gzippedFile, err = os.Create(file_gz)
 			if err != nil {
 				return errors.Wrapf(err, "Unable to open compressed image file for writing: %s", file_gz)
 			}

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -618,7 +618,7 @@ func FileGz(
 			var     gzipStderr io.ReadCloser
             
 			/* Older version of gzip, try it another way: */
-			wwlog.Verbose("%s does not recognize the --keep flag, trying piped stdout", compressor)
+			wwlog.Verbose("%s does not recognize the --keep flag, trying redirected stdout", compressor)
 			
 			/* Open the output file for writing: */
 			gzippedFile, err = os.Create(file_gz)

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -642,7 +642,7 @@ func FileGz(
 			/* Execute the command: */
 			err = proc.Start()
 			if err != nil {
-				proc.Wait()
+                _ = proc.Wait()
 				gzippedFile.Close()
 				os.Remove(file_gz)
 				err = errors.Wrapf(err, "Unable to successfully execute compression program: %s", compressor)

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -596,11 +596,11 @@ func FileGz(
 	compressor, err := exec.LookPath("pigz")
 	if err != nil {
 		wwlog.Verbose("Could not locate PIGZ")
-        compressor, err := exec.LookPath("gzip")
-        if err != nil {
-            wwlog.Verbose("Could not locate GZIP")
-            return errors.Wrapf(err, "No compressor program for image file: %s", file_gz)
-        }
+		compressor, err := exec.LookPath("gzip")
+		if err != nil {
+			wwlog.Verbose("Could not locate GZIP")
+			return errors.Wrapf(err, "No compressor program for image file: %s", file_gz)
+		}
 	}
 
 	wwlog.Verbose("Using compressor program: %s", compressor)
@@ -612,48 +612,48 @@ func FileGz(
 
 	out, err := proc.CombinedOutput()
 	if len(out) > 0 {
-        if err != nil && strings.HasSuffix(compressor, "gzip") && strings.Contains(out, "unrecognized option") {
-            /* Older version of gzip, try it another way: */
-            wwlog.Verbose("%s does not recognize the --keep flag, trying piped stdout", compressor)
-            
-            /* Open the output file for writing: */
-            gzippedFile, err := os.Create(file_gz)
-            if err != nil {
-                return errors.Wrapf(err, "Unable to open compressed image file for writing: %s", file_gz)
-            }
-            
-            /* We'll execute gzip with output to stdout and attach stdout to the compressed file we just
-               created:
-             */
-            proc = exec.Command(
-                compressor,
-                "--stdout",
-                file )
-            proc.Stdout = gzippedFile
-            gzipStderr, err := proc.StderrPipe()
-            if err != nil {
-                return errors.Wrapf(err, "Unable to open stderr pipe for compression program: %s", compressor)
-            }
-            
-            /* Execute the command: */
-            err = proc.Start()
-            if err != nil {
-                proc.Wait()
-                gzippedFile.Close()
-                os.Remove(file_gz)
-                err = errors.Wrapf(err, "Unable to successfully execute compression program: %s", compressor)
-            } else {
-                err = proc.Wait()
-                gzippedFile.Close()
-                if err != nil {
-                    os.Remove(file_gz)
-                    err = errors.Wrapf(err, "Unable to successfully create compressed image file: %s", file_gz)
-                } else {
-                    wwlog.Verbose("Successfully compressed image file: %s", file_gz)
-                }
-            }
-            out, _ = io.ReadAll(gzipStderr)
-        }
+		if err != nil && strings.HasSuffix(compressor, "gzip") && strings.Contains(out, "unrecognized option") {
+			/* Older version of gzip, try it another way: */
+			wwlog.Verbose("%s does not recognize the --keep flag, trying piped stdout", compressor)
+			
+			/* Open the output file for writing: */
+			gzippedFile, err := os.Create(file_gz)
+			if err != nil {
+				return errors.Wrapf(err, "Unable to open compressed image file for writing: %s", file_gz)
+			}
+			
+			/* We'll execute gzip with output to stdout and attach stdout to the compressed file we just
+			   created:
+			 */
+			proc = exec.Command(
+				compressor,
+				"--stdout",
+				file )
+			proc.Stdout = gzippedFile
+			gzipStderr, err := proc.StderrPipe()
+			if err != nil {
+				return errors.Wrapf(err, "Unable to open stderr pipe for compression program: %s", compressor)
+			}
+			
+			/* Execute the command: */
+			err = proc.Start()
+			if err != nil {
+				proc.Wait()
+				gzippedFile.Close()
+				os.Remove(file_gz)
+				err = errors.Wrapf(err, "Unable to successfully execute compression program: %s", compressor)
+			} else {
+				err = proc.Wait()
+				gzippedFile.Close()
+				if err != nil {
+					os.Remove(file_gz)
+					err = errors.Wrapf(err, "Unable to successfully create compressed image file: %s", file_gz)
+				} else {
+					wwlog.Verbose("Successfully compressed image file: %s", file_gz)
+				}
+			}
+			out, _ = io.ReadAll(gzipStderr)
+		}
 		wwlog.Debug(string(out))
 	}
 


### PR DESCRIPTION
The current internal/pkg/util `FileGz()` function properly locates the `pigz` command path using `exec.LookPath()`.  If that command is unavailable, then an info message is emitted and the function uses the string `"gzip"` as the command.  The `--keep` flag is presented to `gzip` to prevent removal of the uncompressed file after successful compression.  But older versions of `gzip` (for example, on CentOS 7) do not grok that flag:

```
   :
Rebuilding container...
INFO   : Created image for VNFS container rocky-8.6: /opt/warewulf/4.3.0/srv/warewulf/container/rocky-8.6.img
VERBOSE: Could not locate PIGZ
VERBOSE: Using gz compressor: gzip
ERROR  : Could not build container rocky-8.6: Failed to compress image for VNFS container rocky-8.6: /opt/warewulf/4.3.0/srv/warewulf/container/rocky-8.6.img.gz: exit status 1
```

```bash
$ gzip --keep
gzip: unrecognized option '--keep'
Try `gzip --help' for more information.
```

This patch introduces code that checks for the text "unrecognized option" on `gzip` failure (since `--keep` is the only flag provided) and in such instances opens the target .gz file itself and associates that file with the stdout for a `gzip --stdout <filename>` command.  The subprocess writes the compressed stream directly to that file:

```
   :
Rebuilding container...
INFO   : Created image for VNFS container rocky-8.6: /opt/warewulf/4.3.0/srv/warewulf/container/rocky-8.6.img
VERBOSE: Could not locate PIGZ
VERBOSE: Using compressor program: /bin/gzip
VERBOSE: /bin/gzip does not recognize the --keep flag, trying redirected stdout
VERBOSE: Successfully compressed image file: /opt/warewulf/4.3.0/srv/warewulf/container/rocky-8.6.img.gz
INFO   : Compressed image for VNFS container rocky-8.6: /opt/warewulf/4.3.0/srv/warewulf/container/rocky-8.6.img.gz
```

```bash
$ ls -l /opt/warewulf/4.3.0/srv/warewulf/container
total 1543537
-rw-r--r-- 1 root root 1080544768 Nov 29 15:11 rocky-8.6.img
-rw-r--r-- 1 root root  498854067 Nov 29 15:12 rocky-8.6.img.gz
```