### PR TITLE
update include/exclude during dist creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - added general test framework which creates temporary directories on the fly
 - only write IPMI if write is true
 - Don't show an error if image files for containers can't be found. #933
+- Clean dir before calling dist target
 
 ## [4.4.0] 2023-01-18
 

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ init:
 	restorecon -r $(WWTFTPDIR)
 
 .PHONY: dist
-dist:
+dist: clean
 	rm -rf .dist/ $(WAREWULF)-$(VERSION).tar.gz
 	mkdir -p .dist/$(WAREWULF)-$(VERSION)
 	rsync -a --exclude=".*" --exclude "*~" * .dist/$(WAREWULF)-$(VERSION)/


### PR DESCRIPTION
For the github actions this shouldn't matter, but calling `make dist` on
development systems creates nasty build artefacts.
