### PR TITLE
change message level from warn to debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   will generate an error #474
 - Create `/etc/systemd/network/10-persistent-net-<netdev>.link` file per network device
 - Fix the issue that the same tag added in `node set` is ignored. #967
+- Change too-verbose warning message level from `Warn` to `Debug`. #1025
 
 ### Changed
 

--- a/internal/pkg/overlay/config.go
+++ b/internal/pkg/overlay/config.go
@@ -43,7 +43,7 @@ func OverlayImage(nodeName string, context string, overlayNames []string) string
 	var name string
 	if context != "" {
 		if len(overlayNames) > 0 {
-			wwlog.Warn("context(%v) and overlays(%v) specified: prioritizing context(%v)",
+			wwlog.Debug("context(%v) and overlays(%v) specified: prioritizing context(%v)",
 				context, overlayNames, context)
 		}
 		name = "__" + strings.ToUpper(context) + "__.img"


### PR DESCRIPTION
## Description of the Pull Request (PR):

change message level of too-verbose messages from warn to debug. 


## This fixes or addresses the following GitHub issues:

 - Fixes #1025


## Before submitting a PR, make sure you have done the following:

- [ ] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [ ] Added changes to the [CHANGELOG](https://github.com/hpcng/warewulf/blob/main/CHANGELOG.md) if necessary
- [ ] Updated [userdocs](https://github.com/hpcng/warewulf/tree/main/userdocs) if necessary
- [ ] Based this PR against the appropriate branch (typically [main](https://github.com/hpcng/warewulf/tree/main/userdocs))
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/hpcng/warewulf/blob/main/CONTRIBUTORS.md)
