### PR TITLE
Fix relative iPXE paths

### DIFF
--- a/internal/pkg/config/tftp.go
+++ b/internal/pkg/config/tftp.go
@@ -7,5 +7,5 @@ type TFTPConf struct {
 	TftpRoot    string `yaml:"tftproot" default:"/var/lib/tftpboot"`
 	SystemdName string `yaml:"systemd name" default:"tftp"`
 
-	IpxeBinaries map[string]string `yaml:"ipxe" default:"{\"00:09\": \"ipxe/ipxe-snponly-x86_64.efi\",\"00:00\": \"ipxe/undionly.kpxe\",\"00:0B\": \"ipxe/arm64-efi/snponly.efi\",\"00:07\":  \"ipxe/ipxe-snponly-x86_64.efi\"}"`
+	IpxeBinaries map[string]string `yaml:"ipxe" default:"{\"00:09\": \"ipxe-snponly-x86_64.efi\",\"00:00\": \"undionly.kpxe\",\"00:0B\": \"arm64-efi/snponly.efi\",\"00:07\":  \"ipxe-snponly-x86_64.efi\"}"`
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

IPXESOURCE is pointing to /usr/share/ipxe/ by default, so the `ipxe/` directory should not be included in the compiled-in relative defaults.

Fixes a bug in #1010

## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/hpcng/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/hpcng/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/hpcng/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/hpcng/warewulf/blob/main/CONTRIBUTORS.md)
