### PR TITLE
fix warewulf.conf location for wwclient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   file is create and will executed after the `ignition-disks-ww4.service` has finished.
   Entries in `/etc/fstab` for every file system are created with the `noauto` option.
 
+- wwclient has now a commandline switch for the location of warewulf.conf
 ## [4.4.0] 2023-01-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,19 +40,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The primary hostname and warewulf server fqdn are now the canonical name in
   `/etc/hosts`
-- new subcommand `wwctl genconf` is available with following subcommands:
-  * `completions` which will create the files used for bash-completion. Also
-     fish an zsh completions can be generated
-  * `defaults` which will generate a valid `defaults.conf`
-  * `man` which will generate the man pages in the specified directory
-  * `reference` which will generate a reference documentation for the wwctl commands
-  * `warwulfconf print` which will print the used `warewulf.conf`. If there is no valid
-     `warewulf.conf` a valid configuration is provided, prefilled with default values
-     and an IP configuration derived from the network configuration of the host
-- All paths can now be configured in `warewulf.conf`, check the paths section of of 
-   `wwctl --emptyconf genconfig warewulfconf print` for the available paths.
-- Added experimental dnsmasq support.
+
 - Refactored `profile add` command to make it alike `node add`. #658 #659 
+
 - The ifcfg ONBOOT parameter is no longer statically `true`, so unconfigured
   interfaces may not be enabled by default. (#644)
 
@@ -65,22 +55,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * `warwulfconf print` which will print the used `warewulf.conf`. If there is no valid
      `warewulf.conf` a valid configuration is provided, prefilled with default values
      and an IP configuration derived from the network configuration of the host
+
 - All paths can now be configured in `warewulf.conf`, check the paths section of of 
    `wwctl --emptyconf genconfig warewulfconf print` for the available paths.
+
 - Added experimental dnsmasq support.
 
-- new subcommand `wwctl genconf` is available with following subcommands:
-  * `completions` which will create the files used for bash-completion. Also
-     fish an zsh completions can be generated
-  * `defaults` which will generate a valid `defaults.conf`
-  * `man` which will generate the man pages in the specified directory
-  * `reference` which will generate a reference documentation for the wwctl commands
-  * `warwulfconf print` which will print the used `warewulf.conf`. If there is no valid
-     `warewulf.conf` a valid configuration is provided, prefilled with default values
-     and an IP configuration derived from the network configuration of the host
-- All paths can now be configured in `warewulf.conf`, check the paths section of of 
-   `wwctl --emptyconf genconfig warewulfconf print` for the available paths.
-- Added experimental dnsmasq support.
 - Check for formal correct IP and MAC addresses for command line options and
   when reading in the configurations
 - Write log messages to stderr rather than stdout. #768


### PR DESCRIPTION
## fix loading of warewulf.conf for wwclient
#781 introduced a new API for reading warewulf.conf. This new API wasn't
implemented in wwclient. This PR introduces this new API to wwclient.
