### PR TITLE
Improved overlay image naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New documentation for development environment (Vagrant)
 
 ### Fixed
-
+- More aggressive `make clean`.
+- Replace deprecated `io.utils` functions with new `os` functions.
 - The correct header is now displayed when `-al` flags are specified to overlay
   list.
 - Added a missing `.ww` extension to the `70-ww4-netname.rules` template in the

--- a/Makefile
+++ b/Makefile
@@ -281,17 +281,36 @@ wwapird: ## Build the rest api server (revese proxy to the grpc api server).
 	go build -o ./wwapird internal/app/api/wwapird/wwapird.go
 
 contclean:
+	rm -f $(WAREWULF)-$(VERSION).tar.gz
+	rm -f bash_completion
+	rm -f config
+	rm -f config_defaults 
+	rm -f Defaults.mk
+	rm -f etc/wwapi{c,d,rd}.conf
+	rm -f etc/wwapi{c,d,rd}.config
+	rm -f include/systemd/warewulfd.service
+	rm -f internal/pkg/buildconfig/setconfigs.go
+	rm -f internal/pkg/config/buildconfig.go
+	rm -f man_page 
+	rm -f print_defaults 
+	rm -f update_configuration
+	rm -f usr/share/man/man1/
+	rm -f warewulf.spec
+	rm -f warewulf-*.tar.gz
+	rm -f wwapic 
+	rm -f wwapid 
+	rm -f wwapird
 	rm -f wwclient
 	rm -f wwctl
-	rm -rf .dist
-	rm -f $(WAREWULF)-$(VERSION).tar.gz
-	rm -rf man_pages
-	rm -f warewulf.spec
-	rm -f config
-	rm -f Defaults.mk
 	rm -rf $(TOOLS_DIR)
-	rm -f update_configuration
-	rm -f etc/wwapi{c,d,rd}.conf
+	rm -rf bash_completion.d
+	rm -rf /config
+	rm -rf .dist/
+	rm -rf _dist/
+	rm -rf etc/bash_completion.d/
+	rm -rf man_pages
+	rm -rf userdocs/_*
+	rm -rf userdocs/reference/*
 
 clean: contclean
 	rm -rf vendor

--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ files: all
 	install -m 0644 include/firewalld/warewulf.xml $(DESTDIR)$(FIREWALLDDIR)
 	install -m 0644 include/systemd/warewulfd.service $(DESTDIR)$(SYSTEMDDIR)
 	install -m 0644 LICENSE.md $(DESTDIR)$(WWDOCDIR)
-	./wwctl genconfig completions > $(DESTDIR)$(BASHCOMPDIR)/wwctl
+	./wwctl --warewulfconf etc/warewulf.conf genconfig completions > $(DESTDIR)$(BASHCOMPDIR)/wwctl
 	cp man_pages/*.1* $(DESTDIR)$(MANDIR)/man1/
 	cp man_pages/*.5* $(DESTDIR)$(MANDIR)/man5/
 	install -m 0644 staticfiles/README-ipxe.md $(DESTDIR)$(WWDATADIR)/ipxe

--- a/internal/app/wwctl/overlay/imprt/main_test.go
+++ b/internal/app/wwctl/overlay/imprt/main_test.go
@@ -2,7 +2,6 @@ package imprt
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -13,7 +12,7 @@ import (
 )
 
 func Test_List(t *testing.T) {
-	tmpdir, err := ioutil.TempDir(os.TempDir(), "warewulf")
+	tmpdir, err := os.MkdirTemp(os.TempDir(), "warewulf")
 	if err != nil {
 		t.Errorf("Could not create temp folder: %v", err)
 		t.FailNow()
@@ -34,7 +33,7 @@ func Test_List(t *testing.T) {
 		t.FailNow()
 	}
 
-	file, err := ioutil.TempFile(tmpdir, "file")
+	file, err := os.CreateTemp(tmpdir, "file")
 	if err != nil {
 		t.Errorf("Could not create tempfile")
 		t.FailNow()

--- a/internal/pkg/overlay/config.go
+++ b/internal/pkg/overlay/config.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/hpcng/warewulf/internal/pkg/wwlog"
 	warewulfconf "github.com/hpcng/warewulf/internal/pkg/config"
 )
 
@@ -30,7 +31,26 @@ func OverlaySourceDir(overlayName string) string {
 /*
 Returns the overlay name of the image for a given node
 */
