### PR TITLE
Update documentation to reference ghcr rather than DockerHub

### DIFF
--- a/internal/app/api/wwapird_curls/curls.sh
+++ b/internal/app/api/wwapird_curls/curls.sh
@@ -15,7 +15,7 @@ curl --cacert /usr/local/etc/warewulf/keys/cacert.pem \
 curl http://localhost:9871/v1/container
 
 # container import
-curl -d '{"source": "docker://warewulf/rocky:8", "name": "rocky-8", "update": true, "default": true}' -H "Content-Type: application/json" -X POST http://localhost:9871/v1/container
+curl -d '{"source": "docker://ghcr.io/hpcng/warewulf-rockylinux:8", "name": "rocky-8", "update": true, "default": true}' -H "Content-Type: application/json" -X POST http://localhost:9871/v1/container
 
 # container delete
 curl -X DELETE http://localhost:9871/v1/container?containerNames=rocky-8

--- a/internal/app/wwctl/container/imprt/root.go
+++ b/internal/app/wwctl/container/imprt/root.go
@@ -16,7 +16,7 @@ are:
  * /path/to/archive/tar/ball
  * /path/to/chroot/
 Imported containers are used to create bootable VNFS images.`,
-		Example: "wwctl container import docker://warewulf/centos-8 my_container",
+		Example: "wwctl container import docker://ghcr.io/hpcng/warewulf-rockylinux:8 rockylinux-8",
 		RunE:    CobraRunE,
 		Args:    cobra.MinimumNArgs(1),
 	}

--- a/userdocs/contents/containers.rst
+++ b/userdocs/contents/containers.rst
@@ -48,7 +48,7 @@ Here is an example of importing from Docker Hub.
 
 .. code-block:: console
 
-   # wwctl container import docker://warewulf/rocky rocky-8
+   # wwctl container import docker://ghcr.io/hpcng/warewulf-rockylinux:8 rocky-8
    Getting image source signatures
    Copying blob d7f16ed6f451 done
    Copying config da2ca70704 done

--- a/userdocs/contributing/development-environment-kvm.rst
+++ b/userdocs/contributing/development-environment-kvm.rst
@@ -102,7 +102,7 @@ Build and install Warewulf on wwdev
    sudo wwctl configure ssh  # Build the basic ssh keys to be included by the default system overlay
 
    # Pull and build the VNFS container and kernel
-   sudo wwctl container import docker://warewulf/centos-8 centos-8 --setdefault
+   sudo wwctl container import docker://ghcr.io/hpcng/warewulf-centos:7 centos-7 --setdefault
    sudo wwctl kernel import build $(uname -r) --setdefault
 
    # Set up the default node profile

--- a/userdocs/contributing/development-environment-vbox.rst
+++ b/userdocs/contributing/development-environment-vbox.rst
@@ -117,7 +117,7 @@ I have VirtualBox running on my desktop.
    sudo wwctl configure ssh  --persist # Build the basic ssh keys to be included by the default system overlay
 
    # Pull and build the VNFS container and kernel
-   sudo wwctl container import docker://warewulf/centos-7 centos-7 --setdefault
+   sudo wwctl container import docker://ghcr.io/hpcng/warewulf-centos:7 centos-7 --setdefault
    sudo wwctl kernel import build $(uname -r) --setdefault
 
    # Set up the default node profile

--- a/userdocs/quickstart/el7.rst
+++ b/userdocs/quickstart/el7.rst
@@ -103,7 +103,7 @@ default running kernel from the controller node and set both in the
 
 .. code-block:: bash
 
-   sudo wwctl container import docker://warewulf/centos-7 centos-7 --setdefault
+   sudo wwctl container import docker://ghcr.io/hpcng/warewulf-centos:7 centos-7 --setdefault
    sudo wwctl kernel import $(uname -r) --setdefault
 
 Set up the default node profile

--- a/userdocs/quickstart/el8.rst
+++ b/userdocs/quickstart/el8.rst
@@ -105,7 +105,7 @@ default running kernel from the controller node and set both in the
 
 .. code-block:: bash
 
-   sudo wwctl container import docker://warewulf/rocky:8 rocky-8
+   sudo wwctl container import docker://ghcr.io/hpcng/warewulf-rockylinux:8 rocky-8
 
 
 Set up the default node profile


### PR DESCRIPTION
Warewulf sample node images are now built automatically with GitHub CI/CD, targeting ghcr.io. This updates the documentation to reference that location rather than DockerHub.