### PR TITLE
Correct header for overlay list -al

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- The correct header is now displayed when `-al` flags are specified to overlay
+  list.
+
 ## [4.4.0] 2023-01-18
 
 ### Added

--- a/internal/app/wwctl/overlay/list/main.go
+++ b/internal/app/wwctl/overlay/list/main.go
@@ -39,16 +39,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 			files := util.FindFiles(path)
 
 			wwlog.Debug("Iterating overlay path: %s", path)
-			if ListContents {
-				var fileCount int
-				for file := range files {
-					fmt.Printf("%-30s /%-12s\n", name, files[file])
-					fileCount++
-				}
-				if fileCount == 0 {
-					fmt.Printf("%-30s %-12d\n", name, 0)
-				}
-			} else if ListLong {
+			if ListLong {
 				for file := range files {
 					s, err := os.Stat(files[file])
 					if err != nil {
@@ -61,7 +52,15 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 					sys := s.Sys()
 
 					fmt.Printf("%v %5d %-5d %-18s /%s\n", perms, sys.(*syscall.Stat_t).Uid, sys.(*syscall.Stat_t).Gid, overlays[o], files[file])
-
+				}
+			} else if ListContents {
+				var fileCount int
+				for file := range files {
+					fmt.Printf("%-30s /%-12s\n", name, files[file])
+					fileCount++
+				}
+				if fileCount == 0 {
+					fmt.Printf("%-30s %-12d\n", name, 0)
 				}
 			} else {
 				fmt.Printf("%-30s %-12d\n", name, len(files))


### PR DESCRIPTION
## Description of the Pull Request (PR):

Causes the correct header to be displayed when both `-a` and `-l` flags are used together.


### This fixes or addresses the following GitHub issues:

 - Fixes #485


#### Before submitting a PR, make sure you have done the following:

- Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/development/contributing/contributing.html)
- Added changes to the [CHANGELOG](https://github.com/hpcng/warewulf/blob/development/CHANGELOG.md) if necessary
- Updated [userdocs](https://github.com/hpcng/warewulf/tree/development/userdocs) if necessary
- Based this PR against the appropriate branch (typically [development](https://github.com/hpcng/warewulf/tree/development/userdocs))
- Added myself as a contributor to the [Contributors File](https://github.com/hpcng/warewulf/blob/development/CONTRIBUTORS.md
