### PR TITLE
Add --- to the head of FallBackConf

### DIFF
--- a/internal/pkg/node/constructors.go
+++ b/internal/pkg/node/constructors.go
@@ -17,7 +17,7 @@ var ConfigFile string
 var DefaultConfig string
 
 // used as fallback if DefaultConfig can't be read
-var FallBackConf = `
+var FallBackConf = `---
 defaultnode:
   runtime overlay:
   - generic


### PR DESCRIPTION
Why have I done this?

- Because defaults.conf had a starting newline, which bugs me.
- Because moving the first line of FallBackConf looks unlovely.
- Because yaml happens to have a --- document-start syntax.

I completely agree that this is (hopefully) a no-op change; but if anyone else thinks it makes things aesthetically more pleasing, and agrees that it doesn't break anything, go ahead and merge. ^_^

Signed-off-by: Jonathon Anderson <janderson@ciq.co>