### PR TITLE
Improved short-runtime-overlay-name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New documentation for development environment (Vagrant)
 
 ### Fixed
-- Use a short name for the merged runtime overlay. (#876)
+- Use a better short name for the merged runtime overlay. (#876)
 - More aggressive `make clean`.
 - Replace deprecated `io.utils` functions with new `os` functions.
 - The correct header is now displayed when `-al` flags are specified to overlay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New documentation for development environment (Vagrant)
 
 ### Fixed
-
+- More aggressive `make clean`.
+- Replace deprecated `io.utils` functions with new `os` functions.
 - The correct header is now displayed when `-al` flags are specified to overlay
   list.
 - Added a missing `.ww` extension to the `70-ww4-netname.rules` template in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New documentation for development environment (Vagrant)
 
 ### Fixed
+- Use a short name for the merged runtime overlay. (#876)
 - More aggressive `make clean`.
 - Replace deprecated `io.utils` functions with new `os` functions.
 - The correct header is now displayed when `-al` flags are specified to overlay

--- a/Makefile
+++ b/Makefile
@@ -281,17 +281,36 @@ wwapird: ## Build the rest api server (revese proxy to the grpc api server).
 	go build -o ./wwapird internal/app/api/wwapird/wwapird.go
 
 contclean:
+	rm -f $(WAREWULF)-$(VERSION).tar.gz
+	rm -f bash_completion
+	rm -f config
+	rm -f config_defaults 
+	rm -f Defaults.mk
+	rm -f etc/wwapi{c,d,rd}.conf
+	rm -f etc/wwapi{c,d,rd}.config
+	rm -f include/systemd/warewulfd.service
+	rm -f internal/pkg/buildconfig/setconfigs.go
+	rm -f internal/pkg/config/buildconfig.go
+	rm -f man_page 
+	rm -f print_defaults 
+	rm -f update_configuration
+	rm -f usr/share/man/man1/
+	rm -f warewulf.spec
+	rm -f warewulf-*.tar.gz
+	rm -f wwapic 
+	rm -f wwapid 
+	rm -f wwapird
 	rm -f wwclient
 	rm -f wwctl
-	rm -rf .dist
-	rm -f $(WAREWULF)-$(VERSION).tar.gz
-	rm -rf man_pages
-	rm -f warewulf.spec
-	rm -f config
-	rm -f Defaults.mk
 	rm -rf $(TOOLS_DIR)
-	rm -f update_configuration
-	rm -f etc/wwapi{c,d,rd}.conf
+	rm -rf bash_completion.d
+	rm -rf /config
+	rm -rf .dist/
+	rm -rf _dist/
+	rm -rf etc/bash_completion.d/
+	rm -rf man_pages
+	rm -rf userdocs/_*
+	rm -rf userdocs/reference/*
 
 clean: contclean
 	rm -rf vendor

--- a/internal/app/wwctl/overlay/imprt/main_test.go
+++ b/internal/app/wwctl/overlay/imprt/main_test.go
@@ -2,7 +2,6 @@ package imprt
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -13,7 +12,7 @@ import (
 )
 
 func Test_List(t *testing.T) {
-	tmpdir, err := ioutil.TempDir(os.TempDir(), "warewulf")
+	tmpdir, err := os.MkdirTemp(os.TempDir(), "warewulf")
 	if err != nil {
 		t.Errorf("Could not create temp folder: %v", err)
 		t.FailNow()
@@ -34,7 +33,7 @@ func Test_List(t *testing.T) {
 		t.FailNow()
 	}
 
-	file, err := ioutil.TempFile(tmpdir, "file")
+	file, err := os.CreateTemp(tmpdir, "file")
 	if err != nil {
 		t.Errorf("Could not create tempfile")
 		t.FailNow()

--- a/internal/pkg/overlay/config.go
+++ b/internal/pkg/overlay/config.go
@@ -3,6 +3,7 @@ package overlay
 import (
 	"os"
 	"path"
+	"strings"
 
 	warewulfconf "github.com/hpcng/warewulf/internal/pkg/config"
 )
@@ -31,5 +32,17 @@ Returns the overlay name of the image for a given node
 */
 func OverlayImage(nodeName string, overlayName []string) string {
 	conf := warewulfconf.Get()
-	return path.Join(conf.Paths.WWProvisiondir, "overlays/", nodeName, "RUNTIME_MERGED_OVERLAY.img")
+	var name string
+	if len(overlayName) == 1 {
+		name = overlayName[0]
+	} else {
+		var sb strings.Builder
+		for _, str := range overlayName {
+			if len(str) > 0 {
+				sb.WriteByte(str[0])
+			}
+		}
+		name = "__wwmerged_" + sb.String()
+	}
+	return path.Join(conf.Paths.WWProvisiondir, "overlays/", nodeName, name + ".img")
 }

--- a/internal/pkg/overlay/config.go
+++ b/internal/pkg/overlay/config.go
@@ -3,7 +3,6 @@ package overlay
 import (
 	"os"
 	"path"
-	"strings"
 
 	warewulfconf "github.com/hpcng/warewulf/internal/pkg/config"
 )
@@ -32,5 +31,5 @@ Returns the overlay name of the image for a given node
 */
 func OverlayImage(nodeName string, overlayName []string) string {
 	conf := warewulfconf.Get()
-	return path.Join(conf.Paths.WWProvisiondir, "overlays/", nodeName, strings.Join(overlayName, "-")+".img")
+	return path.Join(conf.Paths.WWProvisiondir, "overlays/", nodeName, "RUNTIME_MERGED_OVERLAY.img")
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

This improved version uses teh following logic:

if passed a single overlay name
    use that name
else
    create a name from the first letter of each passed overlay plus a prefix.

This preserves single overlay image names by using the full and recognizable
name of the overlay while also shortening the name of merged overlays but still
maintaining some recognizable features from using the first character of the
overlay names.

### This fixes or addresses the following GitHub issues:

 - Fixes #876

