### PR TITLE
Increase linter timeout to 5 minutes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ etc/bash_completion.d/wwctl: wwctl
 
 .PHONY: lint
 lint: $(config)
-	$(GOLANGCI_LINT) run --build-tags "$(WW_GO_BUILD_TAGS)" --skip-dirs internal/pkg/staticfiles ./...
+	$(GOLANGCI_LINT) run --build-tags "$(WW_GO_BUILD_TAGS)" --skip-dirs internal/pkg/staticfiles --timeout=5m ./...
 
 .PHONY: vet
 vet: $(config)


### PR DESCRIPTION
The linter is sometimes timing out when run by GitHub Actions. This PR changes the timeout to 5 minutes.

## This fixes or addresses the following GitHub issues:

 - Fixes #968


## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/development/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/hpcng/warewulf/blob/development/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/hpcng/warewulf/tree/development/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [development](https://github.com/hpcng/warewulf/tree/development/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/hpcng/warewulf/blob/development/CONTRIBUTORS.md)
