### PR TITLE
set the primary network in NodeInfo not in NetDev

### DIFF
--- a/internal/pkg/node/constructors.go
+++ b/internal/pkg/node/constructors.go
@@ -134,13 +134,6 @@ func (config *NodeYaml) FindAllNodes() ([]NodeInfo, error) {
 		for _, netdev := range n.NetDevs {
 			netdev.SetDefFrom(defConfNet)
 		}
-		// set default/primary network is just one network exist
-		if len(n.NetDevs) == 1 {
-			// only way to get the key
-			for key := range node.NetDevs {
-				n.NetDevs[key].Primary.SetDefaultB(true)
-			}
-		}
 		// backward compatibility
 		n.Ipmi.Ipaddr.Set(node.IpmiIpaddr)
 		n.Ipmi.Netmask.Set(node.IpmiNetmask)
@@ -177,6 +170,20 @@ func (config *NodeYaml) FindAllNodes() ([]NodeInfo, error) {
 			// can't call setFrom() as we have to use SetAlt instead of Set for an Entry
 			wwlog.Verbose("Merging profile into node: %s <- %s", nodename, profileName)
 			n.SetAltFrom(config.NodeProfiles[profileName], profileName)
+		}
+		// set default/primary network is just one network exist
+		if len(n.NetDevs) >= 1 {
+			tmpNets := make([]string, 0, len(n.NetDevs))
+			for key := range node.NetDevs {
+				tmpNets = append(tmpNets, key)
+			}
+			sort.Strings(tmpNets)
+			// if a value is present in profile or node, default is not visible
+			wwlog.Debug("%s setting primary network device: %s", n.Id.Get(), tmpNets[0])
+			n.PrimaryNetDev.SetDefault(tmpNets[0])
+		}
+		if dev, ok := n.NetDevs[n.PrimaryNetDev.Get()]; ok {
+			dev.Primary.SetDefaultB(true)
 		}
 		ret = append(ret, n)
 	}

--- a/internal/pkg/node/datastructure.go
+++ b/internal/pkg/node/datastructure.go
@@ -48,6 +48,7 @@ type NodeConf struct {
 	Tags           map[string]string   `yaml:"tags,omitempty" lopt:"tagadd" comment:"base key"`
 	TagsDel        []string            `yaml:"tagsdel,omitempty" lopt:"tagdel" comment:"remove this tags"` // should not go to disk only to wire
 	Keys           map[string]string   `yaml:"keys,omitempty"`                                             // Reverse compatibility
+	PrimaryNetDev  string              `yaml:"primary network,omitempty" lopt:"primarynet" sopt:"p" comment:"Set the primary network interface"`
 }
 
 type IpmiConf struct {
@@ -80,8 +81,6 @@ type NetDevs struct {
 	Netmask string            `yaml:"netmask,omitempty" lopt:"netmask" sopt:"M" comment:"Set the networks netmask"`
 	Gateway string            `yaml:"gateway,omitempty" lopt:"gateway" sopt:"G" comment:"Set the node's network device gateway"`
 	MTU     string            `yaml:"mtu,omitempty" lopt:"mtu" comment:"Set the mtu"`
-	Primary string            `yaml:"primary,omitempty" lopt:"primary" comment:"Enable/disable network device as primary (yes/no)"`
-	Default string            `yaml:"default,omitempty"` /* backward compatibility */
 	Tags    map[string]string `yaml:"tags,omitempty" lopt:"nettagadd" comment:"network tags"`
 	TagsDel []string          `yaml:"tagsdel,omitempty" lopt:"nettagdel" comment:"delete network tags"` // should not go to disk only to wire
 }
@@ -122,6 +121,7 @@ type NodeInfo struct {
 	Kernel         *KernelEntry
 	Ipmi           *IpmiEntry
 	Profiles       Entry
+	PrimaryNetDev  Entry
 	NetDevs        map[string]*NetDevEntry
 	Tags           map[string]*Entry
 }


### PR DESCRIPTION
Prior the primary was a boolean attribute of NetDev, so several
NetDevs could have been primay. Setting is as a sting in NodeConf
assures that only one network could be primary.
If no primary network is set, a valid altvalue will be set.
