### PR TITLE
Add CONTRIBUTING documentation with a DCO

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing
+
+## Contributor's Agreement
+
+You are under no obligation whatsoever to provide any bug fixes, patches, or
+upgrades to the features, functionality or performance of the source code
+("Enhancements") to anyone; however, if you choose to make your Enhancements
+available either publicly, or directly to the project, without imposing a
+separate written license agreement for such Enhancements, then you hereby grant
+the following license: a non-exclusive, royalty-free perpetual license to
+install, use, modify, prepare derivative works, incorporate into other computer
+software, distribute, and sublicense such enhancements or derivative works
+thereof, in binary and source code form.
+
+## Getting Started
+
+When contributing to Warewulf, it is important to properly communicate the gist
+of the contribution. If it is a simple code or editorial fix, simply explaining
+this within the GitHub Pull Request (PR) will suffice. But if this is a larger
+fix or Enhancement, you are advised to first discuss the change with the
+project leader or developers.
+
+All commits must be "Signed-off" by using `git commit -s`, acknowledging that
+you agree to the [Developer Certificate of Origin](DCO.txt).  

--- a/DCO.txt
+++ b/DCO.txt
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
Requires commit sign-off and documents the meaning of signing off for the project.