-func OverlayImage(nodeName string, overlayName []string) string {
+func OverlayImage(nodeName string, overlayName []string, img_context ...string) string {
+	var name string
+	var context string
+
+	/* Check optional context argument. If missing, default to legacy. */
+	if len(img_context) == 0 {
+		context = "legacy"
+	} else {
+		context = img_context[0]
+	}
+
 	conf := warewulfconf.Get()
-	return path.Join(conf.Paths.WWProvisiondir, "overlays/", nodeName, strings.Join(overlayName, "-")+".img")
+
+	switch context {
+	case "legacy":
+		name = strings.Join(overlayName, "-")+".img"
+	default:
+		wwlog.Warn("Context %s passed to OverlayImage(), using %s to build image name.", context, "__" + strings.ToUpper(context) + "__")
+		name = "__" + strings.ToUpper(context) + "__.img"
+	}
+
+	return path.Join(conf.Paths.WWProvisiondir, "overlays/", nodeName, name)
 }

--- a/internal/pkg/warewulfd/provision.go
+++ b/internal/pkg/warewulfd/provision.go
@@ -59,6 +59,8 @@ func ProvisionSend(w http.ResponseWriter, req *http.Request) {
 	status_stage := status_stages[rinfo.stage]
 	var stage_overlays []string
 	var stage_file string = ""
+	var img_context string = "legacy" /* Default to old image name behavior */
+
 	// TODO: when module version is upgraded to go1.18, should be 'any' type
 	var tmpl_data interface{}
 
@@ -128,6 +130,7 @@ func ProvisionSend(w http.ResponseWriter, req *http.Request) {
 	} else if rinfo.stage == "system" {
 		if len(node.SystemOverlay.GetSlice()) != 0 {
 			stage_overlays = node.SystemOverlay.GetSlice()
+			img_context = rinfo.stage
 		} else {
 			wwlog.Warn("No system overlay set for node %s", node.Id.Get())
 		}
@@ -135,8 +138,10 @@ func ProvisionSend(w http.ResponseWriter, req *http.Request) {
 	} else if rinfo.stage == "runtime" {
 		if rinfo.overlay != "" {
 			stage_overlays = []string{rinfo.overlay}
+                        img_context = "legacy"
 		} else if len(node.RuntimeOverlay.GetSlice()) != 0 {
 			stage_overlays = node.RuntimeOverlay.GetSlice()
+                        img_context = rinfo.stage
 		} else {
 			wwlog.Warn("No runtime overlay set for node %s", node.Id.Get())
 		}
@@ -147,7 +152,8 @@ func ProvisionSend(w http.ResponseWriter, req *http.Request) {
 		stage_file, err = getOverlayFile(
 			node.Id.Get(),
 			stage_overlays,
-			conf.Warewulf.AutobuildOverlays)
+			conf.Warewulf.AutobuildOverlays,
+			img_context )
 
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)

--- a/internal/pkg/warewulfd/util.go
+++ b/internal/pkg/warewulfd/util.go
@@ -44,9 +44,10 @@ func sendFile(
 func getOverlayFile(
 	nodeId string,
 	stage_overlays []string,
-	autobuild bool ) (stage_file string, err error) {
+	autobuild bool,
+        img_context string) (stage_file string, err error) {
 
-	stage_file = overlay.OverlayImage(nodeId, stage_overlays)
+	stage_file = overlay.OverlayImage(nodeId, stage_overlays, img_context)
 	err = nil
 
 	build := !util.IsFile(stage_file)


### PR DESCRIPTION
## Description of the Pull Request (PR):

This addresses the system/runtime overlay image naming by adding an optional
argument to OverlayImage() to specify the context in which an image name is
being constructed. If set to "legacy" then the old name joining method is used.
Any other value passed is used to construct a short image name. For example,
the node config:

```
nodeprofiles:
  default:
    comment: This profile is automatically included for each node
    container name: rocky-9
    runtime overlay:
      - generic
      - debug
    system overlay:
       - wwinit
    kernel:
      override: rocky-9
      args: selinux=0 rootfs=tmpfs consoleblank=600
nodes:
  cpu-a-1:
    profiles:
    - default
    network devices:
      clusternet:
        device: eth0
        hwaddr: 28:80:23:e8:7b:f0
        ipaddr: 100.68.0.66
        primary: "true"
```

Produces the overlay images:

```
[root@micropterus overlays]# tree
.
├── cpu-a-1
│   ├── debug.img
│   ├── debug.img.gz
│   ├── generic.img
│   ├── generic.img.gz
│   ├── __RUNTIME__.img
│   ├── __RUNTIME__.img.gz
│   ├── __SYSTEM__.img
│   └── __SYSTEM__.img.gz
```

Functions that use OverlayImage() have been updated to pass the context along
where applicable.

BuildOverlay() gets an optional argument so it can pass the context through.

BuildSpecificOverlays() has been changed to loop over the overlay list, calling
BuildOverlay() for a single overlay at a time and defaulting to the legacy
naming, which for a single overlay just names the image OVERLAYNAME.img.

ProvisionSend() conditionally sends `legacy` for the image if the querystring
specifed an `overlay=` value, otherwise the stage is used, which results in the
`__RUNTIME__.img` or `__SYSTEM__.img` image names.

Because OverlayImage uses the passed img_context to construct the name, it's
open-ended for constructing merged overlays images with short, specific names.

### This fixes or addresses the following GitHub issues:

 - Fixes #876 #852

