### PR TITLE
Updated Makefile to account for vendor/ in dist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY . /warewulf-src
 RUN cd /warewulf-src &&\
   make contclean Defaults.mk \
     PREFIX=/usr \
-    BINDIRa=/usr/bin \
+    BINDIR=/usr/bin \
     SYSCONFDIR=/etc \
     DATADIR=/usr/share \
     LOCALSTATEDIR=/var/lib \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ RUN zypper  -n install --no-recommends git go1.18 libgpgme-devel &&\
 COPY . /warewulf-src
 
 RUN cd /warewulf-src &&\
-  make contclean Defaults.mk \
+  make clean \
+    OFFLINE_BUILD=1 &&\
+  make defaults \
     PREFIX=/usr \
     BINDIR=/usr/bin \
     SYSCONFDIR=/etc \

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,10 @@ include Variables.mk
 include Tools.mk
 
 .PHONY: build
-build: wwctl wwclient man_pages wwapid wwapic wwapird etc/defaults.conf etc/bash_completion.d/wwctl
+build: wwctl wwclient wwapid wwapic wwapird etc/defaults.conf etc/bash_completion.d/wwctl
+
+.PHONY: docs
+docs: man_pages reference
 
 vendor:
 ifndef OFFLINE_BUILD
@@ -81,7 +84,7 @@ test-cover: $(config)
 	go tool cover -html=coverage/cover.out -o=coverage/cover.html
 
 .PHONY: install
-install: all
+install: build docs
 	install -d -m 0755 $(DESTDIR)$(BINDIR)
 	install -d -m 0755 $(DESTDIR)$(WWCHROOTDIR)
 	install -d -m 0755 $(DESTDIR)$(WWPROVISIONDIR)

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
+.PHONY: all
+all: build
+	
 include Variables.mk
 include Tools.mk
 
-.PHONY: all
-all: wwctl wwclient man_pages wwapid wwapic wwapird etc/defaults.conf etc/bash_completion.d/wwctl
+.PHONY: build
+build: wwctl wwclient man_pages wwapid wwapic wwapird etc/defaults.conf etc/bash_completion.d/wwctl
 
 vendor:
 ifndef OFFLINE_BUILD

--- a/Makefile
+++ b/Makefile
@@ -152,13 +152,20 @@ reference: wwctl
 latexpdf: reference
 	make -C userdocs latexpdf
 
+proto = internal/pkg/api/routes/wwapiv1/routes.pb.go \
+	internal/pkg/api/routes/wwapiv1/routes.pb.gw.go \
+	internal/pkg/api/routes/wwapiv1/routes_grpc.pb.go
 .PHONY: proto
-proto: $(PROTOC) $(PROTOC_GEN_GRPC_GATEWAY) $(PROTOC_GEN_GO) $(PROTOC_GEN_GO_GRPC)
-	PATH=$(TOOLS_BIN):$(PATH) $(PROTOC) -I /usr/include -I internal/pkg/api/routes/v1 -I=. \
-		--grpc-gateway_out=. \
+proto: $(proto)
+
+routes_proto = internal/pkg/api/routes/v1/routes.proto
+internal/pkg/api/routes/wwapiv1/%.go: $(PROTOC) $(PROTOC_GEN_GRPC_GATEWAY) $(PROTOC_GEN_GO) $(PROTOC_GEN_GO_GRPC) $(routes_proto)
+	PATH=$(TOOLS_BIN):$(PATH) $(PROTOC) \
+		-I /usr/include -I $(shell dirname $(routes_proto)) -I=. \
 		--grpc-gateway_opt logtostderr=true \
 		--go_out=. \
 		--go-grpc_out=. \
+		--grpc-gateway_out=. \
 		routes.proto
 
 .PHONY: cleanconfig

