### PR TITLE
Configure ONBOOT with netdev.OnBoot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restrict access to `/warewulf/config` to root only. (#728, #742)
 - KERNEL VERSION column is too short. #690
 - Add support for resolving absolute path automatically. #493
+- The network device "OnBoot" parameter correctly configures the ONBOOT ifcfg
+  parameter. (#644)
 
 ### Changed
 
@@ -34,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    `wwctl --emptyconf genconfig warewulfconf print` for the available paths.
 - Added experimental dnsmasq support.
 - Refactored `profile add` command to make it alike `node add`. #658 #659 
+- The ifcfg ONBOOT parameter is no longer statically `true`, so unconfigured
+  interfaces may not be enabled by default. (#644)
 
 - new subcommand `wwctl genconf` is available with following subcommands:
   * `completions` which will create the files used for bash-completion. Also

--- a/internal/pkg/node/constructors.go
+++ b/internal/pkg/node/constructors.go
@@ -37,7 +37,8 @@ defaultnode:
     dummy:
       device: eth0
       type: ethernet
-      netmask: 255.255.255.0`
+      netmask: 255.255.255.0
+      onboot: true`
 
 func init() {
 	conf := warewulfconf.New()
@@ -60,7 +61,6 @@ func New() (NodeYaml, error) {
 	}
 	return Parse(data)
 }
-
 
 // Parse constructs a new nodeDb object from an input YAML
 // document. Passes any errors return from yaml.Unmarshal. Returns an
@@ -99,7 +99,6 @@ func Parse(data []byte) (NodeYaml, error) {
 	wwlog.Debug("Returning node object")
 	return ret, nil
 }
-
 
 /*
 Get all the nodes of a configuration. This function also merges

--- a/overlays/wwinit/etc/sysconfig/network-scripts/ifcfg.ww
+++ b/overlays/wwinit/etc/sysconfig/network-scripts/ifcfg.ww
@@ -24,7 +24,9 @@ HWADDR={{ $netdev.Hwaddr }}
 {{ if $netdev.Type -}}
 TYPE={{ $netdev.Type }}
 {{ end -}}
-ONBOOT=yes
+{{ if $netdev.OnBoot -}}
+ONBOOT={{ $netdev.OnBoot }}
+{{ end -}}
 IPV6INIT=yes
 IPV6_AUTOCONF=yes
 IPV6_DEFROUTE=yes


### PR DESCRIPTION
## Description of the Pull Request (PR):

`netdev.OnBoot` wasn't actually configuring ifcfg ONBOOT, which was set statically to true.


### This fixes or addresses the following GitHub issues:

 - Fixes #644