### PR TITLE
add sort support for returned entry slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The network device "OnBoot" parameter correctly configures the ONBOOT ifcfg
   parameter. (#644)
 - Add support for listing profile/node via comma-separated values. #739
+- Sort the node list returned entries by name. 
 
 ### Changed
 

--- a/internal/pkg/node/methods.go
+++ b/internal/pkg/node/methods.go
@@ -4,11 +4,18 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/hpcng/warewulf/internal/pkg/util"
 	"github.com/hpcng/warewulf/internal/pkg/wwlog"
 )
+
+type sortByName []NodeInfo
+
+func (a sortByName) Len() int           { return len(a) }
+func (a sortByName) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a sortByName) Less(i, j int) bool { return a[i].Id.Print() < a[j].Id.Print() }
 
 func GetUnsetVerbs() []string {
 	return []string{"UNSET", "DELETE", "UNDEF", "undef", "--", "nil", "0.0.0.0"}
@@ -43,6 +50,7 @@ func FilterByName(set []NodeInfo, searchList []string) []NodeInfo {
 		ret = set
 	}
 
+	sort.Sort(sortByName(ret))
 	return ret
 }
 
@@ -58,7 +66,6 @@ func FilterMapByName(inputMap map[string]*NodeConf, searchList []string) (retMap
 					retMap[name] = nConf
 				}
 			}
-
 		}
 	}
 	return retMap
@@ -156,7 +163,6 @@ func (ent *Entry) SetDefault(val string) {
 		return
 	}
 	ent.def = []string{val}
-
 }
 
 /*
@@ -167,7 +173,6 @@ func (ent *Entry) SetDefaultSlice(val []string) {
 		return
 	}
 	ent.def = val
-
 }
 
 /*
@@ -328,7 +333,7 @@ per profile. Else -- is returned.
 func (ent *Entry) Source() string {
 	if len(ent.value) != 0 && len(ent.altvalue) != 0 {
 		return "SUPERSEDED"
-		//return fmt.Sprintf("[%s]", ent.from)
+		// return fmt.Sprintf("[%s]", ent.from)
 	} else if ent.from == "" {
 		return "--"
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Node list returns node entries in random order during test, so in this PR I added sortByName support, which will always return node entries by alphbet ascending names. 


### This fixes or addresses the following GitHub issues:

 - Fixes #


#### Before submitting a PR, make sure you have done the following:

- Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/development/contributing/contributing.html)
- Added changes to the [CHANGELOG](https://github.com/hpcng/warewulf/blob/development/CHANGELOG.md) if necessary
- Updated [userdocs](https://github.com/hpcng/warewulf/tree/development/userdocs) if necessary
- Based this PR against the appropriate branch (typically [development](https://github.com/hpcng/warewulf/tree/development/userdocs))
- Added myself as a contributor to the [Contributors File](https://github.com/hpcng/warewulf/blob/development/CONTRIBUTORS.md
