### PR TITLE
remove signature from OCI image

### DIFF
--- a/internal/pkg/oci/puller.go
+++ b/internal/pkg/oci/puller.go
@@ -131,8 +131,9 @@ func (p *puller) Pull(ctx context.Context, uri, dst string) (err error) {
 
 	// copy to cache location
 	_, err = copy.Image(ctx, policyCtx, cacheRef, srcRef, &copy.Options{
-		ReportWriter: os.Stdout,
-		SourceCtx:    p.sysCtx,
+		ReportWriter:     os.Stdout,
+		SourceCtx:        p.sysCtx,
+		RemoveSignatures: true,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
cosigned images can't be imported all time, so enforce to remove the signature
