### PR TITLE
[hotfix for nightly release]remove update_latest_release

### DIFF
--- a/.github/actions/generate/action.yml
+++ b/.github/actions/generate/action.yml
@@ -104,7 +104,7 @@ runs:
         cat << EOF >> nightly.release.note
         THIS IS A NIGHTLY RELEASE
         
-        This release contains latest commits, which is feature unstable version
+        This release contains latest commits, which is a feature unstable version
 
         ${{ steps.commits.outputs.raw }}
 
@@ -124,7 +124,6 @@ runs:
         prerelease: true
         draft: false
         default_release_name: "warewulf nightly release"
-        update_latest_release: true
         overwrite: true
 
     - name: Update nightly release content

--- a/.github/actions/rpm/action.yml
+++ b/.github/actions/rpm/action.yml
@@ -106,5 +106,4 @@ runs:
       with:
         release_id: ${{ inputs.event-id }}
         file: "/var/lib/mock/${{ inputs.target }}/result/${{ env.RPM }};/var/lib/mock/${{ inputs.target }}/result/${{ env.SRPM }}"
-        update_latest_release: true
         overwrite: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,6 +18,8 @@ jobs:
         steps:
           - name: Checkout Code
             uses: actions/checkout@v3
+            with:
+              ref: 'main'
           - uses: ./.github/actions/generate
             name: generate warewulf spec, dist and collect commits info
             id: generate
@@ -55,6 +57,8 @@ jobs:
         steps:
           - name: Checkout Code
             uses: actions/checkout@v3
+            with:
+              ref: 'main'
           - uses: ./.github/actions/rpm
             name: build rpms
             id: rpm

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,7 @@
 name: nightly
 
 on:
-  #push:
+  workflow_dispatch:
   schedule:
     - cron:  '05 00 * * *'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configure network device MTU in nework configuration scripts. #807
 - OpenSUSE Leap build rebased to 15.5 (15.3 is EOL)
 - New build for Rocky Linux 9
-- Add nightly release support
+- Add nightly release support. #969
 
 ### Fixed
 - Make Variables.mk consistent with spec file w.r.t. WWPROVISIONDIR, e.g.


### PR DESCRIPTION
## Description of the Pull Request (PR):

There is an issue that the option `update_latest_release` in the nightly release will try updating existing published release first. This should be avoided.


## This fixes or addresses the following GitHub issues:

 - Fixes #969


## Before submitting a PR, make sure you have done the following:

- [ ] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [ ] Added changes to the [CHANGELOG](https://github.com/hpcng/warewulf/blob/main/CHANGELOG.md) if necessary
- [ ] Updated [userdocs](https://github.com/hpcng/warewulf/tree/main/userdocs) if necessary
- [ ] Based this PR against the appropriate branch (typically [main](https://github.com/hpcng/warewulf/tree/main/userdocs))
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/hpcng/warewulf/blob/main/CONTRIBUTORS.md)
