### PR TITLE
Suppress vendor errors in makefile

### DIFF
--- a/Variables.mk
+++ b/Variables.mk
@@ -83,7 +83,7 @@ CONFIG := $(shell pwd)
 IPXESOURCE ?= $(PREFIX)/share/ipxe
 
 # helper functions
-godeps=$(shell go list -mod vendor -deps -f '{{if not .Standard}}{{ $$dep := . }}{{range .GoFiles}}{{$$dep.Dir}}/{{.}} {{end}}{{end}}' $(1) | sed "s%${PWD}/%%g")
+godeps=$(shell 2>/dev/null go list -mod vendor -deps -f '{{if not .Standard}}{{ $$dep := . }}{{range .GoFiles}}{{$$dep.Dir}}/{{.}} {{end}}{{end}}' $(1) | sed "s%${PWD}/%%g")
 
 # use GOPROXY for older git clients and speed up downloads
 GOPROXY ?= https://proxy.golang.org


### PR DESCRIPTION
## Description of the Pull Request (PR):

The godeps macro is used by the Makefile to determine if golang binaries need to be rebuilt based on changes to their dependencies, which may include libraries in vendor. This produces errors if the vendor directory is not present.
    
This change suppresses error messages during dependency resolution.

## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/hpcng/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/hpcng/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/hpcng/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/hpcng/warewulf/blob/main/CONTRIBUTORS.md)
