### PR TITLE
Epehermal container mounts on same fs as chroot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add EL9 Quickstart guide to index.rst
 - Container file gids are now updated properly during syncuser. #840
 - Fix build for API.
+- Bindd mounts for `wwctl exec` are now on the same fs
 
 ### Changed
 

--- a/internal/app/wwctl/container/exec/child/root.go
+++ b/internal/app/wwctl/container/exec/child/root.go
@@ -1,6 +1,8 @@
 package child
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+)
 
 var (
 	baseCmd = &cobra.Command{
@@ -12,14 +14,12 @@ var (
 		FParseErrWhitelist:    cobra.FParseErrWhitelist{UnknownFlags: true},
 	}
 	binds    []string
-	tempDir  string
 	nodename string
 )
 
 func init() {
 	baseCmd.Flags().StringVarP(&nodename, "node", "n", "", "create ro overlay for given node")
 	baseCmd.Flags().StringArrayVarP(&binds, "bind", "b", []string{}, "bind points")
-	baseCmd.Flags().StringVar(&tempDir, "tempdir", "", "tempdir")
 }
 
 // GetRootCommand returns the root cobra.Command for the application.


### PR DESCRIPTION
Previously ephemeral container mounts were performed in /tmp. Now these
mounts are overlayed on the same fs as is used for chroots as fs overlays
need to be on the same fs.

Signed-off-by: Christian Goll <cgoll@suse.de>
