### PR TITLE
seperate the path for the iPXE binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - only write IPMI if write is true
 - Don't show an error if image files for containers can't be found. #933
 - Make configured paths available in overlays as `.Path` #960
+- Introduced IPXESOURCE environment variable which allows to specify the path to iPXE 
+  binaries not provided by warewulf
 
 ## [4.4.0] 2023-01-18
 

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,8 @@ install: build docs
 	install -d -m 0755 $(DESTDIR)$(WWDOCDIR)
 	install -d -m 0755 $(DESTDIR)$(FIREWALLDDIR)
 	install -d -m 0755 $(DESTDIR)$(SYSTEMDDIR)
-	install -d -m 0755 $(DESTDIR)$(WWDATADIR)/ipxe
+	install -d -m 0755 $(DESTDIR)$(IPXESOURCE)
+	install -d -m 0755 $(DESTDIR)$(DATADIR)/warewulf
 	test -f $(DESTDIR)$(WWCONFIGDIR)/warewulf.conf || install -m 0644 etc/warewulf.conf $(DESTDIR)$(WWCONFIGDIR)
 	test -f $(DESTDIR)$(WWCONFIGDIR)/nodes.conf || install -m 0644 etc/nodes.conf $(DESTDIR)$(WWCONFIGDIR)
 	test -f $(DESTDIR)$(WWCONFIGDIR)/wwapic.conf || install -m 0644 etc/wwapic.conf $(DESTDIR)$(WWCONFIGDIR)

--- a/Variables.mk
+++ b/Variables.mk
@@ -1,7 +1,7 @@
 -include Defaults.mk
 
 # Linux distro (try and set to /etc/os-release ID)
-OS_REL := $(shell sed -n "s/^ID\s*=\s*['"\""]\(.*\)['"\""]/\1/p" /etc/os-release)
+OS_REL := $(shell sed -n "s/^ID\w*\s*=\s*['"\""]\(.*\)['"\""]/\1/p" /etc/os-release)
 OS ?= $(OS_REL)
 
 ARCH_REL := $(shell uname -p)
@@ -26,14 +26,16 @@ else
   RELEASE ?= 1
 endif
 
-# Use LSB-compliant paths if OS is known
-ifneq ($(OS),)
-  USE_LSB_PATHS := true
-endif
-
 # Always default to GNU autotools default paths if PREFIX has been redefined
 ifdef PREFIX
   USE_LSB_PATHS := false
+endif
+
+# Use LSB-compliant paths if OS is known
+ifneq ($(OS),)
+  USE_LSB_PATHS := true
+  PREFIX="/usr"
+  SYSCONFDIR="/etc"
 endif
 
 # System directory paths
@@ -68,7 +70,7 @@ endif
 TFTPDIR ?= /var/lib/tftpboot
 
 # Warewulf directory paths
-VARLIST += WWCLIENTDIR WWCONFIGDIR WWPROVISIONDIR WWOVERLAYDIR WWCHROOTDIR WWTFTPDIR WWDOCDIR WWDATADIR
+VARLIST += WWCLIENTDIR WWCONFIGDIR WWPROVISIONDIR WWOVERLAYDIR WWCHROOTDIR WWTFTPDIR WWDOCDIR WWDATADIR IPXESOURCE
 WWCONFIGDIR := $(SYSCONFDIR)/$(WAREWULF)
 WWPROVISIONDIR := $(LOCALSTATEDIR)/$(WAREWULF)/provision
 WWOVERLAYDIR := $(LOCALSTATEDIR)/$(WAREWULF)/overlays
@@ -79,6 +81,9 @@ WWDATADIR := $(DATADIR)/$(WAREWULF)
 WWCLIENTDIR ?= /warewulf
 
 CONFIG := $(shell pwd)
+
+# Get iPXE binaries from warewulf
+IPXESOURCE ?= $(DATADIR)/$(WAREWULF)/ipxe
 
 # helper functions
 godeps=$(shell go list -mod vendor -deps -f '{{if not .Standard}}{{ $$dep := . }}{{range .GoFiles}}{{$$dep.Dir}}/{{.}} {{end}}{{end}}' $(1) | sed "s%${PWD}/%%g")

--- a/internal/pkg/config/buildconfig.go.in
+++ b/internal/pkg/config/buildconfig.go.in
@@ -7,6 +7,7 @@ type BuildConfig struct {
 	Sysconfdir     string `default:"@SYSCONFDIR@"`
 	Datadir        string `default:"@DATADIR@"`
 	Localstatedir  string `default:"@LOCALSTATEDIR@"`
+	Ipxesource     string `default:"@IPXESOURCE@"`
 	Srvdir         string `default:"@SRVDIR@"`
 	Tftpdir        string `default:"@TFTPDIR@"`
 	Firewallddir   string `default:"@FIREWALLDDIR@"`

--- a/internal/pkg/configure/tftp.go
+++ b/internal/pkg/configure/tftp.go
@@ -27,7 +27,7 @@ func TFTP() error {
 			continue
 		}
 		copyCheck[f] = true
-		err = util.SafeCopyFile(path.Join(controller.Paths.Datadir, f), path.Join(tftpdir, path.Base(f)))
+		err = util.SafeCopyFile(path.Join(controller.Paths.Ipxesource, f), path.Join(tftpdir, path.Base(f)))
 		if err != nil {
 			wwlog.Warn("ipxe binary could not be copied, booting may not work: %s", err)
 		}


### PR DESCRIPTION
As well the `defaults.conf` as the ipxe binaires were installed
in the same location. This doen't make any problems if the binaries
are installed fromt he warewulf sources but makes it impossible 
to configure the path for system ipxe binaries

Signed-off-by: Christian Goll <cgoll@suse.com>
