### PR TITLE
Emit canonical hostnames first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The correct header is now displayed when `-al` flags are specified to overlay
   list.
 
+### Changed
+
+- The primary hostname and warewulf server fqdn are now the canonical name in
+  `/etc/hosts`
+
 ## [4.4.0] 2023-01-18
 
 ### Added

--- a/overlays/generic/etc/hosts.ww
+++ b/overlays/generic/etc/hosts.ww
@@ -4,16 +4,14 @@
 
 
 # Warewulf Server
-{{$.Ipaddr}} warewulf {{$.BuildHost}}
+{{$.Ipaddr}} {{$.BuildHost}} warewulf
 
 {{- range $node := $.AllNodes}}                  {{/* for each node */}}
 # Entry for {{$node.Id.Get}}
 {{- range $devname, $netdev := $node.NetDevs}} {{/* for each network device on the node */}}
 {{- if $netdev.Ipaddr.Defined}}                {{/* if we have an ip address on this network device */}}
 {{- /* emit the node name as hostname if this is the primary */}}
-{{$netdev.Ipaddr.Get}} {{$node.Id.Get}}-{{$devname}}
-{{- if $netdev.Device.Defined}} {{$node.Id.Get}}-{{$netdev.Device.Get}}{{end}}
-{{- if $netdev.Primary.GetB}} {{$node.Id.Get}}{{end}}
-{{- end}} {{/* end if ip */}}
-{{- end}} {{/* end for each network device */}}
-{{- end}} {{/* end for each node */}}
+{{$netdev.Ipaddr.Get}} {{if $netdev.Primary.GetB}}{{$node.Id.Get}}{{end}} {{$node.Id.Get}}-{{$devname}} {{if $netdev.Device.Defined}}{{$node.Id.Get}}-{{$netdev.Device.Get}}{{end}}
+{{- end }}{{/* if ip */}}
+{{- end }}{{/* for each network device */}}
+{{- end }}{{/* for each node */}}

--- a/overlays/host/etc/hosts.ww
+++ b/overlays/host/etc/hosts.ww
@@ -6,16 +6,14 @@
 
 
 # Warewulf Server
-{{$.Ipaddr}} warewulf {{$.BuildHost}}
+{{$.Ipaddr}} {{$.BuildHost}} warewulf
 
 {{- range $node := $.AllNodes}}                  {{/* for each node */}}
 # Entry for {{$node.Id.Get}}
 {{- range $devname, $netdev := $node.NetDevs}} {{/* for each network device on the node */}}
 {{- if $netdev.Ipaddr.Defined}}                {{/* if we have an ip address on this network device */}}
 {{- /* emit the node name as hostname if this is the primary */}}
-{{$netdev.Ipaddr.Get}} {{$node.Id.Get}}-{{$devname}}
-{{- if $netdev.Device.Defined}} {{$node.Id.Get}}-{{$netdev.Device.Get}}{{end}}
-{{- if $netdev.Primary.GetB}} {{$node.Id.Get}}{{end}}
-{{- end}} {{/* end if ip */}}
-{{- end}} {{/* end for each network device */}}
-{{- end}} {{/* end for each node */}}
+{{$netdev.Ipaddr.Get}} {{if $netdev.Primary.GetB}}{{$node.Id.Get}}{{end}} {{$node.Id.Get}}-{{$devname}} {{if $netdev.Device.Defined}}{{$node.Id.Get}}-{{$netdev.Device.Get}}{{end}}
+{{- end }}{{/* if ip */}}
+{{- end }}{{/* for each network device */}}
+{{- end }}{{/* for each node */}}


### PR DESCRIPTION
The hosts file man page (`man hosts`) states:

> This file is a simple text file that associates IP addresses with
> hostnames, one line per IP address.  For each host a single line should
> be present with the following information:
>
>     IP_address canonical_hostname [aliases...]

As such, it seems that the hostname should be first in the list.

This is particularly true for the `warewulf` alias for the server itself, which is certainly an alias for the canonical hostname.