### PR TITLE
fixed targets for doc build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,12 +216,12 @@ init:
 	cp -r tftpboot/* $(WWTFTPDIR)/ipxe/
 	restorecon -r $(WWTFTPDIR)
 
-wwctl: $(WWCTL_DEPS)
+wwctl: config vendor $(WWCTL_DEPS)
 	@echo Building "$@"
 	@cd cmd/wwctl; GOOS=linux go build -mod vendor -tags "$(WW_GO_BUILD_TAGS)" \
 	-o ../../wwctl
 
-wwclient: $(WWCLIENT_DEPS)
+wwclient: config vendor $(WWCLIENT_DEPS)
 	@echo Building "$@"
 	@cd cmd/wwclient; CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -ldflags "-extldflags -static" \
 	-o ../../wwclient
@@ -246,6 +246,7 @@ dist: vendor config
 	rm -rf .dist
 
 reference: wwctl
+	mkdir -p userdocs/reference
 	./wwctl --emptyconf genconfig reference userdocs/reference/
 
 latexpdf: reference


### PR DESCRIPTION
## Makefile fix up

Building the userdocs via the command `make latexpdf` failed as `wwctl`
couldn't be build as it depends on `config` and `vendor`. This PR fixes 
this.
