### PR TITLE
Fix build configuration on Quickstart guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `--parents` option to `overlay import` subcommand to create necessary
   parent folder.  #608
 - Fix kernelargs are not printing properly in node list output. #828
+- Fix build configuration on Quickstart guide #847
 
 ### Changed
 

--- a/userdocs/quickstart/el8.rst
+++ b/userdocs/quickstart/el8.rst
@@ -13,6 +13,22 @@ Install Warewulf and dependencies
 
    git clone https://github.com/hpcng/warewulf.git
    cd warewulf
+   make genconfig \
+    PREFIX=/usr \
+    BINDIR=/usr/bin \
+    SYSCONFDIR=/etc \
+    DATADIR=/usr/share \
+    LOCALSTATEDIR=/var/lib \
+    SHAREDSTATEDIR=/var/lib \
+    MANDIR=/usr/share/man \
+    INFODIR=/usr/share/info \
+    DOCDIR=/usr/share/doc \
+    SRVDIR=/var/lib \
+    TFTPDIR=/var/lib/tftpboot \
+    SYSTEMDDIR=/usr/lib/systemd/system \
+    BASHCOMPDIR=/etc/bash_completion.d/ \
+    FIREWALLDDIR=/usr/lib/firewalld/services \
+    WWCLIENTDIR=/warewulf
    make all
    sudo make install
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

* without `genconfig`, warewulfd doesn not read `/etc/warewulf/warewuld.conf`, and read `/usr/local/etc/warewulf/warewulf.conf` instead, that is inconsistent with later section on quickstart guide.
* added `genconfig` line to make our build configuration identical to rpm package for EL8, this makes build result consistent with later section on quickstart guide.

### This fixes or addresses the following GitHub issues:

 - Fixes #847


#### Before submitting a PR, make sure you have done the following:

- Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/development/contributing/contributing.html)
- Added changes to the [CHANGELOG](https://github.com/hpcng/warewulf/blob/development/CHANGELOG.md) if necessary
- Updated [userdocs](https://github.com/hpcng/warewulf/tree/development/userdocs) if necessary
- Based this PR against the appropriate branch (typically [development](https://github.com/hpcng/warewulf/tree/development/userdocs))
- Added myself as a contributor to the [Contributors File](https://github.com/hpcng/warewulf/blob/development/CONTRIBUTORS.md
