### PR TITLE
netdev.Type and netdev.MTU are not displayed in profile list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Boolean attributes now correctly account for profile and default
   values. #630
 - Kernvel version is shown correctly
+- Show netdev.Type and netdev.MTU in profile list. #660
 
 ## [4.4.0rc3] 2022-12-23
 

--- a/internal/app/wwctl/profile/list/main.go
+++ b/internal/app/wwctl/profile/list/main.go
@@ -11,7 +11,6 @@ import (
 )
 
 func CobraRunE(cmd *cobra.Command, args []string) error {
-
 	nodeDB, err := node.New()
 	if err != nil {
 		wwlog.Error("Could not open node configuration: %s", err)
@@ -60,7 +59,8 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 				fmt.Printf("%-20s %-18s %s\n", profile.Id.Get(), name+":NETMASK", netdev.Netmask.Print())
 				fmt.Printf("%-20s %-18s %s\n", profile.Id.Get(), name+":GATEWAY", netdev.Gateway.Print())
 				fmt.Printf("%-20s %-18s %s\n", profile.Id.Get(), name+":HWADDR", netdev.Hwaddr.Print())
-				fmt.Printf("%-20s %-18s %s\n", profile.Id.Get(), name+":TYPE", netdev.Hwaddr.Print())
+				fmt.Printf("%-20s %-18s %s\n", profile.Id.Get(), name+":TYPE", netdev.Type.Print())
+				fmt.Printf("%-20s %-18s %s\n", profile.Id.Get(), name+":MTU", netdev.MTU.Print())
 				fmt.Printf("%-20s %-18s %s\n", profile.Id.Get(), name+":ONBOOT", netdev.OnBoot.PrintB())
 				fmt.Printf("%-20s %-18s %s\n", profile.Id.Get(), name+":PRIMARY", netdev.Primary.PrintB())
 				for keyname, key := range netdev.Tags {


### PR DESCRIPTION
## Description of the Pull Request (PR):

show netdev.Type and netdev.MTU in profile list.


### This fixes or addresses the following GitHub issues:

 - Fixes #660 


#### Before submitting a PR, make sure you have done the following:

- Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/development/contributing/contributing.html)
- Added changes to the [CHANGELOG](https://github.com/hpcng/warewulf/blob/development/CHANGELOG.md) if necessary
- Updated [userdocs](https://github.com/hpcng/warewulf/tree/development/userdocs) if necessary
- Based this PR against the appropriate branch (typically [development](https://github.com/hpcng/warewulf/tree/development/userdocs))
- Added myself as a contributor to the [Contributors File](https://github.com/hpcng/warewulf/blob/development/CONTRIBUTORS.md
