### PR TITLE
add support for resolving absolute path automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a missing `.ww` extension to the `70-ww4-netname.rules` template in the
   wwinit overlay.
 - Restrict access to `/warewulf/config` to root only. (#728, #742)
+- Add support for resolving absolute path automatically. #493
 
 ### Changed
 

--- a/internal/pkg/api/container/container.go
+++ b/internal/pkg/api/container/container.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -18,7 +19,6 @@ import (
 )
 
 func ContainerBuild(cbp *wwapiv1.ContainerBuildParameter) (err error) {
-
 	if cbp == nil {
 		return fmt.Errorf("ContainerBuildParameter is nil")
 	}
@@ -60,7 +60,7 @@ func ContainerBuild(cbp *wwapiv1.ContainerBuildParameter) (err error) {
 				return
 			}
 
-			//TODO: Don't loop through profiles, instead have a nodeDB function that goes directly to the map
+			// TODO: Don't loop through profiles, instead have a nodeDB function that goes directly to the map
 			profiles, _ := nodeDB.FindAllProfiles()
 			for _, profile := range profiles {
 				wwlog.Debug("Looking for profile default: %s", profile.Id.Get())
@@ -85,7 +85,6 @@ func ContainerBuild(cbp *wwapiv1.ContainerBuildParameter) (err error) {
 }
 
 func ContainerDelete(cdp *wwapiv1.ContainerDeleteParameter) (err error) {
-
 	if cdp == nil {
 		return fmt.Errorf("ContainerDeleteParameter is nil")
 	}
@@ -132,7 +131,6 @@ ARG_LOOP:
 }
 
 func ContainerImport(cip *wwapiv1.ContainerImportParameter) (containerName string, err error) {
-
 	if cip == nil {
 		err = fmt.Errorf("NodeAddParameter is nil")
 		return
@@ -176,6 +174,14 @@ func ContainerImport(cip *wwapiv1.ContainerImportParameter) (containerName strin
 			// TODO: mhink - return was missing here. Was that deliberate?
 		}
 
+		if util.IsFile(cip.Source) && !filepath.IsAbs(cip.Source) {
+			cip.Source, err = filepath.Abs(cip.Source)
+			if err != nil {
+				err = fmt.Errorf("when resolving absolute path of %s, err: %v", cip.Source, err)
+				wwlog.Error(err.Error())
+				return
+			}
+		}
 		err = container.ImportDocker(cip.Source, cip.Name, sCtx)
 		if err != nil {
 			err = fmt.Errorf("could not import image: %s", err.Error())
@@ -221,7 +227,7 @@ func ContainerImport(cip *wwapiv1.ContainerImportParameter) (containerName strin
 			return
 		}
 
-		//TODO: Don't loop through profiles, instead have a nodeDB function that goes directly to the map
+		// TODO: Don't loop through profiles, instead have a nodeDB function that goes directly to the map
 		profiles, _ := nodeDB.FindAllProfiles()
 		for _, profile := range profiles {
 			wwlog.Debug("Looking for profile default: %s", profile.Id.Get())
@@ -332,7 +338,6 @@ func ContainerList() (containerInfo []*wwapiv1.ContainerInfo, err error) {
 }
 
 func ContainerShow(csp *wwapiv1.ContainerShowParameter) (response *wwapiv1.ContainerShowResponse, err error) {
-
 	containerName := csp.ContainerName
 
 	if !container.ValidName(containerName) {


### PR DESCRIPTION
## Description of the Pull Request (PR):

add support for resolving absolute path automatically

### This fixes or addresses the following GitHub issues:

 - Fixes #493 


#### Before submitting a PR, make sure you have done the following:

- Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/development/contributing/contributing.html)
- Added changes to the [CHANGELOG](https://github.com/hpcng/warewulf/blob/development/CHANGELOG.md) if necessary
- Updated [userdocs](https://github.com/hpcng/warewulf/tree/development/userdocs) if necessary
- Based this PR against the appropriate branch (typically [development](https://github.com/hpcng/warewulf/tree/development/userdocs))
- Added myself as a contributor to the [Contributors File](https://github.com/hpcng/warewulf/blob/development/CONTRIBUTORS.md

### Test
Before
```
[vagrant@localhost ~]$ ls
go  rocky8.tar  warewulf
[vagrant@localhost ~]$ sudo wwctl container import rocky8.tar rocky8
ERROR  : could not import image: error opening file "/rocky8.tar": open /rocky8.tar: no such file or directory
ERROR: could not import image: error opening file "/rocky8.tar": open /rocky8.tar: no such file or directory
[vagrant@localhost ~]$ 
```

After
```
[vagrant@localhost ~]$ ls
go  rocky8.tar  warewulf
[vagrant@localhost ~]$ sudo wwctl container import rocky8.tar rocky8
Copying blob 632b9386947c done  
Copying blob 14a1a0a144bb done  
Copying blob 5ccf08ff10fb done  
Copying blob 408642d7c88b done  
Copying blob 140c8b5c084a done  
Copying config 0db70af127 done  
Writing manifest to image destination
Storing signatures
2023/03/22 04:05:59  info unpack layer: sha256:a8851e0b1ab491e047ffc481a17d818498782bea5e26992272889d12eea8a6a8
2023/03/22 04:06:02  info unpack layer: sha256:33f48be61e8e44aa6d1c050ee6ba4715ed9239e87272eb347a11b55832721491
2023/03/22 04:06:11  info unpack layer: sha256:ffaa1815cd10d29c618a503b97c901124690e984a6deac220207466897e4b43f
2023/03/22 04:06:11  info unpack layer: sha256:108819540b65ae7c1e57b71aa3fd3288366c37b15a6b05252870ea5ec081ff2d
2023/03/22 04:06:11  info unpack layer: sha256:ee8dbfa882bd9ae48dd6d1de0227917a2f471aff5555d41a9ca833cf6b4d2598
WARN   : user: systemd-resolve:193:193 not present on host
uid/gid not synced, run 
wwctl container syncuser --write rocky8
to synchronize uid/gids.
Building container: rocky8
Created image for VNFS container rocky8: /srv/warewulf/container/rocky8.img
Compressed image for VNFS container rocky8: /srv/warewulf/container/rocky8.img.gz
```