### PR TITLE
warn and don't show scary error on syncuids

### DIFF
--- a/internal/pkg/container/syncuids.go
+++ b/internal/pkg/container/syncuids.go
@@ -113,8 +113,8 @@ func (db syncDB) checkConflicts() error {
 		for nameInHost, hostIds := range db {
 			if hostIds.HostID == containerIds.ContainerID {
 				errorMsg := fmt.Sprintf("id(%v) collision: host(%s) container(%s)", containerIds.ContainerID, nameInHost, nameInContainer)
-				wwlog.Error(errorMsg)
-				wwlog.Error("add %s to host to resolve conflict", nameInContainer)
+				wwlog.Warn(errorMsg)
+				wwlog.Warn("add %s to host to resolve conflict", nameInContainer)
 				return errors.New(errorMsg)
 			}
 		}


### PR DESCRIPTION
As warewulf should be warm and welcoming, don't show a scary error if there is
uid/gid mismatch. Logically this is an error but scares the hell out of
inexperienced users.
