### PR TITLE
Replace development with main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,8 +13,8 @@ fixing or enhancing.
 ## Before submitting a PR, make sure you have done the following:
 
 - [ ] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
-- [ ] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/development/contributing/contributing.html)
-- [ ] Added changes to the [CHANGELOG](https://github.com/hpcng/warewulf/blob/development/CHANGELOG.md) if necessary
-- [ ] Updated [userdocs](https://github.com/hpcng/warewulf/tree/development/userdocs) if necessary
-- [ ] Based this PR against the appropriate branch (typically [development](https://github.com/hpcng/warewulf/tree/development/userdocs))
-- [ ] Added myself as a contributor to the [Contributors File](https://github.com/hpcng/warewulf/blob/development/CONTRIBUTORS.md)
+- [ ] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
+- [ ] Added changes to the [CHANGELOG](https://github.com/hpcng/warewulf/blob/main/CHANGELOG.md) if necessary
+- [ ] Updated [userdocs](https://github.com/hpcng/warewulf/tree/main/userdocs) if necessary
+- [ ] Based this PR against the appropriate branch (typically [main](https://github.com/hpcng/warewulf/tree/main/userdocs))
+- [ ] Added myself as a contributor to the [Contributors File](https://github.com/hpcng/warewulf/blob/main/CONTRIBUTORS.md)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,4 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-    target-branch: development
+    target-branch: main

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,13 +5,11 @@ on:
   push:
     branches:
       - main
-      - development
     paths-ignore:
       - 'docs/**'
   pull_request:
     branches:
       - main
-      - development
     paths-ignore:
       - 'docs/**'
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,14 +5,12 @@ on:
   push:
     branches:
       - main
-      - development
       - v4.*.x
     paths:
       - 'userdocs/**'
   pull_request:
     branches:
       - main
-      - development
       - v4.*.x
     paths:
       - 'userdocs/**'

--- a/internal/app/wwctl/overlay/edit/main.go
+++ b/internal/app/wwctl/overlay/edit/main.go
@@ -24,7 +24,7 @@ const initialTemplate = `# This is a Warewulf Template file.
 # Network Config = {{.NetDevs.eth0.Ipaddr}}, {{.NetDevs.eth0.Hwaddr}}, etc.
 #
 # Go to the documentation pages for more information:
-# https://warewulf.org/docs/development/contents/overlays.html
+# https://warewulf.org/docs/main/contents/overlays.html
 #
 # Keep the following for better reference:
 # ---

--- a/userdocs/conf.py
+++ b/userdocs/conf.py
@@ -9,7 +9,7 @@
 project = 'Warewulf User Guide'
 copyright = '2023, Warewulf Project Contributors'
 author = 'Warewulf Project Contributors'
-release = 'development'
+release = 'main'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -39,7 +39,7 @@ html_context = {
     'display_github': True,
     'github_user': 'hpcng',
     'github_repo': 'warewulf',
-    'github_version': 'development',
+    'github_version': 'main',
     'conf_py_path': '/userdocs/',
 }
 


### PR DESCRIPTION
The development branch has been replaced with the main branch in GitHub. Replaces references to development in docs, commands, configuration, and workflows.


## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/development/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/hpcng/warewulf/blob/development/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/hpcng/warewulf/tree/development/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [development](https://github.com/hpcng/warewulf/tree/development/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/hpcng/warewulf/blob/development/CONTRIBUTORS.md)
