### PR TITLE
Update path to warewulf-node-images

### DIFF
--- a/containers/README.md
+++ b/containers/README.md
@@ -2,8 +2,8 @@
 
 Warewulf node images are now being maintained in a separate repository:
 
-https://github.com/hpcng/warewulf-node-images.
+https://github.com/warewulf/warewulf-node-images.
 
 Images are built and published to GHCR automatically:
 
-https://github.com/orgs/hpcng/packages?repo_name=warewulf-node-images
+https://github.com/orgs/warewulf/packages?repo_name=warewulf-node-images


### PR DESCRIPTION
warewulf-node-images has moved to
github.com/warewulf/warewulf-node-images

## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/hpcng/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/hpcng/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/hpcng/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/hpcng/warewulf/blob/main/CONTRIBUTORS.md)
