### PR TITLE
Set umask to 0000 while overlays are being built. Fixes #584

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New man page for `defaults.conf` #593
 - New debug overlay template
-- Fix directories within overlays losing group/other write permissions #584
+
+### Fixed
+
+- Directories within overlays no longer lose group/other write permissions #584
 
 ## [4.4.0rc2] 2022-12-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New man page for `defaults.conf` #593
 - New debug overlay template
+- Fix directories within overlays losing group/other write permissions #584
 
 ## [4.4.0rc2] 2022-12-09
 

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"syscall"
 	"text/template"
 
 	"github.com/hpcng/warewulf/internal/pkg/node"
@@ -196,6 +197,9 @@ func BuildOverlayIndir(nodeInfo node.NodeInfo, overlayNames []string, outputDir 
 	if !util.ValidString(strings.Join(overlayNames, ""), "^[a-zA-Z0-9-._:]+$") {
 		return errors.Errorf("overlay names contains illegal characters: %v", overlayNames)
 	}
+
+	// Temporarily set umask to 0000, so directories in the overlay retain permissions
+	defer syscall.Umask(syscall.Umask(0))
 
 	wwlog.Verbose("Processing node/overlay: %s/%s", nodeInfo.Id.Get(), strings.Join(overlayNames, "-"))
 	for _, overlayName := range overlayNames {


### PR DESCRIPTION
## Description of the Pull Request (PR):

`os.MkdirAll(path.Join(outputDir, location), info.Mode())` respects the set umask, so any write group/other write permissions on directories within an overlay currently get discarded.

Fix:
Set the umask to `0000` only while building overlays.


### This fixes or addresses the following GitHub issues:

 - Fixes #584