--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,10 @@ internal/pkg/api/routes/wwapiv1/%.go: $(PROTOC) $(PROTOC_GEN_GRPC_GATEWAY) $(PRO
 		--grpc-gateway_out=. \
 		routes.proto
 
+.PHONY: cleanproto
+cleanproto:
+	rm -f $(proto)
+
 .PHONY: cleanconfig
 cleanconfig:
 	rm -f $(config)

--- a/Makefile
+++ b/Makefile
@@ -1,44 +1,14 @@
 include Variables.mk
+include Tools.mk
 
 .PHONY: all
-all: config vendor wwctl wwclient man_pages wwapid wwapic wwapird etc/defaults.conf etc/bash_completion.d/wwctl
-
-.PHONY: build
-build: lint test vet all
-
-.PHONY: setup_tools
-setup_tools: $(GO_TOOLS_BIN) $(GOLANGCI_LINT) $(PROTOC_GEN_GO) $(PROTOC_GEN_GO_GRPC)
-
-$(GO_TOOLS_BIN):	
-	GOBIN="$(PWD)/$(TOOLS_BIN)" go install -mod=vendor $(GO_TOOLS)
-
-$(GOLANGCI_LINT):
-	curl -qq -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TOOLS_BIN) $(GOLANGCI_LINT_VERSION)
-
-$(PROTOC):
-	cd $(PWD)/$(TOOLS_DIR) && curl -LO $(PROTOC_URL) && unzip protoc-24.0-linux-$(ARCHITECTURE_CPU).zip
-
-$(PROTOC_GEN_GRPC_GATEWAY):
-	curl -L $(PROTOC_GEN_GRPC_GATEWAY_URL) -o $(PROTOC_GEN_GRPC_GATEWAY)
-	chmod +x $(PROTOC_GEN_GRPC_GATEWAY)
-
-$(PROTOC_GEN_GO):
-	GOBIN="$(PWD)/$(TOOLS_BIN)" go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28
-
-$(PROTOC_GEN_GO_GRPC):
-	GOBIN="$(PWD)/$(TOOLS_BIN)" go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
-
-.PHONY: setup
-setup: vendor $(TOOLS_DIR) setup_tools
+all: wwctl wwclient man_pages wwapid wwapic wwapird etc/defaults.conf etc/bash_completion.d/wwctl
 
 vendor:
 ifndef OFFLINE_BUILD
 	go mod tidy -v
 	go mod vendor
 endif
-
-$(TOOLS_DIR):
-	mkdir -p $@
 
 .PHONY: config
 config: etc/wwapic.conf \
@@ -48,14 +18,44 @@ config: etc/wwapic.conf \
 	internal/pkg/config/buildconfig.go \
 	warewulf.spec
 
-etc/defaults.conf: wwctl
-	./wwctl --emptyconf genconfig defaults >etc/defaults.conf
-
 %: %.in
 	sed -ne "$(foreach V,$(VARLIST),s,@$V@,$(strip $($V)),g;)p" $@.in >$@
 
