### PR TITLE
Fix newline when printing AllNodes

### DIFF
--- a/overlays/debug/warewulf/template-variables.md.ww
+++ b/overlays/debug/warewulf/template-variables.md.ww
@@ -165,4 +165,4 @@ data from other structures.
     - Primary: {{ $netdev.Primary.Get }}
     - Tags: {{ range $key, $value := $netdev.Tags }}{{ $key }}={{ $value.Get }} {{ end }}
 {{- end }}
-{{- end }}
+{{ end }}


### PR DESCRIPTION
Fixes a bug in the debug template that was causing the next node to be printed on the same line as the last line of the previous node.

Previously:

```yaml
- AllNodes[0]:
  - Id: asdf1
[...]
    - Tags: - AllNodes[1]:
  - Id: n1
```

Now:

```yaml
- AllNodes[0]:
  - Id: asdf1
[...]
    - Tags: 
- AllNodes[1]:
  - Id: n1
```