### PR TITLE
Restore %config(noreplace) to nodes.conf

### DIFF
--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -120,7 +120,7 @@ getent group %{wwgroup} >/dev/null || groupadd -r %{wwgroup}
 %config(noreplace) %{_sysconfdir}/warewulf/wwapi*.conf
 %config(noreplace) %{_sysconfdir}/warewulf/examples
 %config(noreplace) %{_sysconfdir}/warewulf/ipxe
-%attr(0640,-,-) %{_sysconfdir}/warewulf/nodes.conf
+%config(noreplace) %attr(0640,-,-) %{_sysconfdir}/warewulf/nodes.conf
 %{_sysconfdir}/bash_completion.d/wwctl
 
 %dir %{_sharedstatedir}/warewulf


### PR DESCRIPTION
The previous PR #888 erroneously removed the %config(noreplace) macro from the nodes.conf file. This PR restores it.