### PR TITLE
add error handling to dynamic network configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add EL9 Quickstart guide to index.rst
 - Container file gids are now updated properly during syncuser. #840
 - Fix build for API.
+- Add error handling to `wwctl`'s dynamic IP configuration attempt.
 
 ### Changed
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -27,3 +27,4 @@
 * Jeffrey Frey @jtfrey 
 * Xu Yang(Jason Yang) <jasonyangshadow@gmail.com> @JasonYangShadow
 * Arnaud LECOMTE <contact@arnaud-lcm.com>
+* Matt Jolly <Matt.Jolly@footclan.ninja>

--- a/internal/pkg/config/root.go
+++ b/internal/pkg/config/root.go
@@ -119,7 +119,10 @@ func (conf *RootConf) SetDynamicDefaults() (err error) {
 
 		if conf.Ipaddr == "" {
 			wwlog.Verbose("Configuration has no valid network, going to dynamic values")
-			conn, _ := net.Dial("udp", "8.8.8.8:80")
+			conn, err := net.Dial("udp", "8.8.8.8:80")
+			if err != nil {
+				return errors.Wrap(err, "Couldn't establish a connection to remote")
+			}
 			defer conn.Close()
 			ipaddr = conn.LocalAddr().(*net.UDPAddr).IP
 			mask = ipaddr.DefaultMask()


### PR DESCRIPTION
## Description of the Pull Request (PR):

`wwctl` panics rather than returning an error if it cannot detect the IP address and one is not provided in config (e.g. during the build process).

Before:

```
goroutine 1 [running]:
github.com/hpcng/warewulf/internal/pkg/config.(*RootConf).SetDynamicDefaults(0x555b2e273340)
        /var/tmp/portage/sys-cluster/warewulf-4.4.1_p20230907/work/warewulf-f1eab8c363e135eca608c7471464e0fb5460bae7/internal/pkg/config/root.go:123 +0xaf
github.com/hpcng/warewulf/internal/app/wwctl.rootPersistentPreRunE(0xc0002a9900?, {0xc000526be0?, 0x4?, 0x555b2d8c071b?})
        /var/tmp/portage/sys-cluster/warewulf-4.4.1_p20230907/work/warewulf-f1eab8c363e135eca608c7471464e0fb5460bae7/internal/app/wwctl/root.go:92 +0x125
github.com/spf13/cobra.(*Command).execute(0x555b2e210720, {0xc000526bc0, 0x2, 0x2})
        /var/tmp/portage/sys-cluster/warewulf-4.4.1_p20230907/work/warewulf-f1eab8c363e135eca608c7471464e0fb5460bae7/vendor/github.com/spf13/cobra/command.go:891 +0x75f
github.com/spf13/cobra.(*Command).ExecuteC(0x555b2e20b980)
        /var/tmp/portage/sys-cluster/warewulf-4.4.1_p20230907/work/warewulf-f1eab8c363e135eca608c7471464e0fb5460bae7/vendor/github.com/spf13/cobra/command.go:1044 +0x3a5
github.com/spf13/cobra.(*Command).Execute(0xc0000021a0?)
        /var/tmp/portage/sys-cluster/warewulf-4.4.1_p20230907/work/warewulf-f1eab8c363e135eca608c7471464e0fb5460bae7/vendor/github.com/spf13/cobra/command.go:968 +0x13
main.main()
        /var/tmp/portage/sys-cluster/warewulf-4.4.1_p20230907/work/warewulf-f1eab8c363e135eca608c7471464e0fb5460bae7/cmd/wwctl/main.go:13 +0x1e
make: *** [Makefile:52: etc/defaults.conf] Error 2
make: *** Waiting for unfinished jobs....
make: *** [Makefile:128: etc/bash_completion.d/wwctl] Error 2
make: *** [Makefile:145: man_pages] Error 2
```

After:

```
./wwctl --emptyconf genconfig defaults >etc/defaults.conf
mkdir -p etc/bash_completion.d/
./wwctl --emptyconf genconfig man docs/man/man1
./wwctl --emptyconf genconfig completions >etc/bash_completion.d/wwctl
ERROR: Couldn't establish a connection to remote: dial udp 8.8.8.8:80: connect: network is unreachable
make: *** [Makefile:145: man_pages] Error 255
make: *** Waiting for unfinished jobs....
ERROR: Couldn't establish a connection to remote: dial udp 8.8.8.8:80: connect: network is unreachable
ERROR: Couldn't establish a connection to remote: dial udp 8.8.8.8:80: connect: network is unreachable
make: *** [Makefile:52: etc/defaults.conf] Error 255
make: *** [Makefile:128: etc/bash_completion.d/wwctl] Error 255
```


#### Before submitting a PR, make sure you have done the following:

- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/development/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/hpcng/warewulf/blob/development/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/hpcng/warewulf/tree/development/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [development](https://github.com/hpcng/warewulf/tree/development/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/hpcng/warewulf/blob/development/CONTRIBUTORS.md
