### PR TITLE
Mark vendor target phony and update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ build: wwctl wwclient wwapid wwapic wwapird etc/defaults.conf etc/bash_completio
 .PHONY: docs
 docs: man_pages reference
 
+.PHONY: vendor
 vendor:
 	go mod tidy -v
 	go mod vendor

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6
 	github.com/opencontainers/umoci v0.4.6
 	github.com/pkg/errors v0.9.1
+	github.com/sassoftware/go-rpmutils v0.2.0
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.2
 	github.com/talos-systems/go-smbios v0.1.1
@@ -79,7 +80,6 @@ require (
 	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/rootless-containers/proto v0.1.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/sassoftware/go-rpmutils v0.2.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace // indirect
 	github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980 // indirect


### PR DESCRIPTION
The vendor target can't reliably determine when it needs to run, so mark it phony. At the same time, update go.mod.