### PR TITLE
add git tag to nightly release

### DIFF
--- a/.github/actions/generate/action.yml
+++ b/.github/actions/generate/action.yml
@@ -106,8 +106,10 @@ runs:
         
         This release contains latest commits, which is a feature unstable version
 
+        Reflog:
         ${{ steps.commits.outputs.raw }}
 
+        Commits:
         ${{ steps.commits.outputs.commits }}
         EOF
       shell: bash
@@ -119,12 +121,12 @@ runs:
         GITHUB_TOKEN: ${{ inputs.token }}
       with:
         release_id: ${{ inputs.event-id }}
+        delete_file: "warewulf-*.tar.gz;warewulf-*.rpm"
         file: ${{ env.DIST }}
         tag_name: "nightly"
         prerelease: true
         draft: false
         default_release_name: "warewulf nightly release"
-        overwrite: true
 
     - name: Update nightly release content
       if: inputs.nightly == 'true' && steps.should-continue.outputs.continue == 'true'

--- a/.github/actions/rpm/action.yml
+++ b/.github/actions/rpm/action.yml
@@ -20,9 +20,6 @@ inputs:
   event-id:
     description: "Github event id"
     required: true
-  nightly:
-    description: "Whether it is nightly release"
-    default: 'false'
 
 runs:
   using: "composite"
@@ -68,25 +65,6 @@ runs:
         mock -r ${{ inputs.target }} --chroot -- make -C /builddir/build/BUILD/warewulf-${{ env.EXPECTED_VERSION }} test
       shell: bash
 
-    # we need to rename the RPMs and SRPMs to overwrite for nightly release
-    - name: Rename the built RPMs for nightly build
-      if: inputs.nightly == 'true'
-      run: |
-        VERSION=$(rpm -q --qf "%{VERSION}\n" --specfile warewulf.spec)
-        GENERIC_RELEASE=$(rpm -q --qf "%{RELEASE}\n" --specfile warewulf.spec | cut -d. -f1-2)
-        RPM=warewulf-${VERSION}-${GENERIC_RELEASE}.${{ inputs.dist }}.${{ inputs.arch }}.rpm
-        SRPM=warewulf-${VERSION}-${GENERIC_RELEASE}.${{ inputs.dist }}.src.rpm
-
-        RNAME_RPM=warewulf-${VERSION}.${{ inputs.dist }}.${{ inputs.arch }}.rpm
-        RNAME_SRPM=warewulf-${VERSION}.${{ inputs.dist }}.src.rpm
-
-        mv /var/lib/mock/${{ inputs.target }}/result/${RPM} /var/lib/mock/${{ inputs.target }}/result/${RNAME_RPM}
-        mv /var/lib/mock/${{ inputs.target }}/result/${SRPM} /var/lib/mock/${{ inputs.target }}/result/${RNAME_SRPM}
-
-        echo "RPM=${RNAME_RPM}" >> $GITHUB_ENV
-        echo "SRPM=${RNAME_SRPM}" >> $GITHUB_ENV
-      shell: bash
-
     - name: Upload RPM
       uses: actions/upload-artifact@v3
       with:
@@ -106,4 +84,3 @@ runs:
       with:
         release_id: ${{ inputs.event-id }}
         file: "/var/lib/mock/${{ inputs.target }}/result/${{ env.RPM }};/var/lib/mock/${{ inputs.target }}/result/${{ env.SRPM }}"
-        overwrite: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -69,4 +69,3 @@ jobs:
               token: ${{ secrets.GITHUB_TOKEN }}
               version: ${{ needs.generate.outputs.version }}
               event-id: ${{ needs.generate.outputs.release-id }}
-              nightly: 'true'


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add git tag into nightly releases items.

![image](https://github.com/hpcng/warewulf/assets/2051711/15539a27-bb32-4530-9099-ef3b4bdab586)


## This fixes or addresses the following GitHub issues:

 - Fixes #


## Before submitting a PR, make sure you have done the following:

- [ ] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [ ] Added changes to the [CHANGELOG](https://github.com/hpcng/warewulf/blob/main/CHANGELOG.md) if necessary
- [ ] Updated [userdocs](https://github.com/hpcng/warewulf/tree/main/userdocs) if necessary
- [ ] Based this PR against the appropriate branch (typically [main](https://github.com/hpcng/warewulf/tree/main/userdocs))
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/hpcng/warewulf/blob/main/CONTRIBUTORS.md)
