### PR TITLE
replacing using different string spliter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 'wwctl node edit' inconsistent state with warewulfd.  #691
 - Add `--parents` option to `overlay import` subcommand to create necessary
   parent folder.  #608
+- Fix kernelargs are not printing properly in node list output. #828
 
 ### Changed
 

--- a/internal/app/wwctl/node/list/main.go
+++ b/internal/app/wwctl/node/list/main.go
@@ -29,9 +29,9 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 		}
 		nodeInfo, err := apinode.NodeList(&req)
 		if len(nodeInfo.Output) > 0 {
-			ph := helper.NewPrintHelper(strings.Split(nodeInfo.Output[0], "="))
+			ph := helper.NewPrintHelper(strings.Split(nodeInfo.Output[0], ":=:"))
 			for _, val := range nodeInfo.Output[1:] {
-				ph.Append(strings.Split(val, "="))
+				ph.Append(strings.Split(val, ":=:"))
 			}
 			ph.Render()
 		}

--- a/internal/pkg/api/node/list.go
+++ b/internal/pkg/api/node/list.go
@@ -29,7 +29,7 @@ func NodeList(nodeGet *wwapiv1.GetNodeList) (nodeList wwapiv1.NodeList, err erro
 	sort.Strings(nodeGet.Nodes)
 	if nodeGet.Type == wwapiv1.GetNodeList_Simple {
 		nodeList.Output = append(nodeList.Output,
-			fmt.Sprintf("%s=%s=%s", "NODE NAME", "PROFILES", "NETWORK"))
+			fmt.Sprintf("%s:=:%s:=:%s", "NODE NAME", "PROFILES", "NETWORK"))
 		for _, n := range node.FilterByName(nodes, nodeGet.Nodes) {
 			var netNames []string
 			for k := range n.NetDevs {
@@ -37,31 +37,31 @@ func NodeList(nodeGet *wwapiv1.GetNodeList) (nodeList wwapiv1.NodeList, err erro
 			}
 			sort.Strings(netNames)
 			nodeList.Output = append(nodeList.Output,
-				fmt.Sprintf("%s=%s=%s", n.Id.Print(), n.Profiles.Print(), strings.Join(netNames, ", ")))
+				fmt.Sprintf("%s:=:%s:=:%s", n.Id.Print(), n.Profiles.Print(), strings.Join(netNames, ", ")))
 		}
 	} else if nodeGet.Type == wwapiv1.GetNodeList_Network {
 		nodeList.Output = append(nodeList.Output,
-			fmt.Sprintf("%s=%s=%s=%s=%s=%s", "NODE NAME", "NAME", "HWADDR", "IPADDR", "GATEWAY", "DEVICE"))
+			fmt.Sprintf("%s:=:%s:=:%s:=:%s:=:%s:=:%s", "NODE NAME", "NAME", "HWADDR", "IPADDR", "GATEWAY", "DEVICE"))
 		for _, n := range node.FilterByName(nodes, nodeGet.Nodes) {
 			if len(n.NetDevs) > 0 {
 				for name := range n.NetDevs {
 					nodeList.Output = append(nodeList.Output,
-						fmt.Sprintf("%s=%s=%s=%s=%s=%s", n.Id.Print(), name,
+						fmt.Sprintf("%s:=:%s:=:%s:=:%s:=:%s:=:%s", n.Id.Print(), name,
 							n.NetDevs[name].Hwaddr.Print(),
 							n.NetDevs[name].Ipaddr.Print(),
 							n.NetDevs[name].Gateway.Print(),
 							n.NetDevs[name].Device.Print()))
 				}
 			} else {
-				fmt.Printf("%s=%s=%s=%s=%s=%s", n.Id.Print(), "--", "--", "--", "--", "--")
+				fmt.Printf("%s:=:%s:=:%s:=:%s:=:%s:=:%s", n.Id.Print(), "--", "--", "--", "--", "--")
 			}
 		}
 	} else if nodeGet.Type == wwapiv1.GetNodeList_Ipmi {
 		nodeList.Output = append(nodeList.Output,
-			fmt.Sprintf("%s=%s=%s=%s=%s", "NODE NAME", "IPMI IPADDR", "IPMI PORT", "IPMI USERNAME", "IPMI INTERFACE"))
+			fmt.Sprintf("%s:=:%s:=:%s:=:%s:=:%s", "NODE NAME", "IPMI IPADDR", "IPMI PORT", "IPMI USERNAME", "IPMI INTERFACE"))
 		for _, n := range node.FilterByName(nodes, nodeGet.Nodes) {
 			nodeList.Output = append(nodeList.Output,
-				fmt.Sprintf("%s=%s=%s=%s=%s", n.Id.Print(),
+				fmt.Sprintf("%s:=:%s:=:%s:=:%s:=:%s", n.Id.Print(),
 					n.Ipmi.Ipaddr.Print(),
 					n.Ipmi.Port.Print(),
 					n.Ipmi.UserName.Print(),
@@ -69,17 +69,17 @@ func NodeList(nodeGet *wwapiv1.GetNodeList) (nodeList wwapiv1.NodeList, err erro
 		}
 	} else if nodeGet.Type == wwapiv1.GetNodeList_Long {
 		nodeList.Output = append(nodeList.Output,
-			fmt.Sprintf("%s=%s=%s=%s", "NODE NAME", "KERNEL OVERRIDE", "CONTAINER", "OVERLAYS (S/R)"))
+			fmt.Sprintf("%s:=:%s:=:%s:=:%s", "NODE NAME", "KERNEL OVERRIDE", "CONTAINER", "OVERLAYS (S/R)"))
 		for _, n := range node.FilterByName(nodes, nodeGet.Nodes) {
 			nodeList.Output = append(nodeList.Output,
-				fmt.Sprintf("%s=%s=%s=%s", n.Id.Print(),
+				fmt.Sprintf("%s:=:%s:=:%s:=:%s", n.Id.Print(),
 					n.Kernel.Override.Print(),
 					n.ContainerName.Print(),
 					n.SystemOverlay.Print()+"/"+n.RuntimeOverlay.Print()))
 		}
 	} else if nodeGet.Type == wwapiv1.GetNodeList_All {
 		nodeList.Output = append(nodeList.Output,
-			fmt.Sprintf("%s=%s=%s=%s", "NODE", "FIELD", "PROFILE", "VALUE"))
+			fmt.Sprintf("%s:=:%s:=:%s:=:%s", "NODE", "FIELD", "PROFILE", "VALUE"))
 		for _, n := range node.FilterByName(nodes, nodeGet.Nodes) {
 			nType := reflect.TypeOf(n)
 			nVal := reflect.ValueOf(n)
@@ -97,12 +97,12 @@ func NodeList(nodeGet *wwapiv1.GetNodeList) (nodeList wwapiv1.NodeList, err erro
 					fieldSource = entr.Source()
 					fieldVal = entr.Print()
 					nodeList.Output = append(nodeList.Output,
-						fmt.Sprintf("%s=%s=%s=%s", n.Id.Print(), fieldName, fieldSource, fieldVal))
+						fmt.Sprintf("%s:=:%s:=:%s:=:%s", n.Id.Print(), fieldName, fieldSource, fieldVal))
 				} else if nType.Field(i).Type == reflect.TypeOf(map[string]*node.Entry{}) {
 					entrMap := nVal.Field(i).Interface().(map[string]*node.Entry)
 					for key, val := range entrMap {
 						nodeList.Output = append(nodeList.Output,
-							fmt.Sprintf("%s=%s=%s=%s", n.Id.Print(), key, val.Source(), val.Print()))
+							fmt.Sprintf("%s:=:%s:=:%s:=:%s", n.Id.Print(), key, val.Source(), val.Print()))
 					}
 				} else if nType.Field(i).Type == reflect.TypeOf(map[string]*node.NetDevEntry{}) {
 					netDevs := nVal.Field(i).Interface().(map[string]*node.NetDevEntry)
@@ -128,7 +128,7 @@ func NodeList(nodeGet *wwapiv1.GetNodeList) (nodeList wwapiv1.NodeList, err erro
 								// only print fields with lopt
 								if netConfField.Tag.Get("lopt") != "" {
 									nodeList.Output = append(nodeList.Output,
-										fmt.Sprintf("%s=%s=%s=%s", n.Id.Print(), fieldName, fieldSource, fieldVal))
+										fmt.Sprintf("%s:=:%s:=:%s:=:%s", n.Id.Print(), fieldName, fieldSource, fieldVal))
 								}
 							} else if netInfoType.Field(j).Type == reflect.TypeOf(map[string]*node.Entry{}) {
 								for key, val := range netInfoVal.Field(j).Interface().(map[string]*node.Entry) {
@@ -136,7 +136,7 @@ func NodeList(nodeGet *wwapiv1.GetNodeList) (nodeList wwapiv1.NodeList, err erro
 									fieldSource = val.Source()
 									fieldVal = val.Print()
 									nodeList.Output = append(nodeList.Output,
-										fmt.Sprintf("%s=%s=%s=%s", n.Id.Print(), keyfieldName, fieldSource, fieldVal))
+										fmt.Sprintf("%s:=:%s:=:%s:=:%s", n.Id.Print(), keyfieldName, fieldSource, fieldVal))
 								}
 							}
 
@@ -158,14 +158,14 @@ func NodeList(nodeGet *wwapiv1.GetNodeList) (nodeList wwapiv1.NodeList, err erro
 							fieldSource = entr.Source()
 							fieldVal = entr.Print()
 							nodeList.Output = append(nodeList.Output,
-								fmt.Sprintf("%s=%s=%s=%s", n.Id.Print(), fieldName, fieldSource, fieldVal))
+								fmt.Sprintf("%s:=:%s:=:%s:=:%s", n.Id.Print(), fieldName, fieldSource, fieldVal))
 						} else if nestInfoType.Elem().Field(j).Type == reflect.TypeOf(map[string]*node.Entry{}) {
 							for key, val := range nestInfoVal.Elem().Field(j).Interface().(map[string]*node.Entry) {
 								fieldName = fieldName + ":" + key
 								fieldSource = val.Source()
 								fieldVal = val.Print()
 								nodeList.Output = append(nodeList.Output,
-									fmt.Sprintf("%s=%s=%s=%s", n.Id.Print(), fieldName, fieldSource, fieldVal))
+									fmt.Sprintf("%s:=:%s:=:%s:=:%s", n.Id.Print(), fieldName, fieldSource, fieldVal))
 							}
 						}
 					}


### PR DESCRIPTION
## Description of the Pull Request (PR):

originally we are using `=` as the splitter but this will prevent from printing `=` in the value.
in this PR, we are using a more completed splitter. 


### This fixes or addresses the following GitHub issues:

 - Fixes #828 


#### Before submitting a PR, make sure you have done the following:

- Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/development/contributing/contributing.html)
- Added changes to the [CHANGELOG](https://github.com/hpcng/warewulf/blob/development/CHANGELOG.md) if necessary
- Updated [userdocs](https://github.com/hpcng/warewulf/tree/development/userdocs) if necessary
- Based this PR against the appropriate branch (typically [development](https://github.com/hpcng/warewulf/tree/development/userdocs))
- Added myself as a contributor to the [Contributors File](https://github.com/hpcng/warewulf/blob/development/CONTRIBUTORS.md
