### PR TITLE
advanced command line completion for wwctl overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Entries in `/etc/fstab` for every file system are created with the `noauto` option.
 - wwclient has now a commandline switch for the location of warewulf.conf
 - `wwctl overlay edit` uses a temporary file and checks mtime.
+- Changed the bash completions for the `wwctl overlay` commands so that the files of the
+  overlays are expanded
 
 ## [4.4.0] 2023-01-18
 

--- a/internal/app/wwctl/overlay/show/root.go
+++ b/internal/app/wwctl/overlay/show/root.go
@@ -18,11 +18,16 @@ var (
 		Aliases:               []string{"cat"},
 		Args:                  cobra.ExactArgs(2),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			if len(args) != 0 {
-				return nil, cobra.ShellCompDirectiveNoFileComp
+			if len(args) == 0 {
+				list, _ := overlay.FindOverlays()
+				return list, cobra.ShellCompDirectiveNoFileComp
+			} else if len(args) == 1 {
+				ret, err := overlay.OverlayGetFiles(args[0])
+				if err == nil {
+					return ret, cobra.ShellCompDirectiveNoFileComp
+				}
 			}
-			list, _ := overlay.FindOverlays()
-			return list, cobra.ShellCompDirectiveNoFileComp
+			return []string{""}, cobra.ShellCompDirectiveNoFileComp
 		},
 	}
 	NodeName string
@@ -33,12 +38,7 @@ func init() {
 	baseCmd.PersistentFlags().StringVarP(&NodeName, "render", "r", "", "node used for the variables in the template")
 	if err := baseCmd.RegisterFlagCompletionFunc("render", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		nodeDB, _ := node.New()
-		nodes, _ := nodeDB.FindAllNodes()
-		var node_names []string
-		for _, node := range nodes {
-			node_names = append(node_names, node.Id.Get())
-		}
-		return node_names, cobra.ShellCompDirectiveNoFileComp
+		return nodeDB.NodeList(), cobra.ShellCompDirectiveNoFileComp
 	}); err != nil {
 		log.Println(err)
 	}

--- a/internal/pkg/node/util.go
+++ b/internal/pkg/node/util.go
@@ -46,3 +46,12 @@ func (config *NodeYaml) FindByIpaddr(ipaddr string) (NodeInfo, error) {
 
 	return ret, errors.New("No nodes found with IP Addr: " + ipaddr)
 }
+
+// Return just the node list as string slice
+func (config *NodeYaml) NodeList() []string {
+	ret := make([]string, len(config.Nodes))
+	for key := range config.Nodes {
+		ret = append(ret, key)
+	}
+	return ret
+}

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -433,3 +433,19 @@ func ScanLines(data []byte, atEOF bool) (advance int, token []byte, err error) {
 	// Request more data.
 	return 0, nil, nil
 }
+
+// Get all the files as a string slice for a given overlay
+func OverlayGetFiles(name string) (files []string, err error) {
+	baseDir := OverlaySourceDir(name)
+	if !util.IsDir(baseDir) {
+		err = fmt.Errorf("overlay %s doesn't exist", name)
+		return
+	}
+	err = filepath.Walk(baseDir, func(path string, info fs.FileInfo, err error) error {
+		if util.IsFile(path) {
+			files = append(files, strings.TrimPrefix(path, baseDir))
+		}
+		return nil
+	})
+	return
+}


### PR DESCRIPTION

Various wwctl overlay commands just completed the overlay names. With
this PR e.g.
`wwctl overlay edit <TAB>`
will complete the available overlay names and
`wwctl overlay edit wwinit <TAB>`
will complete all the availble files in the overlay wwinit

