### PR TITLE
griznog fix build errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New documentation for development environment (Vagrant)
 
 ### Fixed
-
+- More aggressive `make clean`.
+- Replace deprecated `io.utils` functions with new `os` functions.
 - The correct header is now displayed when `-al` flags are specified to overlay
   list.
 - Added a missing `.ww` extension to the `70-ww4-netname.rules` template in the

--- a/Makefile
+++ b/Makefile
@@ -281,17 +281,36 @@ wwapird: ## Build the rest api server (revese proxy to the grpc api server).
 	go build -o ./wwapird internal/app/api/wwapird/wwapird.go
 
 contclean:
+	rm -f $(WAREWULF)-$(VERSION).tar.gz
+	rm -f bash_completion
+	rm -f config
+	rm -f config_defaults 
+	rm -f Defaults.mk
+	rm -f etc/wwapi{c,d,rd}.conf
+	rm -f etc/wwapi{c,d,rd}.config
+	rm -f include/systemd/warewulfd.service
+	rm -f internal/pkg/buildconfig/setconfigs.go
+	rm -f internal/pkg/config/buildconfig.go
+	rm -f man_page 
+	rm -f print_defaults 
+	rm -f update_configuration
+	rm -f usr/share/man/man1/
+	rm -f warewulf.spec
+	rm -f warewulf-*.tar.gz
+	rm -f wwapic 
+	rm -f wwapid 
+	rm -f wwapird
 	rm -f wwclient
 	rm -f wwctl
-	rm -rf .dist
-	rm -f $(WAREWULF)-$(VERSION).tar.gz
-	rm -rf man_pages
-	rm -f warewulf.spec
-	rm -f config
-	rm -f Defaults.mk
 	rm -rf $(TOOLS_DIR)
-	rm -f update_configuration
-	rm -f etc/wwapi{c,d,rd}.conf
+	rm -rf bash_completion.d
+	rm -rf /config
+	rm -rf .dist/
+	rm -rf _dist/
+	rm -rf etc/bash_completion.d/
+	rm -rf man_pages
+	rm -rf userdocs/_*
+	rm -rf userdocs/reference/*
 
 clean: contclean
 	rm -rf vendor

--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ files: all
 	install -m 0644 include/firewalld/warewulf.xml $(DESTDIR)$(FIREWALLDDIR)
 	install -m 0644 include/systemd/warewulfd.service $(DESTDIR)$(SYSTEMDDIR)
 	install -m 0644 LICENSE.md $(DESTDIR)$(WWDOCDIR)
-	./wwctl genconfig completions > $(DESTDIR)$(BASHCOMPDIR)/wwctl
+	./wwctl --warewulfconf etc/warewulf.conf genconfig completions > $(DESTDIR)$(BASHCOMPDIR)/wwctl
 	cp man_pages/*.1* $(DESTDIR)$(MANDIR)/man1/
 	cp man_pages/*.5* $(DESTDIR)$(MANDIR)/man5/
 	install -m 0644 staticfiles/README-ipxe.md $(DESTDIR)$(WWDATADIR)/ipxe

--- a/internal/app/wwctl/overlay/imprt/main_test.go
+++ b/internal/app/wwctl/overlay/imprt/main_test.go
@@ -2,7 +2,6 @@ package imprt
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -13,7 +12,7 @@ import (
 )
 
 func Test_List(t *testing.T) {
-	tmpdir, err := ioutil.TempDir(os.TempDir(), "warewulf")
+	tmpdir, err := os.MkdirTemp(os.TempDir(), "warewulf")
 	if err != nil {
 		t.Errorf("Could not create temp folder: %v", err)
 		t.FailNow()
@@ -34,7 +33,7 @@ func Test_List(t *testing.T) {
 		t.FailNow()
 	}
 
-	file, err := ioutil.TempFile(tmpdir, "file")
+	file, err := os.CreateTemp(tmpdir, "file")
 	if err != nil {
 		t.Errorf("Could not create tempfile")
 		t.FailNow()


### PR DESCRIPTION
- More aggressive cleaning based on contents of .gitignore.
- Replace deprecated io.ioutil functions with new os versions.

## Description of the Pull Request (PR):

Fix assorted build errors I encountered building on Rocky 9.2. Not sure teh OS
matters, but that is it.

