### PR TITLE
bash completion for all overlay commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Entries in `/etc/fstab` for every file system are created with the `noauto` option.
 - wwclient has now a commandline switch for the location of warewulf.conf
 - `wwctl overlay edit` uses a temporary file and checks mtime.
-- Changed the bash completions for the `wwctl overlay` commands so that the files of the
+- Changed the bash completions all the `wwctl overlay` commands so that the files of the
   overlays are expanded
 
 ## [4.4.0] 2023-01-18

--- a/internal/app/wwctl/overlay/chown/root.go
+++ b/internal/app/wwctl/overlay/chown/root.go
@@ -14,11 +14,16 @@ var (
 		RunE:                  CobraRunE,
 		Args:                  cobra.RangeArgs(3, 4),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			if len(args) != 0 {
-				return nil, cobra.ShellCompDirectiveNoFileComp
+			if len(args) == 0 {
+				list, _ := overlay.FindOverlays()
+				return list, cobra.ShellCompDirectiveNoFileComp
+			} else if len(args) == 1 {
+				ret, err := overlay.OverlayGetFiles(args[0])
+				if err == nil {
+					return ret, cobra.ShellCompDirectiveNoFileComp
+				}
 			}
-			list, _ := overlay.FindOverlays()
-			return list, cobra.ShellCompDirectiveNoFileComp
+			return []string{""}, cobra.ShellCompDirectiveNoFileComp
 		},
 	}
 )

--- a/internal/app/wwctl/overlay/delete/root.go
+++ b/internal/app/wwctl/overlay/delete/root.go
@@ -15,11 +15,16 @@ var (
 		Args:                  cobra.RangeArgs(1, 2),
 		Aliases:               []string{"rm", "del"},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			if len(args) != 0 {
-				return nil, cobra.ShellCompDirectiveNoFileComp
+			if len(args) == 0 {
+				list, _ := overlay.FindOverlays()
+				return list, cobra.ShellCompDirectiveNoFileComp
+			} else if len(args) == 1 {
+				ret, err := overlay.OverlayGetFiles(args[0])
+				if err == nil {
+					return ret, cobra.ShellCompDirectiveNoFileComp
+				}
 			}
-			list, _ := overlay.FindOverlays()
-			return list, cobra.ShellCompDirectiveNoFileComp
+			return []string{""}, cobra.ShellCompDirectiveNoFileComp
 		},
 	}
 	Force   bool

--- a/internal/app/wwctl/overlay/edit/root.go
+++ b/internal/app/wwctl/overlay/edit/root.go
@@ -14,11 +14,16 @@ var (
 		RunE:                  CobraRunE,
 		Args:                  cobra.ExactArgs(2),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			if len(args) != 0 {
-				return nil, cobra.ShellCompDirectiveNoFileComp
+			if len(args) == 0 {
+				list, _ := overlay.FindOverlays()
+				return list, cobra.ShellCompDirectiveNoFileComp
+			} else if len(args) == 1 {
+				ret, err := overlay.OverlayGetFiles(args[0])
+				if err == nil {
+					return ret, cobra.ShellCompDirectiveNoFileComp
+				}
 			}
-			list, _ := overlay.FindOverlays()
-			return list, cobra.ShellCompDirectiveNoFileComp
+			return []string{""}, cobra.ShellCompDirectiveNoFileComp
 		},
 	}
 	CreateDirs bool

--- a/internal/app/wwctl/overlay/list/root.go
+++ b/internal/app/wwctl/overlay/list/root.go
@@ -14,7 +14,6 @@ var (
 		RunE:                  CobraRunE,
 		Args:                  cobra.MinimumNArgs(0),
 		Aliases:               []string{"ls"},
-		ValidArgs:             []string{"system", "runtime"},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) != 0 {
 				return nil, cobra.ShellCompDirectiveNoFileComp

--- a/internal/app/wwctl/overlay/mkdir/root.go
+++ b/internal/app/wwctl/overlay/mkdir/root.go
@@ -1,6 +1,7 @@
 package mkdir
 
 import (
+	"github.com/hpcng/warewulf/internal/pkg/overlay"
 	"github.com/spf13/cobra"
 )
 
@@ -12,6 +13,18 @@ var (
 		Long:                  "This command creates a new directory within the Warewulf OVERLAY_NAME.",
 		RunE:                  CobraRunE,
 		Args:                  cobra.MinimumNArgs(2),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) == 0 {
+				list, _ := overlay.FindOverlays()
+				return list, cobra.ShellCompDirectiveNoFileComp
+			} else if len(args) == 1 {
+				ret, err := overlay.OverlayGetFiles(args[0])
+				if err == nil {
+					return ret, cobra.ShellCompDirectiveNoFileComp
+				}
+			}
+			return []string{""}, cobra.ShellCompDirectiveNoFileComp
+		},
 	}
 	PermMode int32
 )

--- a/internal/app/wwctl/overlay/show/root.go
+++ b/internal/app/wwctl/overlay/show/root.go
@@ -1,6 +1,7 @@
 package show
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/hpcng/warewulf/internal/pkg/node"
@@ -25,6 +26,8 @@ var (
 				ret, err := overlay.OverlayGetFiles(args[0])
 				if err == nil {
 					return ret, cobra.ShellCompDirectiveNoFileComp
+				} else {
+					return []string{fmt.Sprint(err)}, cobra.ShellCompDirectiveFilterDirs
 				}
 			}
 			return []string{""}, cobra.ShellCompDirectiveNoFileComp


### PR DESCRIPTION
added the list command for the overlay files for all `wwctl overlay` commands. Preivous commits fell under the floor.
