### PR TITLE
Fix the issue that the same tag added via `node set` is ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug when using `wwctl container import --force` to replace an existing container
   will generate an error #474
 - Create `/etc/systemd/network/10-persistent-net-<netdev>.link` file per network device
+- Fix the issue that the same tag added in `node set` is ignored. #967
 
 ### Changed
 

--- a/internal/app/wwctl/node/set/main_test.go
+++ b/internal/app/wwctl/node/set/main_test.go
@@ -414,3 +414,69 @@ nodes:
 		run_test(t, tt)
 	}
 }
+
+func Test_Node_Add(t *testing.T) {
+	tests := []test_description{
+		{
+			args:    []string{"--tagadd=email=node", "n01"},
+			wantErr: false,
+			stdout:  "",
+			inDB: `WW_INTERNAL: 43
+nodeprofiles:
+  default:
+    comment: testit
+    tags:
+      email: profile
+nodes:
+  n01:
+    profiles:
+    - default`,
+			outDb: `WW_INTERNAL: 43
+nodeprofiles:
+  default:
+    comment: testit
+    tags:
+      email: profile
+nodes:
+  n01:
+    profiles:
+    - default
+    tags:
+      email: node
+`},
+		{
+			args:    []string{"--tagadd=newtag=newval", "n01"},
+			wantErr: false,
+			stdout:  "",
+			inDB: `WW_INTERNAL: 43
+nodeprofiles:
+  default:
+    comment: testit
+    tags:
+      email: profile
+nodes:
+  n01:
+    profiles:
+    - default
+    tags:
+      email: node`,
+			outDb: `WW_INTERNAL: 43
+nodeprofiles:
+  default:
+    comment: testit
+    tags:
+      email: profile
+nodes:
+  n01:
+    profiles:
+    - default
+    tags:
+      email: node
+      newtag: newval
+`},
+	}
+
+	for _, tt := range tests {
+		run_test(t, tt)
+	}
+}

--- a/internal/pkg/node/transformers.go
+++ b/internal/pkg/node/transformers.go
@@ -206,6 +206,11 @@ func recursiveSetter(source, target interface{}, nameArg string, setter func(*En
 								newEntr := new(Entry)
 								setter(newEntr, sourceIter.Value().String(), nameArg)
 								targetValue.Elem().Field(i).SetMapIndex(sourceIter.Key(), reflect.ValueOf(newEntr))
+							} else {
+								// update the entry with latest value
+								if entry, ok := targetValue.Elem().Field(i).MapIndex(sourceIter.Key()).Interface().(*Entry); ok {
+									setter(entry, sourceIter.Value().String(), nameArg)
+								}
 							}
 						}
 					} else {


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR helps fix the issue that profile existing tag won't be added to the node configuration. The patch fixes the issue by updating the map value if key already exists.   

## This fixes or addresses the following GitHub issues:

 - Fixes #967
 - Fixed #1056 


## Before submitting a PR, make sure you have done the following:

- [ ] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [ ] Added changes to the [CHANGELOG](https://github.com/hpcng/warewulf/blob/main/CHANGELOG.md) if necessary
- [ ] Updated [userdocs](https://github.com/hpcng/warewulf/tree/main/userdocs) if necessary
- [ ] Based this PR against the appropriate branch (typically [main](https://github.com/hpcng/warewulf/tree/main/userdocs))
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/hpcng/warewulf/blob/main/CONTRIBUTORS.md)
