### PR TITLE
fix wwctl node edit inconsistent state with warewulfd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parameter. (#644)
 - Add support for listing profile/node via comma-separated values. #739
 - Sort the node list returned entries by name. 
+- 'wwctl node edit' inconsistent state with warewulfd.  #691
 
 ### Changed
 

--- a/internal/app/wwctl/node/edit/main.go
+++ b/internal/app/wwctl/node/edit/main.go
@@ -13,7 +13,9 @@ import (
 	apiutil "github.com/hpcng/warewulf/internal/pkg/api/util"
 	"github.com/hpcng/warewulf/internal/pkg/node"
 	"github.com/hpcng/warewulf/internal/pkg/util"
+	"github.com/hpcng/warewulf/internal/pkg/warewulfd"
 	"github.com/hpcng/warewulf/internal/pkg/wwlog"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 )
@@ -129,6 +131,11 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		} else {
 			break
 		}
+	}
+
+	err = warewulfd.DaemonReload()
+	if err != nil {
+		return errors.Wrap(err, "failed to reload warewulf daemon")
 	}
 
 	return nil


### PR DESCRIPTION
## Description of the Pull Request (PR):

fix wwctl node edit inconsistent state with warewulfd

### This fixes or addresses the following GitHub issues:

 - Fixes #691


#### Before submitting a PR, make sure you have done the following:

- Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/development/contributing/contributing.html)
- Added changes to the [CHANGELOG](https://github.com/hpcng/warewulf/blob/development/CHANGELOG.md) if necessary
- Updated [userdocs](https://github.com/hpcng/warewulf/tree/development/userdocs) if necessary
- Based this PR against the appropriate branch (typically [development](https://github.com/hpcng/warewulf/tree/development/userdocs))
- Added myself as a contributor to the [Contributors File](https://github.com/hpcng/warewulf/blob/development/CONTRIBUTORS.md

## Test

prerequisites:
```
[vagrant@localhost warewulf]$ sudo wwctl node list -a n1 | grep hwaddr
  n1    default:hwaddr   --       de:ad:be:ef:00:00  
```

before
```
[vagrant@localhost warewulf]$ curl -L http://localhost:9873/ipxe/de-ad-be-ef-00-00
#!ipxe

echo
echo ================================================================================
echo Warewulf v4 now booting: n1 (de:ad:be:ef:00:00)
echo
echo Container:     

echo Kernel:         (container default)

echo KernelArgs:    quiet crashkernel=no vga=791 net.naming-scheme=v238
echo

set uri_base http://192.168.200.1:9873/provision/de:ad:be:ef:00:00?assetkey=${asset}&uuid=${uuid}
echo Warewulf Controller: 192.168.200.1

echo Downloading Kernel Image:
kernel --name kernel ${uri_base}&stage=kernel       || goto reboot

# imgextract causes RAM space problems on non-EFI systems (because of the 3GB barrier
# in 32-Bit mode).
# -> Use the old initrd method with a compressed image to save as much RAM as possible
# in this early boot stage.
# See <https://github.com/hpcng/warewulf/issues/222> for more details.
iseq ${platform} efi && goto efi || goto noefi

:efi
....

[vagrant@localhost warewulf]$ sudo wwctl node edit n1
? Are you sure you want to modify 1 nodes? [y/N] y█
WARN   : Profile not found for node 'n1': default
[vagrant@localhost warewulf]$ curl -L http://localhost:9873/ipxe/de-ad-be-ef-00-00
#!ipxe

echo
echo ================================================================================
echo Warewulf v4
echo
echo MESSAGE: This node is unconfigured. Please have your system administrator add a
echo          configuration for this node with HW address: de:ad:be:ef:00:00
echo
echo Rebooting in 1 minute...
sleep 60
reboot[vagrant@localhost warewulf]$ curl -L http://localhost:9873/ipxe/de-ad-be-ef-00-01
#!ipxe

echo
echo ================================================================================
echo Warewulf v4
echo
echo MESSAGE: This node is unconfigured. Please have your system administrator add a
echo          configuration for this node with HW address: de:ad:be:ef:00:01
echo
echo Rebooting in 1 minute...
sleep 60
reboot[vagrant@localhost warewulf]$ sudo cat /usr/local/etc/warewulf/nodes.conf 
WW_INTERNAL: 43
nodeprofiles: {}
nodes:
  n1:
    profiles:
    - default
    network devices:
      default:
        hwaddr: de:ad:be:ef:00:01
```

after:
```
[vagrant@localhost warewulf]$ sudo cat /usr/local/etc/warewulf/nodes.conf 
WW_INTERNAL: 43
nodeprofiles: {}
nodes:
  n1:
    profiles:
    - default
    network devices:
      default:
        hwaddr: de:ad:be:ef:00:01

[vagrant@localhost warewulf]$ curl -L http://localhost:9873/ipxe/de-ad-be-ef-00-01
#!ipxe

echo
echo ================================================================================
echo Warewulf v4 now booting: n1 (de:ad:be:ef:00:01)
echo
echo Container:     

echo Kernel:         (container default)

echo KernelArgs:    quiet crashkernel=no vga=791 net.naming-scheme=v238
echo

set uri_base http://192.168.200.1:9873/provision/de:ad:be:ef:00:01?assetkey=${asset}&uuid=${uuid}
echo Warewulf Controller: 192.168.200.1

echo Downloading Kernel Image:
kernel --name kernel ${uri_base}&stage=kernel       || goto reboot

# imgextract causes RAM space problems on non-EFI systems (because of the 3GB barrier
# in 32-Bit mode).
# -> Use the old initrd method with a compressed image to save as much RAM as possible
# in this early boot stage.
# See <https://github.com/hpcng/warewulf/issues/222> for more details.
iseq ${platform} efi && goto efi || goto noefi

:efi
....


[vagrant@localhost warewulf]$ sudo wwctl node edit n1
Are you sure you want to modify 1 nodes: y
WARN   : Profile not found for node 'n1': default
[vagrant@localhost warewulf]$ sudo cat /usr/local/etc/warewulf/nodes.conf 
WW_INTERNAL: 43
nodeprofiles: {}
nodes:
  n1:
    profiles:
    - default
    network devices:
      default:
        hwaddr: de:ad:be:ef:00:00

[vagrant@localhost warewulf]$ curl -L http://localhost:9873/ipxe/de-ad-be-ef-00-01
#!ipxe

echo
echo ================================================================================
echo Warewulf v4
echo
echo MESSAGE: This node is unconfigured. Please have your system administrator add a
echo          configuration for this node with HW address: de:ad:be:ef:00:01
echo
echo Rebooting in 1 minute...
sleep 60

reboot[vagrant@localhost warewulf]$ curl -L http://localhost:9873/ipxe/de-ad-be-ef-00-00
#!ipxe

echo
echo ================================================================================
echo Warewulf v4 now booting: n1 (de:ad:be:ef:00:00)
echo
echo Container:     

echo Kernel:         (container default)

echo KernelArgs:    quiet crashkernel=no vga=791 net.naming-scheme=v238
echo

set uri_base http://192.168.200.1:9873/provision/de:ad:be:ef:00:00?assetkey=${asset}&uuid=${uuid}
echo Warewulf Controller: 192.168.200.1

echo Downloading Kernel Image:
kernel --name kernel ${uri_base}&stage=kernel       || goto reboot

# imgextract causes RAM space problems on non-EFI systems (because of the 3GB barrier
# in 32-Bit mode).
# -> Use the old initrd method with a compressed image to save as much RAM as possible
# in this early boot stage.
# See <https://github.com/hpcng/warewulf/issues/222> for more details.
iseq ${platform} efi && goto efi || goto noefi

:efi
....
```


