### PR TITLE
Quickstart doc updates

### DIFF
--- a/userdocs/quickstart/el7.rst
+++ b/userdocs/quickstart/el7.rst
@@ -38,27 +38,41 @@ address of your cluster's private network interface:
 
 .. code-block:: yaml
 
-   ipaddr: 192.168.200.1
-   netmask: 255.255.255.0
-   warewulf:
-     port: 9873
-     secure: false
-     update interval: 60
-   dhcp:
-     enabled: true
-     range start: 192.168.200.10
-     range end: 192.168.200.99
-     template: default
-     systemd name: dhcpd
-   tftp:
-     enabled: true
-     tftproot: /var/lib/tftpboot
-     systemd name: tftp
-   nfs:
-     systemd name: nfs-server
-     exports:
-       - /home
-       - /var/warewulf
+    WW_INTERNAL: 43
+    ipaddr: 192.168.200.1
+    netmask: 255.255.255.0
+    network: 192.168.200.0
+    warewulf:
+      port: 9873
+      secure: false
+      update interval: 60
+      autobuild overlays: true
+      host overlay: true
+      syslog: false
+    dhcp:
+      enabled: true
+      range start: 192.168.200.50
+      range end: 192.168.200.99
+      systemd name: dhcpd
+    tftp:
+      enabled: true
+      systemd name: tftp
+    nfs:
+      enabled: true
+      export paths:
+      - path: /home
+        export options: rw,sync
+        mount options: defaults
+        mount: true
+      - path: /opt
+        export options: ro,sync,no_root_squash
+        mount options: defaults
+        mount: false
+      systemd name: nfs-server
+    container mounts:
+      - source: /etc/resolv.conf
+        dest: /etc/resolv.conf
+        readonly: true
 
 .. note::
 

--- a/userdocs/quickstart/el7.rst
+++ b/userdocs/quickstart/el7.rst
@@ -139,7 +139,7 @@ configuration, we can set them in the default profile as follows:
 
 .. code-block:: bash
 
-   sudo wwctl profile set -y default --netname default --netmask 255.255.255.0 --gateway 192.168.200.1
+   sudo wwctl profile set -y default --netdev eth0 --netmask 255.255.255.0 --gateway 192.168.200.1
    sudo wwctl profile list
 
 Add a node
@@ -159,7 +159,7 @@ configurations.
 
 .. code-block:: bash
 
-   sudo wwctl node add n0000.cluster --netname default -I 192.168.200.100 --discoverable
+   sudo wwctl node add n0000.cluster --ipaddr 192.168.200.100 --discoverable true
    sudo wwctl node list -a n0000
 
 Turn on your compute node and watch it boot!

--- a/userdocs/quickstart/el8.rst
+++ b/userdocs/quickstart/el8.rst
@@ -187,7 +187,7 @@ configurations.
 
 .. code-block:: bash
 
-   sudo wwctl node add n0000.cluster --ipaddr 192.168.200.100 --discoverable
+   sudo wwctl node add n0000.cluster --ipaddr 192.168.200.100 --discoverable true
 
 At this point you can view the basic configuration of this node by
 typing the following:

--- a/userdocs/quickstart/el8.rst
+++ b/userdocs/quickstart/el8.rst
@@ -57,27 +57,41 @@ address of your cluster's private network interface:
 
 .. code-block:: yaml
 
-   ipaddr: 192.168.200.1
-   netmask: 255.255.255.0
-   warewulf:
-     port: 9873
-     secure: false
-     update interval: 60
-   dhcp:
-     enabled: true
-     range start: 192.168.200.10
-     range end: 192.168.200.99
-     template: default
-     systemd name: dhcpd
-   tftp:
-     enabled: true
-     tftproot: /var/lib/tftpboot
-     systemd name: tftp
-   nfs:
-     systemd name: nfs-server
-     exports:
-       - /home
-       - /var/warewulf
+    WW_INTERNAL: 43
+    ipaddr: 192.168.200.1
+    netmask: 255.255.255.0
+    network: 192.168.200.0
+    warewulf:
+      port: 9873
+      secure: false
+      update interval: 60
+      autobuild overlays: true
+      host overlay: true
+      syslog: false
+    dhcp:
+      enabled: true
+      range start: 192.168.200.50
+      range end: 192.168.200.99
+      systemd name: dhcpd
+    tftp:
+      enabled: true
+      systemd name: tftp
+    nfs:
+      enabled: true
+      export paths:
+      - path: /home
+        export options: rw,sync
+        mount options: defaults
+        mount: true
+      - path: /opt
+        export options: ro,sync,no_root_squash
+        mount options: defaults
+        mount: false
+      systemd name: nfs-server
+    container mounts:
+      - source: /etc/resolv.conf
+        dest: /etc/resolv.conf
+        readonly: true
 
 .. note::
 

