### PR TITLE
Restrict access to /warewulf/config from overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Container file gids are now updated properly during syncuser. #840
+- Restrict access to `/warewulf/config` to root only. (#728, #742)
 
 ## [4.4.0] 2023-01-18
 

--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,7 @@ files: all
 	chmod 600 $(DESTDIR)$(WWOVERLAYDIR)/wwinit/etc/ssh/ssh*
 	chmod 600 $(DESTDIR)$(WWOVERLAYDIR)/wwinit/etc/NetworkManager/system-connections/ww4-managed.ww
 	chmod 644 $(DESTDIR)$(WWOVERLAYDIR)/wwinit/etc/ssh/ssh*.pub.ww
+	chmod 600 $(DESTDIR)$(WWOVERLAYDIR)/wwinit/warewulf/config.ww
 	chmod 750 $(DESTDIR)$(WWOVERLAYDIR)/host
 	install -m 0755 wwctl $(DESTDIR)$(BINDIR)
 	install -m 0755 wwapic $(DESTDIR)$(BINDIR)


### PR DESCRIPTION
The wwinit overlay populates /warewulf/config with information about the
Warewulf configuration. This includes the IPMI password, which should not be
visible to regular users. This changes the installed permissions of the file to
be readable by root only.

Closes #728

Signed-off-by: Jonathon Anderson <janderson@ciq.co>

