### PR TITLE
Add missing packages to build on EL8

### DIFF
--- a/userdocs/quickstart/el8.rst
+++ b/userdocs/quickstart/el8.rst
@@ -9,7 +9,7 @@ Install Warewulf and dependencies
 
    sudo dnf groupinstall "Development Tools"
    sudo dnf install epel-release
-   sudo dnf install golang tftp-server dhcp-server nfs-utils
+   sudo dnf install golang tftp-server dhcp-server nfs-utils gpgpme-devel libassuan-devel
 
    git clone https://github.com/hpcng/warewulf.git
    cd warewulf


### PR DESCRIPTION
## Description of the Pull Request (PR):

Following the instructions [here](https://warewulf.org/docs/development/quickstart/el8.html) will fail when running `make all` on a fresh Rocky Linux 8.7 install because `gpgme-devel` and `libassum-devel` aren't installed by default.