+wwctl: config vendor $(call godeps,cmd/wwctl/main.go)
+	GOOS=linux go build -mod vendor -tags "$(WW_GO_BUILD_TAGS)" -o wwctl cmd/wwctl/main.go
+
+wwclient: config vendor $(call godeps,cmd/wwclient/main.go)
+	CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -ldflags "-extldflags -static" -o wwclient cmd/wwclient/main.go
+
+update_configuration: config vendor $(call godeps,cmd/update_configuration/update_configuration.go)
+	go build -X 'github.com/hpcng/warewulf/internal/pkg/node.ConfigFile=./etc/nodes.conf'" \
+	    -mod vendor -tags "$(WW_GO_BUILD_TAGS)" -o update_configuration cmd/update_configuration/update_configuration.go
+
+wwapid: config vendor $(call godeps,internal/app/api/wwapid/wwapid.go)
+	go build -o ./wwapid internal/app/api/wwapid/wwapid.go
+
+wwapic: config vendor $(call godeps,internal/app/api/wwapic/wwapic.go)
+	go build -o ./wwapic  internal/app/api/wwapic/wwapic.go
+
+wwapird: config vendor $(call godeps,internal/app/api/wwapird/wwapird.go)
+	go build -o ./wwapird internal/app/api/wwapird/wwapird.go
+
+.PHONY: man_pages
+man_pages: wwctl $(wildcard docs/man/man5/*.5)
+	mkdir -p docs/man/man1
+	./wwctl --emptyconf genconfig man docs/man/man1
+	gzip --force docs/man/man1/*.1
+	gzip --force --keep docs/man/man5/*.5
+
+etc/defaults.conf: wwctl
+	./wwctl --emptyconf genconfig defaults >etc/defaults.conf
+
+etc/bash_completion.d/wwctl: wwctl
+	mkdir -p etc/bash_completion.d/
+	./wwctl --emptyconf genconfig completions >etc/bash_completion.d/wwctl
+
 .PHONY: lint
-lint: setup_tools
+lint: config $(GOLANGCI_LINT)
 	$(GOLANGCI_LINT) run --build-tags "$(WW_GO_BUILD_TAGS)" --skip-dirs internal/pkg/staticfiles ./...
 
 .PHONY: vet
@@ -123,44 +123,14 @@ install: all
 	install -m 0644 staticfiles/x86_64.efi $(DESTDIR)$(WWDATADIR)/ipxe
 	install -m 0644 staticfiles/x86_64.kpxe $(DESTDIR)$(WWDATADIR)/ipxe
 
-etc/bash_completion.d/wwctl: wwctl
-	mkdir -p etc/bash_completion.d/
-	./wwctl --emptyconf genconfig completions >etc/bash_completion.d/wwctl
-
 .PHONY: init
 init:
 	systemctl daemon-reload
 	cp -r tftpboot/* $(WWTFTPDIR)/ipxe/
 	restorecon -r $(WWTFTPDIR)
 
-wwctl: config vendor $(call godeps,cmd/wwctl/main.go)
-	GOOS=linux go build -mod vendor -tags "$(WW_GO_BUILD_TAGS)" -o wwctl cmd/wwctl/main.go
-
-wwclient: config vendor $(call godeps,cmd/wwclient/main.go)
-	CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -ldflags "-extldflags -static" -o wwclient cmd/wwclient/main.go
-
-.PHONY: man_pages
-man_pages: wwctl $(wildcard docs/man/man5/*.5)
-	mkdir -p docs/man/man1
-	./wwctl --emptyconf genconfig man docs/man/man1
-	gzip --force docs/man/man1/*.1
-	gzip --force --keep docs/man/man5/*.5
-
-update_configuration: vendor $(call godeps,cmd/update_configuration/update_configuration.go)
-	go build -X 'github.com/hpcng/warewulf/internal/pkg/node.ConfigFile=./etc/nodes.conf'" \
-	    -mod vendor -tags "$(WW_GO_BUILD_TAGS)" -o update_configuration cmd/update_configuration/update_configuration.go
-
-wwapid: $(call godeps,internal/app/api/wwapid/wwapid.go)
-	go build -o ./wwapid internal/app/api/wwapid/wwapid.go
-
-wwapic: $(call godeps,internal/app/api/wwapic/wwapic.go)
-	go build -o ./wwapic  internal/app/api/wwapic/wwapic.go
-
-wwapird: $(call godeps,internal/app/api/wwapird/wwapird.go)
-	go build -o ./wwapird internal/app/api/wwapird/wwapird.go
-
 .PHONY: dist
-dist: vendor config
+dist: vendor
 	rm -rf .dist/ $(WAREWULF)-$(VERSION).tar.gz
 	mkdir -p .dist/$(WAREWULF)-$(VERSION)
 	rsync -a --exclude=".*" --exclude "*~" * .dist/$(WAREWULF)-$(VERSION)/
@@ -184,25 +154,47 @@ proto: $(PROTOC) $(PROTOC_GEN_GRPC_GATEWAY) $(PROTOC_GEN_GO) $(PROTOC_GEN_GO_GRP
 		--go-grpc_out=. \
 		routes.proto
 
-.PHONY: contclean
-contclean:
-	rm -f Defaults.mk
-	rm -f $(WAREWULF)-$(VERSION).tar.gz
-	rm -f wwapi{c,d,rd} etc/wwapi{c,d,rd}.conf
+.PHONY: cleanconfig
+cleanconfig:
+	rm -f etc/wwapi{c,d,rd}.conf
 	rm -f include/systemd/warewulfd.service
 	rm -f internal/pkg/config/buildconfig.go
-	rm -f update_configuration
 	rm -f warewulf.spec
-	rm -f wwclient
-	rm -f wwctl
-	rm -rf $(TOOLS_DIR)
-	rm -rf .dist/
 	rm -rf etc/bash_completion.d/
-	rm -rf userdocs/_*
-	rm -rf userdocs/reference/*
 	rm -rf etc/defaults.conf
+
+.PHONY: cleantest
+cleantest:
 	rm -rf *.coverprofile
 
-.PHONY: clean
-clean: contclean
+.PHONY: cleandist
+cleandist:
+	rm -f $(WAREWULF)-$(VERSION).tar.gz
+	rm -rf .dist/
+
+.PHONY: cleanmake
+cleanmake:
+	rm -f Defaults.mk
+
+.PHONY: cleanbin
+cleanbin:
+	rm -f wwapi{c,d,rd}
+	rm -f wwclient
+	rm -f wwctl
+	rm -f update_configuration
+
+.PHONY: cleandocs
+cleandocs:
+	rm -rf userdocs/_*
+	rm -rf userdocs/reference/*
+	rm -rf docs/man/man1
+	rm -rf docs/man/man5/*.gz
+
+.PHONY: cleanvendor
+cleanvendor:
+ifndef OFFLINE_BUILD
 	rm -rf vendor
+endif
+
+.PHONY: clean
+clean: cleanconfig cleantest cleandist cleantools cleanmake cleanbin cleandocs cleanvendor

--- a/Tools.mk
+++ b/Tools.mk
@@ -1,0 +1,47 @@
+TOOLS_DIR := .tools
+TOOLS_BIN := $(TOOLS_DIR)/bin
+
+GO_TOOLS_BIN := $(addprefix $(TOOLS_BIN)/, $(notdir $(GO_TOOLS)))
+GO_TOOLS_VENDOR := $(addprefix vendor/, $(GO_TOOLS))
+GOLANGCI_LINT := $(TOOLS_BIN)/golangci-lint
+GOLANGCI_LINT_VERSION := v1.53.2
+PROTOC_GEN_GO := $(TOOLS_BIN)/protoc-gen-go
+PROTOC_GEN_GO_GRPC := $(TOOLS_BIN)/protoc-gen-go-grpc
+PROTOC := $(TOOLS_BIN)/protoc
+PROTOC_GEN_GRPC_GATEWAY := $(TOOLS_BIN)/protoc-gen-grpc-gateway
+
+ifeq ($(ARCH),aarch64)
+PROTOC_URL := https://github.com/protocolbuffers/protobuf/releases/download/v24.0/protoc-24.0-linux-aarch_64.zip
+PROTOC_GEN_GRPC_GATEWAY_URL := https://github.com/grpc-ecosystem/grpc-gateway/releases/download/v2.16.2/protoc-gen-grpc-gateway-v2.16.2-linux-arm64
+else
+PROTOC_URL := https://github.com/protocolbuffers/protobuf/releases/download/v24.0/protoc-24.0-linux-x86_64.zip
+PROTOC_GEN_GRPC_GATEWAY_URL := https://github.com/grpc-ecosystem/grpc-gateway/releases/download/v2.16.2/protoc-gen-grpc-gateway-v2.16.2-linux-x86_64
+endif
+
+$(TOOLS_DIR):
+	mkdir -p $@
+
+.PHONY: tools
+tools: $(GO_TOOLS_BIN) $(GOLANGCI_LINT) $(PROTOC_GEN_GO) $(PROTOC_GEN_GO_GRPC)
+
+$(GO_TOOLS_BIN):
+	GOBIN="$(PWD)/$(TOOLS_BIN)" go install -mod=vendor $(GO_TOOLS)
+
+$(GOLANGCI_LINT):
+	curl -qq -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TOOLS_BIN) $(GOLANGCI_LINT_VERSION)
+
+$(PROTOC):
+	cd $(PWD)/$(TOOLS_DIR) && curl -LO $(PROTOC_URL) && unzip protoc-24.0-linux-$(ARCHITECTURE_CPU).zip
+
+$(PROTOC_GEN_GRPC_GATEWAY):
+	curl -L $(PROTOC_GEN_GRPC_GATEWAY_URL) -o $(PROTOC_GEN_GRPC_GATEWAY)
+	chmod +x $(PROTOC_GEN_GRPC_GATEWAY)
+
+$(PROTOC_GEN_GO):
+	GOBIN="$(PWD)/$(TOOLS_BIN)" go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28
+
+$(PROTOC_GEN_GO_GRPC):
+	GOBIN="$(PWD)/$(TOOLS_BIN)" go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
+
+.PHONY: cleantools
+	rm -rf $(TOOLS_DIR)

--- a/Tools.mk
+++ b/Tools.mk
@@ -3,11 +3,13 @@ TOOLS_BIN := $(TOOLS_DIR)/bin
 
 GO_TOOLS_BIN := $(addprefix $(TOOLS_BIN)/, $(notdir $(GO_TOOLS)))
 GO_TOOLS_VENDOR := $(addprefix vendor/, $(GO_TOOLS))
+
 GOLANGCI_LINT := $(TOOLS_BIN)/golangci-lint
 GOLANGCI_LINT_VERSION := v1.53.2
+
+PROTOC := $(TOOLS_BIN)/protoc
 PROTOC_GEN_GO := $(TOOLS_BIN)/protoc-gen-go
 PROTOC_GEN_GO_GRPC := $(TOOLS_BIN)/protoc-gen-go-grpc
-PROTOC := $(TOOLS_BIN)/protoc
 PROTOC_GEN_GRPC_GATEWAY := $(TOOLS_BIN)/protoc-gen-grpc-gateway
 
 ifeq ($(ARCH),aarch64)
@@ -32,6 +34,7 @@ $(GOLANGCI_LINT):
 
 $(PROTOC): $(TOOLS_DIR)
 	cd $(TOOLS_DIR) && curl -LO $(PROTOC_URL) && unzip -o $(notdir $(PROTOC_URL))
+	touch --no-create $(PROTOC) # by default the timestamp is preserved from the archive
 
 $(PROTOC_GEN_GRPC_GATEWAY):
 	curl -L $(PROTOC_GEN_GRPC_GATEWAY_URL) -o $(PROTOC_GEN_GRPC_GATEWAY)

--- a/Tools.mk
+++ b/Tools.mk
@@ -30,8 +30,8 @@ $(GO_TOOLS_BIN):
 $(GOLANGCI_LINT):
 	curl -qq -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TOOLS_BIN) $(GOLANGCI_LINT_VERSION)
 
-$(PROTOC):
-	cd $(PWD)/$(TOOLS_DIR) && curl -LO $(PROTOC_URL) && unzip protoc-24.0-linux-$(ARCHITECTURE_CPU).zip
+$(PROTOC): $(TOOLS_DIR)
+	cd $(TOOLS_DIR) && curl -LO $(PROTOC_URL) && unzip -o $(notdir $(PROTOC_URL))
 
 $(PROTOC_GEN_GRPC_GATEWAY):
 	curl -L $(PROTOC_GEN_GRPC_GATEWAY_URL) -o $(PROTOC_GEN_GRPC_GATEWAY)

--- a/Tools.mk
+++ b/Tools.mk
@@ -47,4 +47,5 @@ $(PROTOC_GEN_GO_GRPC):
 	GOBIN="$(PWD)/$(TOOLS_BIN)" go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
 
 .PHONY: cleantools
+cleantools:
 	rm -rf $(TOOLS_DIR)

--- a/Variables.mk
+++ b/Variables.mk
@@ -4,6 +4,9 @@
 OS_REL := $(shell sed -n "s/^ID\s*=\s*['"\""]\(.*\)['"\""]/\1/p" /etc/os-release)
 OS ?= $(OS_REL)
 
+ARCH_REL := $(shell uname -p)
+ARCH ?= $(ARCH_REL)
+
 # List of variables to save and replace in files
 VARLIST := OS
 
@@ -75,24 +78,7 @@ WWDOCDIR := $(DOCDIR)/$(WAREWULF)
 WWDATADIR := $(DATADIR)/$(WAREWULF)
 WWCLIENTDIR ?= /warewulf
 
-# auto installed tooling
-TOOLS_DIR := .tools
-TOOLS_BIN := $(TOOLS_DIR)/bin
 CONFIG := $(shell pwd)
-
-# tools
-GO_TOOLS_BIN := $(addprefix $(TOOLS_BIN)/, $(notdir $(GO_TOOLS)))
-GO_TOOLS_VENDOR := $(addprefix vendor/, $(GO_TOOLS))
-GOLANGCI_LINT := $(TOOLS_BIN)/golangci-lint
-GOLANGCI_LINT_VERSION := v1.53.2
-PROTOC_GEN_GO := $(TOOLS_BIN)/protoc-gen-go
-PROTOC_GEN_GO_GRPC := $(TOOLS_BIN)/protoc-gen-go-grpc
-PROTOC := $(TOOLS_BIN)/protoc
-PROTOC_URL := https://github.com/protocolbuffers/protobuf/releases/download/v24.0/protoc-24.0-linux-x86_64.zip
-#PROTOC_URL := https://github.com/protocolbuffers/protobuf/releases/download/v24.0/protoc-24.0-linux-aarch_64.zip
-PROTOC_GEN_GRPC_GATEWAY := $(TOOLS_BIN)/protoc-gen-grpc-gateway
-PROTOC_GEN_GRPC_GATEWAY_URL := https://github.com/grpc-ecosystem/grpc-gateway/releases/download/v2.16.2/protoc-gen-grpc-gateway-v2.16.2-linux-x86_64
-#PROTOC_GEN_GRPC_GATEWAY_URL := https://github.com/grpc-ecosystem/grpc-gateway/releases/download/v2.16.2/protoc-gen-grpc-gateway-v2.16.2-linux-arm64
 
 # helper functions
 godeps=$(shell go list -deps -f '{{if not .Standard}}{{ $$dep := . }}{{range .GoFiles}}{{$$dep.Dir}}/{{.}} {{end}}{{end}}' $(1) | sed "s%${PWD}/%%g")
@@ -106,5 +92,6 @@ export GOPROXY
 # built tags needed for wwbuild binary
 WW_GO_BUILD_TAGS := containers_image_openpgp containers_image_ostree
 
-Defaults.mk:
+.PHONY: defaults
+defaults:
 	printf " $(foreach V,$(VARLIST),$V := $(strip $($V))\n)" >Defaults.mk

--- a/Variables.mk
+++ b/Variables.mk
@@ -83,8 +83,6 @@ CONFIG := $(shell pwd)
 # helper functions
 godeps=$(shell go list -deps -f '{{if not .Standard}}{{ $$dep := . }}{{range .GoFiles}}{{$$dep.Dir}}/{{.}} {{end}}{{end}}' $(1) | sed "s%${PWD}/%%g")
 
-ARCHITECTURE_CPU=$(shell lscpu | grep 'Architecture' | cut -d':' -f2 | xargs)
-
 # use GOPROXY for older git clients and speed up downloads
 GOPROXY ?= https://proxy.golang.org
 export GOPROXY

--- a/userdocs/contributing/development-environment-vagrant.rst
+++ b/userdocs/contributing/development-environment-vagrant.rst
@@ -158,7 +158,7 @@ Vagrantfile
                 git clone https://github.com/hpcng/warewulf.git
                 cd warewulf
                 git checkout v4.4.0
-                make clean Defaults.mk \
+                make clean defaults \
                     PREFIX=/usr \
                     BINDIR=/usr/bin \
                     SYSCONFDIR=/etc \

--- a/userdocs/quickstart/el8.rst
+++ b/userdocs/quickstart/el8.rst
@@ -14,7 +14,7 @@ Install Warewulf and dependencies
 
    git clone https://github.com/hpcng/warewulf.git
    cd warewulf
-   make clean Defaults.mk \
+   make clean defaults \
     PREFIX=/usr \
     BINDIR=/usr/bin \
     SYSCONFDIR=/etc \

--- a/userdocs/quickstart/el9.rst
+++ b/userdocs/quickstart/el9.rst
@@ -14,7 +14,7 @@ Install Warewulf and dependencies
 
    git clone https://github.com/hpcng/warewulf.git
    cd warewulf
-   make clean Defaults.mk \
+   make clean defaults \
     PREFIX=/usr \
     BINDIR=/usr/bin \
     SYSCONFDIR=/etc \

--- a/userdocs/quickstart/suse15.rst
+++ b/userdocs/quickstart/suse15.rst
@@ -16,7 +16,7 @@ Install Warewulf and dependencies
 
    git clone https://github.com/hpcng/warewulf.git
    cd warewulf
-   PREFIX=/usr SYSCONFDIR=/etc TFTPDIR=/srv/tftproot LOCALSTATEDIR=/var/lib make clean Defaults.mk
+   PREFIX=/usr SYSCONFDIR=/etc TFTPDIR=/srv/tftproot LOCALSTATEDIR=/var/lib make clean defaults
    make all
    sudo make install
 

--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -71,7 +71,7 @@ system for large clusters of bare metal and/or virtual systems.
 %build
 %{?with_offline:OFFLINE_BUILD=1}
 # Install to sharedstatedir by redirecting LOCALSTATEDIR
-make Defaults.mk \
+make defaults \
     PREFIX=%{_prefix} \
     BINDIR=%{_bindir} \
     SYSCONFDIR=%{_sysconfdir} \


### PR DESCRIPTION
The previous PR #890 introduced a `Defaults.mk` target for defining default variables for future calls to `make`. This functionality was already present in a different form, but this new "real" target had an unintended side-effect of causing the target to be called automatically at reference, even the optional reference `-include Defaults.mk`. This is undesirable as it causes the generation of defaults even during a `make clean`.

This commit resolves these issues and further refactors the Makefile, building on the work in #890, but with additional understanding:

* Convert the `Defaults.mk` target to the "phony" `defaults` target, preventing automatic generation
* Remove `make clean` from `warewulf.spec`, expecting the contents of the dist to be appropriate
* Refactor and split `clean` targets
* Update `cleanvendor` to reflect `OFFLINE_BUILD`, similar to the `vendor` target
* Move "tools" targets into `Tools.mk`
* Add `ARCH` to `Variables.mk` for architecture-specific actions