--- a/userdocs/quickstart/el9.rst
+++ b/userdocs/quickstart/el9.rst
@@ -57,27 +57,41 @@ address of your cluster's private network interface:
 
 .. code-block:: yaml
 
-   ipaddr: 192.168.200.1
-   netmask: 255.255.255.0
-   warewulf:
-     port: 9873
-     secure: false
-     update interval: 60
-   dhcp:
-     enabled: true
-     range start: 192.168.200.10
-     range end: 192.168.200.99
-     template: default
-     systemd name: dhcpd
-   tftp:
-     enabled: true
-     tftproot: /var/lib/tftpboot
-     systemd name: tftp
-   nfs:
-     systemd name: nfs-server
-     exports:
-       - /home
-       - /var/warewulf
+    WW_INTERNAL: 43
+    ipaddr: 192.168.200.1
+    netmask: 255.255.255.0
+    network: 192.168.200.0
+    warewulf:
+      port: 9873
+      secure: false
+      update interval: 60
+      autobuild overlays: true
+      host overlay: true
+      syslog: false
+    dhcp:
+      enabled: true
+      range start: 192.168.200.50
+      range end: 192.168.200.99
+      systemd name: dhcpd
+    tftp:
+      enabled: true
+      systemd name: tftp
+    nfs:
+      enabled: true
+      export paths:
+      - path: /home
+        export options: rw,sync
+        mount options: defaults
+        mount: true
+      - path: /opt
+        export options: ro,sync,no_root_squash
+        mount options: defaults
+        mount: false
+      systemd name: nfs-server
+    container mounts:
+      - source: /etc/resolv.conf
+        dest: /etc/resolv.conf
+        readonly: true
 
 .. note::
 

--- a/userdocs/quickstart/el9.rst
+++ b/userdocs/quickstart/el9.rst
@@ -151,7 +151,7 @@ the ``default`` node profile:
 
 .. code-block:: bash
 
-   sudo wwctl profile set --yes --container rocky-8 "default"
+   sudo wwctl profile set --yes --container rocky-9 "default"
 
 Next we set some default networking configurations for the first
 ethernet device. On modern Linux distributions, the name of the device

--- a/userdocs/quickstart/suse15.rst
+++ b/userdocs/quickstart/suse15.rst
@@ -164,7 +164,7 @@ configurations.
 
 .. code-block:: bash
 
-   sudo wwctl node add n0000.cluster --netdev eth0 -I 192.168.200.100 --discoverable
+   sudo wwctl node add n0000.cluster --netdev eth0 --ipaddr 192.168.200.100 --discoverable true
    sudo wwctl node list -a n0000.cluster
 
 Warewulf Overlays

--- a/userdocs/quickstart/suse15.rst
+++ b/userdocs/quickstart/suse15.rst
@@ -46,36 +46,41 @@ address of your cluster's private network interface:
 
 .. code-block:: yaml
 
-   ipaddr: 192.168.200.1
-   netmask: 255.255.255.0
-   warewulf:
-     port: 9873
-     secure: false
-     update interval: 60
-     autobuild overlays: true
-     host overlay: true
-   dhcp:
-     enabled: true
-     range start: 192.168.200.10
-     range end: 192.168.200.99
-     template: default
-     systemd name: dhcpd
-   tftp:
-     enabled: true
-     tftproot: /var/lib/tftpboot
-     systemd name: tftp
-   nfs:
-     enabled: true
-     export paths:
-     - path: /home
-       export options: rw,sync
-       mount options: defaults
-       mount: true
-     - path: /opt
-       export options: ro,sync,no_root_squash
-       mount options: defaults
-       mount: false
-     systemd name: nfs-server
+    WW_INTERNAL: 43
+    ipaddr: 192.168.200.1
+    netmask: 255.255.255.0
+    network: 192.168.200.0
+    warewulf:
+      port: 9873
+      secure: false
+      update interval: 60
+      autobuild overlays: true
+      host overlay: true
+      syslog: false
+    dhcp:
+      enabled: true
+      range start: 192.168.200.50
+      range end: 192.168.200.99
+      systemd name: dhcpd
+    tftp:
+      enabled: true
+      systemd name: tftp
+    nfs:
+      enabled: true
+      export paths:
+      - path: /home
+        export options: rw,sync
+        mount options: defaults
+        mount: true
+      - path: /opt
+        export options: ro,sync,no_root_squash
+        mount options: defaults
+        mount: false
+      systemd name: nfs-server
+    container mounts:
+      - source: /etc/resolv.conf
+        dest: /etc/resolv.conf
+        readonly: true
 
 .. note::
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Update some of the Quickstart documentation. 

- Update the `warewulf.conf` file to match version in `development` branch.
- Consistent flags for the `node add` syntax. 
- Change container name to `rocky-9` in the profile section of the el9 quickstart.
