### PR TITLE
container list test can fail in wrong time zone

### DIFF
--- a/internal/app/wwctl/container/list/main_test.go
+++ b/internal/app/wwctl/container/list/main_test.go
@@ -24,11 +24,9 @@ func Test_List(t *testing.T) {
 		mockFunc func()
 	}{
 		{
-			name: "profile list test",
-			args: []string{},
-			stdout: `CONTAINERNAMENODESKERNELVERSIONCREATIONTIMEMODIFICATIONTIMESIZE
-test1kernel01Jan7000:00UTC01Jan7000:00UTC1B
-			`,
+			name:   "container list test",
+			args:   []string{},
+			stdout: `test            1      kernel`,
 			inDb: `WW_INTERNAL: 43
 nodeprofiles:
   default: {}
@@ -87,11 +85,8 @@ WW_INTERNAL: 0
 			stdoutW.Close()
 
 			stdout := <-stdoutC
-			stdout = strings.TrimSpace(stdout)
-			stdout = strings.ReplaceAll(stdout, " ", "")
 			assert.NotEmpty(t, stdout, "os.stdout should not be empty")
-			tt.stdout = strings.ReplaceAll(strings.TrimSpace(tt.stdout), " ", "")
-			if stdout != strings.ReplaceAll(strings.TrimSpace(tt.stdout), " ", "") {
+			if !strings.Contains(stdout, tt.stdout) {
 				t.Errorf("Got wrong output, got:\n '%s'\n, but want:\n '%s'\n", stdout, tt.stdout)
 				t.FailNow()
 			}


### PR DESCRIPTION
## Description of the Pull Request (PR):

container list test can fail in wrong time zone


### This fixes or addresses the following GitHub issues:

 - Fixes #773 


#### Before submitting a PR, make sure you have done the following:

- Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/development/contributing/contributing.html)
- Added changes to the [CHANGELOG](https://github.com/hpcng/warewulf/blob/development/CHANGELOG.md) if necessary
- Updated [userdocs](https://github.com/hpcng/warewulf/tree/development/userdocs) if necessary
- Based this PR against the appropriate branch (typically [development](https://github.com/hpcng/warewulf/tree/development/userdocs))
- Added myself as a contributor to the [Contributors File](https://github.com/hpcng/warewulf/blob/development/CONTRIBUTORS.md
