### PR TITLE
allow empty commits on doc workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -68,5 +68,5 @@ jobs:
           cp -r userdocs/_build/html ~/warewulf-web/static/docs/${GITHUB_REF##*/}
           cd ~/warewulf-web
           git add static/docs/${GITHUB_REF##*/}
-          git commit -m "Update ${GITHUB_REF##*/} docs"
+          git commit --allow-empty -m "Update ${GITHUB_REF##*/} docs"
           git push


### PR DESCRIPTION

Hopefully removes following error message after a merge
```
Cloning into '/home/runner/warewulf-web'...
On branch main
Your branch is up to date with 'origin/main'.

nothing to commit, working tree clean
Error: Process completed with exit code 1.
```
