### PR TITLE
do not download protobuf stuff on offline builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,15 +151,16 @@ reference: wwctl
 
 latexpdf: reference
 	make -C userdocs latexpdf
-
-proto = internal/pkg/api/routes/wwapiv1/routes.pb.go \
+ifndef OFFLINE_BUILD
+protofiles = internal/pkg/api/routes/wwapiv1/routes.pb.go \
 	internal/pkg/api/routes/wwapiv1/routes.pb.gw.go \
 	internal/pkg/api/routes/wwapiv1/routes_grpc.pb.go
 .PHONY: proto
-proto: $(proto)
+
+proto: $(protofiles)
 
 routes_proto = internal/pkg/api/routes/v1/routes.proto
-internal/pkg/api/routes/wwapiv1/%.go: $(PROTOC) $(PROTOC_GEN_GRPC_GATEWAY) $(PROTOC_GEN_GO) $(PROTOC_GEN_GO_GRPC) $(routes_proto)
+$(protofiles): $(routes_proto) $(PROTOC) $(PROTOC_GEN_GRPC_GATEWAY) $(PROTOC_GEN_GO) $(PROTOC_GEN_GO_GRPC)
 	PATH=$(TOOLS_BIN):$(PATH) $(PROTOC) \
 		-I /usr/include -I $(shell dirname $(routes_proto)) -I=. \
 		--grpc-gateway_opt logtostderr=true \
@@ -168,9 +169,11 @@ internal/pkg/api/routes/wwapiv1/%.go: $(PROTOC) $(PROTOC_GEN_GRPC_GATEWAY) $(PRO
 		--grpc-gateway_out=. \
 		routes.proto
 
+endif
+
 .PHONY: cleanproto
 cleanproto:
-	rm -f $(proto)
+	rm -f $(protofiles)
 
 .PHONY: cleanconfig
 cleanconfig:


### PR DESCRIPTION
All the proto stuff will be downloaded so just disable all protobuff rules and targets on OFFLINE_BUILD.
