### PR TITLE
short runtime overlay name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New documentation for development environment (Vagrant)
 
 ### Fixed
-
+- Use a shorter/fixed name for the merged runtime overlay image. (#876)
 - The correct header is now displayed when `-al` flags are specified to overlay
   list.
 - Added a missing `.ww` extension to the `70-ww4-netname.rules` template in the

--- a/internal/pkg/overlay/config.go
+++ b/internal/pkg/overlay/config.go
@@ -3,7 +3,6 @@ package overlay
 import (
 	"os"
 	"path"
-	"strings"
 
 	warewulfconf "github.com/hpcng/warewulf/internal/pkg/config"
 )
@@ -32,5 +31,5 @@ Returns the overlay name of the image for a given node
 */
 func OverlayImage(nodeName string, overlayName []string) string {
 	conf := warewulfconf.Get()
-	return path.Join(conf.Paths.WWProvisiondir, "overlays/", nodeName, strings.Join(overlayName, "-")+".img")
+	return path.Join(conf.Paths.WWProvisiondir, "overlays/", nodeName, "RUNTIME_MERGED_OVERLAY.img")
 }


### PR DESCRIPTION
- Use short/fixed name for runtime overlay image.
- Update changelog.

## Description of the Pull Request (PR):

Use a short/fixed length name for the merged runtime overlay image. Addresses
#876. Could probably use a more impressive choice of name, but as-is this fixes
the filename too long error.


### This fixes or addresses the following GitHub issues:

 - Fixes #876

